### PR TITLE
Fresh sessions, resume by id, and a persistent tandem prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ tandem (claude)> switch   # after exiting claude: continue instantly in codex
 tandem (codex)> exit
 to continue this session: tandem resume a1b2c3d4e5f6
 $ tandem resume           # continue the most recent session here
-$ tandem resume <id>      # continue a specific session (id from the exit hint)
+$ tandem resume <id>      # continue a specific session (id from the exit hint,
+                          #   run from that session's own directory)
 $ tandem run --on codex "second opinion: why is this test flaky?"
 $ tandem status           # pairing, roles, sync position
+$ tandem switch           # one-shot flip; does not enter a harness
 $ tandem doctor [--live]  # verify both sessions are resumable
 $ tandem sync             # manual catch-up translation (local file I/O only)
 $ tandem sync-mcp         # opt-in: copy MCP server configs between the tools
@@ -30,6 +32,18 @@ $ tandem sync-mcp         # opt-in: copy MCP server configs between the tools
   The shadow side is pure local file I/O: tandem tails the active
   transcript, translates each entry, and appends to the shadow's session
   file. The shadow's model is never called to "catch up".
+- **A persistent prompt, not the OS shell.** Leaving the harness lands you
+  at `tandem (claude)>` instead of back in your shell. There, `switch`
+  flips roles and drops you straight into the other tool (no re-launch
+  needed), Enter or `resume` re-enters the current one, and
+  `status`/`sync`/`doctor`/`run --on …`/`sync-mcp` run the same
+  implementations as their one-shot forms, always against this session.
+  `exit` (or Ctrl-D) returns to your shell and prints
+  `to continue this session: tandem resume <id>` — pass that id to
+  `tandem resume <id>` from the session's own directory. Every one-shot
+  command also works from the OS shell, targeting the directory's most
+  recently used session; one-shot `tandem switch` only flips, it does not
+  enter a harness.
 - **PTY passthrough.** `tandem` launches the real CLI on a pty (raw mode,
   SIGWINCH resize forwarding, signals through the line discipline). Tandem
   never scrapes terminal output; the transcript files are the source of

--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ format. Switching is instant — the shadow was always resume-ready via that
 tool's native `--resume`/`resume` mechanism.
 
 ```
-$ tandem start          # pair a claude + codex session for this directory
-$ tandem                # work in the active harness (untouched native UX)
-$ tandem switch         # flip active/shadow, instantly
-$ tandem                # continue the same conversation in the other tool
+$ tandem                  # fresh paired claude+codex session; enters claude
+$ tandem --active codex   # fresh session with codex active instead
+tandem (claude)> switch   # after exiting claude: continue instantly in codex
+tandem (codex)> exit
+to continue this session: tandem resume a1b2c3d4e5f6
+$ tandem resume           # continue the most recent session here
+$ tandem resume <id>      # continue a specific session (id from the exit hint)
 $ tandem run --on codex "second opinion: why is this test flaky?"
-$ tandem status         # pairing, roles, sync position
-$ tandem doctor [--live]# verify both sessions are resumable
-$ tandem sync           # manual catch-up translation (local file I/O only)
-$ tandem sync-mcp       # opt-in: copy MCP server configs between the tools
+$ tandem status           # pairing, roles, sync position
+$ tandem doctor [--live]  # verify both sessions are resumable
+$ tandem sync             # manual catch-up translation (local file I/O only)
+$ tandem sync-mcp         # opt-in: copy MCP server configs between the tools
 ```
 
 ## How it works
@@ -52,7 +55,7 @@ $ tandem sync-mcp       # opt-in: copy MCP server configs between the tools
   `[tandem: turn N could not be translated from <tool> — <reason>; raw
   entry quarantined at ~/.tandem/quarantine/...]` — at most one per turn,
   and sync continues. The shadow is never corrupted or truncated.
-- **Memory files.** `tandem start` and every `tandem switch` sync
+- **Memory files.** A fresh `tandem` launch and every switch sync
   CLAUDE.md ↔ AGENTS.md: shared content lives in a
   `<!-- tandem:shared:begin/end -->` block (newer file wins), tool-specific
   text outside the block is preserved, and a file without markers is read

--- a/docs/plans/2026-07-29-native-tool-call-translation.md
+++ b/docs/plans/2026-07-29-native-tool-call-translation.md
@@ -1,0 +1,1521 @@
+# Native Tool-Call Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the summarize-to-prose policy for tool activity with native tool-call translation in both sync directions, with a semantic mapping layer (`toolmap.py`) that re-expresses common tools in the shadow harness's own vocabulary.
+
+**Architecture:** The converter keeps its stash-on-call flow but, on each ToolResult, emits the mapped **call + result as an adjacent native pair** instead of a prose summary. A new pure module `toolmap.py` decides per call between Tier 1 (semantic re-expression: Bash↔exec_command, Edit/Write↔apply_patch, Read→cat -n, Grep/Glob→rg, TodoWrite↔update_plan) and Tier 2 (verbatim pass-through — spike-proven safe). The harness adapters gain dumb tool_call/tool_result rendering; a dangle-flush closes unpaired calls with `(tool result not recorded)` whenever a source is drained on role flip.
+
+**Tech Stack:** Python 3.11+, pydantic v2, pytest. No new dependencies.
+
+**Spec:** `docs/specs/2026-07-29-native-tool-call-translation-design.md` — read it before starting.
+
+## Global Constraints
+
+- Attribution: tool calls/results carry **no** `[via claude-code]`/`[via codex]` tag; text messages keep tags unchanged.
+- No output clipping anywhere in the new path — outputs ride verbatim.
+- Placeholder output wording, exactly: `(tool result not recorded)`.
+- `map_pair` never raises: any mapping surprise degrades to Tier 2 pass-through.
+- Honesty rule: Tier-1 only when the native rendering truthfully describes what happened (overwrite `Write`, `replace_all` Edit, multi-file patch → Tier 2).
+- Codex rendering convention: mapped ToolCall with `dict` arguments → `function_call`; `str` arguments → `custom_tool_call`.
+- Claude rendering convention: `ToolResult.structured` → `toolUseResult` sibling; `ToolResult.is_error` → `tool_result.is_error`.
+- `docs/superpowers/` is gitignored in this repo — specs live in `docs/specs/`, plans in `docs/plans/`.
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Run tests with `python3 -m pytest tests/ -q` from the repo root (`uv run pytest` if a venv isn't active).
+
+## File Structure
+
+- Create `src/tandem/toolmap.py` — the mapping layer (pure functions, no I/O). Owns the exec-output header parser (moves here from `summarize.py` because the mapper, not the renderer, synthesizes `toolUseResult`/`is_error` — deliberate small deviation from the spec's "keep it in summarize.py").
+- Create `tests/test_toolmap.py` — unit tests for mappings.
+- Modify `src/tandem/events.py` — add `SessionContext.claude_run_msg_id`.
+- Modify `src/tandem/converter.py` — pair-at-result emission, orphan fallback, `flush_dangling`.
+- Modify `src/tandem/harness/codex.py` — render tool events; `model_provider` fix.
+- Modify `src/tandem/harness/claude_code.py` — render tool events; `message.id` runs.
+- Modify `src/tandem/sync.py` — `SyncEngine.flush_dangling` + crash recovery.
+- Modify `src/tandem/ops.py` — flush wiring on switch/one-off drains.
+- Modify `src/tandem/summarize.py` — shrink to orphan-only.
+- Modify `tests/test_converter.py`, `tests/test_sync.py` — expectations change from prose summaries to native pairs.
+
+---
+
+### Task 1: model_provider bug fix (independent rider)
+
+Codex ≥0.145's interactive `thread/resume` rejects rollouts whose `session_meta` lacks `model_provider` (``Model provider `` not found``, -32600). Tandem's shadow rollouts omit it.
+
+**Files:**
+- Modify: `src/tandem/harness/codex.py` (the `meta` dict in `create_shadow_transcript`, around line 68)
+- Test: `tests/test_toolmap.py` (create the file now; this test lives here to avoid touching unrelated suites)
+
+**Interfaces:**
+- Consumes: `conftest.Env` fixture (`env_factory`) which calls `create_shadow_transcript`.
+- Produces: `session_meta.payload.model_provider == "openai"` in every tandem-minted rollout.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_toolmap.py
+"""Tool mapping layer + related shadow-file invariants."""
+
+import json
+
+
+class TestShadowRolloutMeta:
+    def test_model_provider_written(self, env_factory):
+        env = env_factory()
+        meta = json.loads(env.codex_shadow.read_text().splitlines()[0])
+        assert meta["type"] == "session_meta"
+        # codex >= 0.145 interactive thread/resume rejects rollouts without
+        # this ("Model provider `` not found", -32600)
+        assert meta["payload"]["model_provider"] == "openai"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: FAIL with `KeyError: 'model_provider'`
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/harness/codex.py`, inside `create_shadow_transcript`, add one key to the `meta["payload"]` dict after `"source": "exec",`:
+
+```python
+                "source": "exec",
+                "thread_source": "user",
+                # codex >= 0.145 interactive thread/resume rejects rollouts
+                # without a provider id; "openai" is codex's built-in default
+                "model_provider": "openai",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the whole suite (goldens must not care)**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tandem/harness/codex.py tests/test_toolmap.py
+git commit -m "fix: write model_provider in shadow rollout session_meta
+
+Interactive codex resume (>=0.145) rejects rollouts without it; only
+codex exec resume tolerates the omission, which is how M1 validation
+missed it.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: toolmap foundation — pass-through + Bash↔exec_command
+
+**Files:**
+- Create: `src/tandem/toolmap.py`
+- Test: `tests/test_toolmap.py` (append)
+
+**Interfaces:**
+- Consumes: `ToolCall`, `ToolResult` from `src/tandem/events.py` (pydantic models; `ToolCall.arguments: dict | str`; `ToolResult.output: str`, `.is_error: bool`, `.structured: dict | None`).
+- Produces (later tasks rely on these exact names):
+  - `toolmap.map_pair(call: ToolCall, result: ToolResult, target: str) -> tuple[ToolCall, ToolResult]` where `target` is `"claude"` or `"codex"`.
+  - `toolmap.PLACEHOLDER_OUTPUT = "(tool result not recorded)"`.
+  - `toolmap.parse_exec_output(raw: str) -> tuple[str | None, str]` (exit-code, body) — moved logic from `summarize._codex_exec_output`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_toolmap.py`:
+
+```python
+from tandem import toolmap
+from tandem.events import ToolCall, ToolResult
+
+
+def call(tool, arguments, source="claude", call_id="c1"):
+    return ToolCall(source=source, call_id=call_id, tool=tool, arguments=arguments)
+
+
+def result(output, source="claude", call_id="c1", structured=None, is_error=False):
+    return ToolResult(source=source, call_id=call_id, output=output,
+                      structured=structured, is_error=is_error)
+
+
+class TestBashExecCommand:
+    def test_bash_to_exec_command(self):
+        c, r = toolmap.map_pair(
+            call("Bash", {"command": "pytest -q"}),
+            result("3 failed", structured={"stdout": "3 failed", "stderr": ""}),
+            "codex",
+        )
+        assert c.tool == "exec_command"
+        assert c.arguments == {"cmd": "pytest -q"}
+        assert c.call_id == "c1"          # call ids ride verbatim
+        assert r.output == "3 failed"     # no fake codex exit-code header
+
+    def test_exec_command_to_bash_strips_header(self):
+        raw = ("Chunk ID: 0\nProcess exited with code 1\nWall time: 0.1 s\n"
+               "Original token count: 5\nOutput:\n3 failed")
+        c, r = toolmap.map_pair(
+            call("exec_command", '{"cmd": "pytest -q"}', source="codex"),
+            result(raw, source="codex"),
+            "claude",
+        )
+        assert c.tool == "Bash"
+        assert c.arguments == {"command": "pytest -q"}
+        assert r.output == "3 failed"
+        assert r.is_error is True
+        assert r.structured == {"stdout": "3 failed", "exitCode": 1}
+
+    def test_exec_command_exit_zero_not_error(self):
+        raw = "Process exited with code 0\nOutput:\nok"
+        _, r = toolmap.map_pair(
+            call("exec_command", '{"cmd": "true"}', source="codex"),
+            result(raw, source="codex"), "claude",
+        )
+        assert r.is_error is False
+        assert r.structured == {"stdout": "ok", "exitCode": 0}
+
+
+class TestPassThrough:
+    def test_unknown_claude_tool_rides_verbatim_to_codex(self):
+        c, r = toolmap.map_pair(
+            call("AskUserQuestion", {"questions": [{"q": "a?"}]}),
+            result("answer: a"), "codex",
+        )
+        assert c.tool == "AskUserQuestion"
+        assert c.arguments == {"questions": [{"q": "a?"}]}
+        assert r.output == "answer: a"
+
+    def test_unknown_codex_tool_rides_verbatim_to_claude(self):
+        c, r = toolmap.map_pair(
+            call("write_stdin", '{"chars": "y\\n"}', source="codex"),
+            result("ok", source="codex"), "claude",
+        )
+        assert c.tool == "write_stdin"
+        assert c.arguments == {"chars": "y\n"}   # json args parsed for tool_use.input
+        assert r.structured == {"stdout": "ok"}  # default toolUseResult
+
+    def test_unparseable_str_args_wrapped_for_claude(self):
+        c, _ = toolmap.map_pair(
+            call("mystery", "not json", source="codex"),
+            result("ok", source="codex"), "claude",
+        )
+        assert c.arguments == {"input": "not json"}
+
+    def test_mapping_never_raises(self):
+        # Bash with pathological arguments degrades to pass-through
+        c, _ = toolmap.map_pair(call("Bash", "i am not a dict"), result("x"), "codex")
+        assert c.tool == "Bash"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tandem.toolmap'` (the Task-1 test still passes)
+
+- [ ] **Step 3: Implement `src/tandem/toolmap.py`**
+
+```python
+"""Tool vocabulary mapping between harnesses.
+
+Spec: docs/specs/2026-07-29-native-tool-call-translation-design.md.
+
+Tier 1 re-expresses common tools in the target harness's own vocabulary so
+shadow history reads as the shadow's own work; Tier 2 passes name and
+arguments through verbatim (spike-validated safe on both sides, 2026-07).
+Honesty rule: Tier 1 only when the native rendering truthfully describes
+what happened; anything that doesn't fit degrades to Tier 2. map_pair never
+raises on shape surprises.
+
+Rendering conventions consumed by the adapters:
+- codex target: ToolCall with dict arguments renders as function_call, str
+  arguments as custom_tool_call input.
+- claude target: ToolResult.structured becomes the toolUseResult sibling,
+  ToolResult.is_error the tool_result is_error flag.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+
+from .events import ToolCall, ToolResult
+
+PLACEHOLDER_OUTPUT = "(tool result not recorded)"
+
+_EXIT_RE = re.compile(r"^(?:Process exited|Exit code)[^\d-]*(-?\d+)", re.M)
+_OUTPUT_RE = re.compile(r"^Output:\n", re.M)
+
+
+def parse_exec_output(raw: str) -> tuple[str | None, str]:
+    """codex exec_command output has a header (chunk id, wall time, exit
+    code, token count) followed by 'Output:\\n<text>'."""
+    exit_code = None
+    m = _EXIT_RE.search(raw)
+    if m:
+        exit_code = m.group(1)
+    m = _OUTPUT_RE.search(raw)
+    return exit_code, raw[m.end():] if m else raw
+
+
+def map_pair(
+    call: ToolCall, result: ToolResult, target: str
+) -> tuple[ToolCall, ToolResult]:
+    """One completed source-native pair -> one target-native pair."""
+    try:
+        mapper = _TO_CODEX if target == "codex" else _TO_CLAUDE
+        fn = mapper.get(call.tool)
+        if fn is not None:
+            mapped = fn(call, result)
+            if mapped is not None:
+                return mapped
+    except Exception:
+        pass  # honesty rule: surprises fall through to pass-through
+    return _passthrough(call, result, target)
+
+
+def _passthrough(
+    call: ToolCall, result: ToolResult, target: str
+) -> tuple[ToolCall, ToolResult]:
+    if target == "claude":
+        args = call.arguments
+        if isinstance(args, str):
+            try:
+                parsed = json.loads(args)
+                args = parsed if isinstance(parsed, dict) else {"input": args}
+            except json.JSONDecodeError:
+                args = {"input": args}
+        call = call.model_copy(update={"arguments": args})
+        if result.structured is None:
+            result = result.model_copy(update={"structured": {"stdout": result.output}})
+    return call, result
+
+
+def _retool(call, result, tool, arguments, output=None, structured=None,
+            is_error=None):
+    new_call = call.model_copy(update={"tool": tool, "arguments": arguments})
+    updates = {"tool": tool}
+    if output is not None:
+        updates["output"] = output
+    if structured is not None:
+        updates["structured"] = structured
+    if is_error is not None:
+        updates["is_error"] = is_error
+    return new_call, result.model_copy(update=updates)
+
+
+# -- claude -> codex ---------------------------------------------------------
+
+def _bash_to_exec(call, result):
+    args = call.arguments
+    if not isinstance(args, dict):
+        return None
+    return _retool(call, result, "exec_command", {"cmd": str(args.get("command", ""))})
+
+
+# -- codex -> claude ---------------------------------------------------------
+
+def _exec_to_bash(call, result):
+    args = call.arguments
+    if isinstance(args, str):
+        args = json.loads(args)
+    if not isinstance(args, dict):
+        return None
+    exit_code, body = parse_exec_output(result.output)
+    structured: dict = {"stdout": body}
+    is_error = False
+    if exit_code is not None:
+        structured["exitCode"] = int(exit_code)
+        is_error = exit_code != "0"
+    return _retool(call, result, "Bash", {"command": str(args.get("cmd", ""))},
+                   output=body, structured=structured, is_error=is_error)
+
+
+_TO_CODEX = {
+    "Bash": _bash_to_exec,
+}
+
+_TO_CLAUDE = {
+    "exec_command": _exec_to_bash,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/toolmap.py tests/test_toolmap.py
+git commit -m "feat: toolmap foundation - pass-through tiers + Bash<->exec_command
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: toolmap claude→codex — Read, Write, Edit, Grep, Glob, TodoWrite
+
+**Files:**
+- Modify: `src/tandem/toolmap.py`
+- Test: `tests/test_toolmap.py` (append)
+
+**Interfaces:**
+- Consumes: `_retool`, `_TO_CODEX` from Task 2.
+- Produces: Tier-1 claude→codex mappings. `apply_patch` calls are emitted with **str** arguments (the patch text) so the codex renderer picks `custom_tool_call`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_toolmap.py`:
+
+```python
+class TestClaudeToCodexTier1:
+    def test_read_plain(self):
+        c, r = toolmap.map_pair(
+            call("Read", {"file_path": "/a/b.py"}),
+            result("1\timport os"), "codex",
+        )
+        assert c.tool == "exec_command"
+        assert c.arguments == {"cmd": "cat -n /a/b.py"}
+        assert r.output == "1\timport os"
+
+    def test_read_ranged(self):
+        c, _ = toolmap.map_pair(
+            call("Read", {"file_path": "/a/b.py", "offset": 10, "limit": 5}),
+            result("10\tx"), "codex",
+        )
+        assert c.arguments == {"cmd": "cat -n /a/b.py | sed -n '10,14p'"}
+
+    def test_write_create_becomes_add_file_patch(self):
+        c, _ = toolmap.map_pair(
+            call("Write", {"file_path": "/p/hello.txt", "content": "hi\nthere"}),
+            result("ok", structured={"type": "create", "filePath": "/p/hello.txt",
+                                     "content": "hi\nthere"}),
+            "codex",
+        )
+        assert c.tool == "apply_patch"
+        assert isinstance(c.arguments, str)   # str => custom_tool_call
+        assert c.arguments == (
+            "*** Begin Patch\n*** Add File: /p/hello.txt\n+hi\n+there\n*** End Patch"
+        )
+
+    def test_write_overwrite_falls_back(self):
+        c, _ = toolmap.map_pair(
+            call("Write", {"file_path": "/p/x.txt", "content": "new"}),
+            result("ok", structured={"type": "update", "filePath": "/p/x.txt"}),
+            "codex",
+        )
+        assert c.tool == "Write"   # Tier 2: honesty rule
+
+    def test_edit_becomes_update_file_patch(self):
+        c, _ = toolmap.map_pair(
+            call("Edit", {"file_path": "/p/a.py", "old_string": "x = 1",
+                          "new_string": "x = 2"}),
+            result("ok"), "codex",
+        )
+        assert c.tool == "apply_patch"
+        assert c.arguments == (
+            "*** Begin Patch\n*** Update File: /p/a.py\n-x = 1\n+x = 2\n*** End Patch"
+        )
+
+    def test_edit_replace_all_falls_back(self):
+        c, _ = toolmap.map_pair(
+            call("Edit", {"file_path": "/p/a.py", "old_string": "x",
+                          "new_string": "y", "replace_all": True}),
+            result("ok"), "codex",
+        )
+        assert c.tool == "Edit"
+
+    def test_grep_and_glob(self):
+        c, _ = toolmap.map_pair(
+            call("Grep", {"pattern": "def main", "path": "src"}),
+            result("src/a.py:1:def main"), "codex",
+        )
+        assert c.arguments == {"cmd": "rg -n 'def main' src"}
+        c, _ = toolmap.map_pair(
+            call("Glob", {"pattern": "**/*.py"}), result("a.py"), "codex",
+        )
+        assert c.arguments == {"cmd": "rg --files -g '**/*.py'"}
+
+    def test_todowrite_becomes_update_plan(self):
+        c, _ = toolmap.map_pair(
+            call("TodoWrite", {"todos": [
+                {"content": "fix bug", "status": "in_progress", "activeForm": "Fixing"},
+                {"content": "add test", "status": "pending", "activeForm": "Adding"},
+            ]}),
+            result("Todos have been modified successfully"), "codex",
+        )
+        assert c.tool == "update_plan"
+        assert c.arguments == {"plan": [
+            {"step": "fix bug", "status": "in_progress"},
+            {"step": "add test", "status": "pending"},
+        ]}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: the new class FAILS (Read passes through as `Read`, etc.)
+
+- [ ] **Step 3: Implement**
+
+Add to `src/tandem/toolmap.py` (claude→codex section), and register in `_TO_CODEX`:
+
+```python
+def _sh_quote(path: str) -> str:
+    q = shlex.quote(path)
+    return q
+
+
+def _read_to_cat(call, result):
+    args = call.arguments
+    if not isinstance(args, dict) or not args.get("file_path"):
+        return None
+    cmd = f"cat -n {_sh_quote(args['file_path'])}"
+    offset, limit = args.get("offset"), args.get("limit")
+    if offset or limit:
+        start = int(offset or 1)
+        end = f"{start + int(limit) - 1}" if limit else "$"
+        cmd += f" | sed -n '{start},{end}p'"
+    return _retool(call, result, "exec_command", {"cmd": cmd})
+
+
+def _patch(op: str, path: str, body: str) -> str:
+    return f"*** Begin Patch\n*** {op} File: {path}\n{body}\n*** End Patch"
+
+
+def _write_to_patch(call, result):
+    args = call.arguments
+    s = result.structured or {}
+    if not isinstance(args, dict) or s.get("type") != "create":
+        return None  # overwrite or unknown: honesty rule, Tier 2
+    content = s.get("content") if isinstance(s.get("content"), str) else args.get("content", "")
+    body = "\n".join("+" + line for line in content.splitlines())
+    return _retool(call, result, "apply_patch",
+                   _patch("Add", args.get("file_path", "?"), body))
+
+
+def _edit_to_patch(call, result):
+    args = call.arguments
+    if not isinstance(args, dict) or args.get("replace_all"):
+        return None
+    hunks = (result.structured or {}).get("structuredPatch") or []
+    if hunks:
+        lines: list[str] = []
+        for h in hunks:
+            lines.append("@@")
+            lines.extend(h.get("lines") or [])
+        body = "\n".join(lines)
+    else:
+        old = [f"-{l}" for l in str(args.get("old_string", "")).splitlines()]
+        new = [f"+{l}" for l in str(args.get("new_string", "")).splitlines()]
+        body = "\n".join(old + new)
+    return _retool(call, result, "apply_patch",
+                   _patch("Update", args.get("file_path", "?"), body))
+
+
+def _grep_to_rg(call, result):
+    args = call.arguments
+    if not isinstance(args, dict) or not args.get("pattern"):
+        return None
+    flag = "-l" if args.get("output_mode") == "files_with_matches" else "-n"
+    cmd = f"rg {flag}"
+    if args.get("-i"):
+        cmd += " -i"
+    if args.get("glob"):
+        cmd += f" -g {shlex.quote(args['glob'])}"
+    cmd += f" {shlex.quote(args['pattern'])}"
+    if args.get("path"):
+        cmd += f" {_sh_quote(args['path'])}"
+    return _retool(call, result, "exec_command", {"cmd": cmd})
+
+
+def _glob_to_rg(call, result):
+    args = call.arguments
+    if not isinstance(args, dict) or not args.get("pattern"):
+        return None
+    cmd = f"rg --files -g {shlex.quote(args['pattern'])}"
+    if args.get("path"):
+        cmd += f" {_sh_quote(args['path'])}"
+    return _retool(call, result, "exec_command", {"cmd": cmd})
+
+
+def _todos_to_plan(call, result):
+    args = call.arguments
+    if not isinstance(args, dict) or not isinstance(args.get("todos"), list):
+        return None
+    plan = [{"step": t.get("content", ""), "status": t.get("status", "pending")}
+            for t in args["todos"] if isinstance(t, dict)]
+    return _retool(call, result, "update_plan", {"plan": plan})
+```
+
+Update the registry:
+
+```python
+_TO_CODEX = {
+    "Bash": _bash_to_exec,
+    "Read": _read_to_cat,
+    "Write": _write_to_patch,
+    "Edit": _edit_to_patch,
+    "Grep": _grep_to_rg,
+    "Glob": _glob_to_rg,
+    "TodoWrite": _todos_to_plan,
+}
+```
+
+Note: `shlex.quote("/a/b.py")` returns the path unquoted (safe chars), which is why the test expects `cat -n /a/b.py` but `'def main'` for the pattern with a space.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/toolmap.py tests/test_toolmap.py
+git commit -m "feat: toolmap claude->codex Tier-1 mappings
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: toolmap codex→claude — apply_patch→Write/Edit, update_plan→TodoWrite
+
+**Files:**
+- Modify: `src/tandem/toolmap.py`
+- Test: `tests/test_toolmap.py` (append)
+
+**Interfaces:**
+- Consumes: `_retool`, `_TO_CLAUDE`, `_passthrough` from Task 2.
+- Produces: Tier-1 codex→claude mappings; `_parse_patch(patch: str) -> list[tuple[str, str, list[str]]]` (op, path, body-lines) helper.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_toolmap.py`:
+
+```python
+ADD_PATCH = "*** Begin Patch\n*** Add File: /p/hello.txt\n+hi\n+there\n*** End Patch"
+UPDATE_PATCH = ("*** Begin Patch\n*** Update File: /p/a.py\n@@\n ctx\n-x = 1\n+x = 2\n"
+                "*** End Patch")
+MULTI_PATCH = ("*** Begin Patch\n*** Add File: /p/a\n+1\n*** Add File: /p/b\n+2\n"
+               "*** End Patch")
+
+
+class TestCodexToClaudeTier1:
+    def test_apply_patch_add_becomes_write(self):
+        c, r = toolmap.map_pair(
+            call("apply_patch", ADD_PATCH, source="codex"),
+            result("Done!", source="codex"), "claude",
+        )
+        assert c.tool == "Write"
+        assert c.arguments == {"file_path": "/p/hello.txt", "content": "hi\nthere"}
+        assert r.structured == {"type": "create", "filePath": "/p/hello.txt",
+                                "content": "hi\nthere"}
+
+    def test_apply_patch_update_becomes_edit(self):
+        c, r = toolmap.map_pair(
+            call("apply_patch", UPDATE_PATCH, source="codex"),
+            result("Done!", source="codex"), "claude",
+        )
+        assert c.tool == "Edit"
+        assert c.arguments == {"file_path": "/p/a.py", "old_string": "ctx\nx = 1",
+                               "new_string": "ctx\nx = 2"}
+        assert r.structured == {"filePath": "/p/a.py", "oldString": "ctx\nx = 1",
+                                "newString": "ctx\nx = 2"}
+
+    def test_multi_file_patch_falls_back(self):
+        c, _ = toolmap.map_pair(
+            call("apply_patch", MULTI_PATCH, source="codex"),
+            result("Done!", source="codex"), "claude",
+        )
+        assert c.tool == "apply_patch"
+        assert c.arguments == {"input": MULTI_PATCH}
+
+    def test_update_plan_becomes_todowrite(self):
+        c, r = toolmap.map_pair(
+            call("update_plan",
+                 '{"plan": [{"step": "fix bug", "status": "in_progress"}]}',
+                 source="codex"),
+            result("Plan updated", source="codex"), "claude",
+        )
+        assert c.tool == "TodoWrite"
+        assert c.arguments == {"todos": [
+            {"content": "fix bug", "status": "in_progress", "activeForm": "fix bug"},
+        ]}
+        assert r.output == "Plan updated"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: new class FAILS (apply_patch passes through with `{"input": ...}` but tool name stays `apply_patch` — the Write/Edit assertions fail)
+
+- [ ] **Step 3: Implement**
+
+Add to `src/tandem/toolmap.py` (codex→claude section):
+
+```python
+_FILE_OP_RE = re.compile(r"^\*\*\* (Add|Update|Delete) File: (.+)$")
+
+
+def _parse_patch(patch: str) -> list[tuple[str, str, list[str]]]:
+    """V4A patch text -> [(op, path, body-lines)]. Ignores Begin/End lines."""
+    ops: list[tuple[str, str, list[str]]] = []
+    for line in patch.splitlines():
+        if line in ("*** Begin Patch", "*** End Patch"):
+            continue
+        m = _FILE_OP_RE.match(line)
+        if m:
+            ops.append((m.group(1), m.group(2), []))
+        elif ops:
+            ops[-1][2].append(line)
+    return ops
+
+
+def _patch_to_edit(call, result):
+    patch = call.arguments if isinstance(call.arguments, str) else ""
+    ops = _parse_patch(patch)
+    if len(ops) != 1:
+        return None
+    op, path, body = ops[0]
+    if op == "Add":
+        content = "\n".join(l[1:] for l in body if l.startswith("+"))
+        return _retool(
+            call, result, "Write", {"file_path": path, "content": content},
+            structured={"type": "create", "filePath": path, "content": content},
+        )
+    if op == "Update":
+        old = "\n".join(l[1:] for l in body if l[:1] in (" ", "-"))
+        new = "\n".join(l[1:] for l in body if l[:1] in (" ", "+"))
+        return _retool(
+            call, result, "Edit",
+            {"file_path": path, "old_string": old, "new_string": new},
+            structured={"filePath": path, "oldString": old, "newString": new},
+        )
+    return None  # Delete etc.: Tier 2
+
+
+def _plan_to_todos(call, result):
+    args = call.arguments
+    if isinstance(args, str):
+        args = json.loads(args)
+    if not isinstance(args, dict) or not isinstance(args.get("plan"), list):
+        return None
+    todos = [{"content": s.get("step", ""), "status": s.get("status", "pending"),
+              "activeForm": s.get("step", "")}
+             for s in args["plan"] if isinstance(s, dict)]
+    return _retool(call, result, "TodoWrite", {"todos": todos},
+                   structured={"stdout": result.output})
+```
+
+Update the registry:
+
+```python
+_TO_CLAUDE = {
+    "exec_command": _exec_to_bash,
+    "apply_patch": _patch_to_edit,
+    "update_plan": _plan_to_todos,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/toolmap.py tests/test_toolmap.py
+git commit -m "feat: toolmap codex->claude Tier-1 mappings incl. V4A patch parsing
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: codex renderer — function_call / custom_tool_call pairs
+
+**Files:**
+- Modify: `src/tandem/harness/codex.py` (`render_events`, currently lines 242–305)
+- Test: `tests/test_toolmap.py` (append)
+
+**Interfaces:**
+- Consumes: `ToolCall`/`ToolResult` events with **codex-vocabulary** content (from `toolmap`); the dict-vs-str arguments convention.
+- Produces: `response_item` lines: `function_call {name, arguments: <json str>, call_id}` / `custom_tool_call {name, input, call_id}` and matching `function_call_output` / `custom_tool_call_output {call_id, output}`. No `event_msg` lines for tool activity.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_toolmap.py`:
+
+```python
+from tandem.events import SessionContext
+from tandem.harness import get_adapter
+
+
+def _ctx(direction="claude->codex"):
+    return SessionContext(
+        tandem_id="t1", cwd="/p", direction=direction,
+        claude_session_id="11111111-1111-4111-8111-111111111111",
+        codex_session_id="019faca1-0000-7000-8000-000000000001",
+        claude_leaf_uuid="seed",
+    )
+
+
+class TestCodexToolRendering:
+    def test_function_call_pair(self):
+        ctx = _ctx()
+        entries = get_adapter("codex").render_events([
+            call("exec_command", {"cmd": "ls"}, call_id="c9"),
+            result("a.py", call_id="c9"),
+        ], ctx)
+        assert [e["payload"]["type"] for e in entries] == [
+            "function_call", "function_call_output"]
+        assert entries[0]["payload"]["name"] == "exec_command"
+        assert entries[0]["payload"]["arguments"] == '{"cmd": "ls"}'
+        assert entries[0]["payload"]["call_id"] == "c9"
+        assert entries[1]["payload"] == {
+            "type": "function_call_output", "call_id": "c9", "output": "a.py"}
+        assert all(e["type"] == "response_item" for e in entries)
+
+    def test_custom_tool_call_pair(self):
+        ctx = _ctx()
+        entries = get_adapter("codex").render_events([
+            call("apply_patch", "*** Begin Patch\n*** End Patch", call_id="c2"),
+            result("Done!", call_id="c2"),
+        ], ctx)
+        assert [e["payload"]["type"] for e in entries] == [
+            "custom_tool_call", "custom_tool_call_output"]
+        assert entries[0]["payload"]["input"].startswith("*** Begin Patch")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: FAIL — `render_events` currently drops tool events (returns `[]`)
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/harness/codex.py` `render_events`, add branches to the `for ev in events:` loop (after the `assistant_message` branch), plus a batch-local set before the loop:
+
+```python
+        out: list[dict[str, Any]] = []
+        custom_ids: set[str] = set()   # calls rendered as custom_tool_call
+        for ev in events:
+```
+
+```python
+            elif ev.kind == "tool_call":
+                if isinstance(ev.arguments, str):
+                    custom_ids.add(ev.call_id)
+                    payload: dict[str, Any] = {
+                        "type": "custom_tool_call", "name": ev.tool,
+                        "input": ev.arguments, "call_id": ev.call_id,
+                    }
+                else:
+                    payload = {
+                        "type": "function_call", "name": ev.tool,
+                        "arguments": json.dumps(ev.arguments, ensure_ascii=False),
+                        "call_id": ev.call_id,
+                    }
+                out.append({"timestamp": ts, "type": "response_item", "payload": payload})
+            elif ev.kind == "tool_result":
+                ptype = ("custom_tool_call_output" if ev.call_id in custom_ids
+                         else "function_call_output")
+                out.append({
+                    "timestamp": ts, "type": "response_item",
+                    "payload": {"type": ptype, "call_id": ev.call_id,
+                                "output": ev.output},
+                })
+```
+
+Add `import json` to the module imports (it is not currently imported there). The converter always emits a call adjacent to its result in the same batch, so the batch-local `custom_ids` set is sufficient to pick the output type.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/harness/codex.py tests/test_toolmap.py
+git commit -m "feat: codex renderer emits native function_call/custom_tool_call pairs
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: claude renderer — tool_use/tool_result + message.id runs
+
+**Files:**
+- Modify: `src/tandem/events.py` (SessionContext)
+- Modify: `src/tandem/harness/claude_code.py` (`render_events`, currently lines 226–254)
+- Test: `tests/test_toolmap.py` (append)
+
+**Interfaces:**
+- Consumes: `ToolCall`/`ToolResult` events with **claude-vocabulary** content; `ToolResult.structured` → `toolUseResult`, `.is_error` → `tool_result.is_error`.
+- Produces: `assistant` entries with a `tool_use` block (`stop_reason: "tool_use"`) and `user` entries with a `tool_result` block + `toolUseResult` sibling; new `SessionContext.claude_run_msg_id: str | None` — consecutive assistant entries share one `message.id`, reset by any rendered user-side entry.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_toolmap.py`:
+
+```python
+from tandem.events import AssistantMessage, UserMessage
+
+
+class TestClaudeToolRendering:
+    def test_tool_pair_and_message_id_runs(self):
+        ctx = _ctx("codex->claude")
+        adapter = get_adapter("claude")
+        entries = adapter.render_events([
+            AssistantMessage(source="codex", text="Looking around."),
+            call("Bash", {"command": "ls"}, source="codex", call_id="c1"),
+            result("a.py", source="codex", call_id="c1",
+                   structured={"stdout": "a.py", "exitCode": 0}),
+            call("Bash", {"command": "cat a.py"}, source="codex", call_id="c2"),
+            result("print(1)", source="codex", call_id="c2",
+                   structured={"stdout": "print(1)", "exitCode": 0}),
+        ], ctx)
+
+        types = [e["type"] for e in entries]
+        assert types == ["assistant", "assistant", "user", "assistant", "user"]
+
+        text_msg, tool1, res1, tool2, res2 = entries
+        # text and the first tool_use share one API message id; the
+        # tool_result (a user entry) ends the run, so the next call gets a
+        # fresh id
+        assert tool1["message"]["id"] == text_msg["message"]["id"]
+        assert tool2["message"]["id"] != tool1["message"]["id"]
+
+        block = tool1["message"]["content"][0]
+        assert block == {"type": "tool_use", "id": "c1", "name": "Bash",
+                         "input": {"command": "ls"}}
+        assert tool1["message"]["stop_reason"] == "tool_use"
+
+        rblock = res1["message"]["content"][0]
+        assert rblock == {"type": "tool_result", "tool_use_id": "c1",
+                          "content": "a.py", "is_error": False}
+        assert res1["toolUseResult"] == {"stdout": "a.py", "exitCode": 0}
+
+        # uuid/parentUuid chain is intact across the mixed entries
+        for prev, cur in zip(entries, entries[1:]):
+            assert cur["parentUuid"] == prev["uuid"]
+        assert ctx.claude_leaf_uuid == entries[-1]["uuid"]
+
+    def test_is_error_flag_rides(self):
+        ctx = _ctx("codex->claude")
+        entries = get_adapter("claude").render_events([
+            call("Bash", {"command": "false"}, source="codex", call_id="c3"),
+            result("", source="codex", call_id="c3", is_error=True,
+                   structured={"stdout": "", "exitCode": 1}),
+        ], ctx)
+        assert entries[1]["message"]["content"][0]["is_error"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: FAIL — tool events are dropped by the current renderer
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/events.py`, add to `SessionContext` (after `claude_leaf_uuid`):
+
+```python
+    # message.id shared by the current contiguous run of rendered assistant
+    # entries; any rendered user-side entry resets it (a real transcript has
+    # one id per API response, and regrouping by id must not strand a
+    # tool_use away from its tool_result)
+    claude_run_msg_id: str | None = None
+```
+
+In `src/tandem/harness/claude_code.py`, replace the body of `render_events` with:
+
+```python
+        out: list[dict[str, Any]] = []
+        for ev in events:
+            if ev.kind in ("user_message", "tool_result"):
+                ctx.claude_run_msg_id = None
+            if ev.kind == "user_message":
+                entry = self._base_entry(ctx, "user")
+                entry["message"] = {"role": "user", "content": ev.text}
+            elif ev.kind == "assistant_message":
+                entry = self._base_entry(ctx, "assistant")
+                entry["message"] = self._assistant_message(
+                    ctx, entry, [{"type": "text", "text": ev.text}], "end_turn"
+                )
+            elif ev.kind == "tool_call":
+                entry = self._base_entry(ctx, "assistant")
+                inp = ev.arguments if isinstance(ev.arguments, dict) else {"input": ev.arguments}
+                entry["message"] = self._assistant_message(
+                    ctx, entry,
+                    [{"type": "tool_use", "id": ev.call_id, "name": ev.tool,
+                      "input": inp}],
+                    "tool_use",
+                )
+            elif ev.kind == "tool_result":
+                entry = self._base_entry(ctx, "user")
+                entry["message"] = {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": ev.call_id,
+                                 "content": ev.output, "is_error": ev.is_error}],
+                }
+                entry["toolUseResult"] = ev.structured or {"stdout": ev.output}
+            else:
+                continue
+            if ev.timestamp:
+                entry["timestamp"] = ev.timestamp
+            ctx.claude_leaf_uuid = entry["uuid"]
+            out.append(entry)
+        return out
+
+    def _assistant_message(
+        self, ctx: SessionContext, entry: dict[str, Any],
+        content: list[dict[str, Any]], stop_reason: str,
+    ) -> dict[str, Any]:
+        if ctx.claude_run_msg_id is None:
+            ctx.claude_run_msg_id = f"msg_tandem_{entry['uuid'][:8]}"
+        return {
+            "role": "assistant",
+            "model": "<synced>",
+            "id": ctx.claude_run_msg_id,
+            "type": "message",
+            "content": content,
+            "stop_reason": stop_reason,
+            "stop_sequence": None,
+        }
+```
+
+(This also switches plain assistant text to run-shared ids, per the spec.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: PASS. Also run `python3 -m pytest tests/ -q` — existing suites must still pass (they don't assert per-entry unique message ids).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/events.py src/tandem/harness/claude_code.py tests/test_toolmap.py
+git commit -m "feat: claude renderer emits tool_use/tool_result with message.id runs
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: converter policy — pair-at-result emission + orphan fallback
+
+**Files:**
+- Modify: `src/tandem/converter.py` (`_apply_policy` ToolResult branch, lines 83–99; module docstring)
+- Modify: `tests/test_converter.py` (golden expectations)
+- Modify: `tests/test_sync.py:36` (one summary assertion)
+
+**Interfaces:**
+- Consumes: `toolmap.map_pair`, `summarize.summarize_orphan_result`, `other()` from `tandem.harness`.
+- Produces: translated output for a completed pair is now `[mapped ToolCall, mapped ToolResult]` (untagged); orphan results stay prose commentary.
+
+- [ ] **Step 1: Update the golden tests to expect native pairs**
+
+Replace `TestClaudeToCodex.test_golden` and `TestCodexToClaude` golden assertions in `tests/test_converter.py`:
+
+```python
+class TestClaudeToCodex:
+    def test_golden(self):
+        entries, ctx = translate_file("claude-probe.jsonl", "claude->codex")
+
+        assert all(set(e) == {"timestamp", "type", "payload"} for e in entries)
+
+        user_items = [
+            e for e in entries
+            if e["type"] == "response_item" and e["payload"].get("role") == "user"
+        ]
+        assert len(user_items) == 1
+        text = user_items[0]["payload"]["content"][0]["text"]
+        assert text.startswith("[via claude-code] Create a file named hello.txt")
+
+        assistant_items = [
+            e for e in entries
+            if e["type"] == "response_item" and e["payload"].get("role") == "assistant"
+        ]
+        texts = [a["payload"]["content"][0]["text"] for a in assistant_items]
+        # 2 claude text messages, still attribution-tagged
+        assert len(texts) == 2
+        assert all(t.startswith("[via claude-code]") for t in texts)
+
+        # the Write became a native custom_tool_call apply_patch pair
+        customs = [e["payload"] for e in entries
+                   if e["payload"].get("type") == "custom_tool_call"]
+        assert len(customs) == 1
+        assert customs[0]["name"] == "apply_patch"
+        assert "*** Add File:" in customs[0]["input"]
+        assert "+hi tandem" in customs[0]["input"]
+
+        # the Bash became a native exec_command pair
+        fcalls = [e["payload"] for e in entries
+                  if e["payload"].get("type") == "function_call"]
+        assert len(fcalls) == 1
+        assert fcalls[0]["name"] == "exec_command"
+        assert "cat hello.txt" in fcalls[0]["arguments"]
+        outs = [e["payload"] for e in entries
+                if e["payload"].get("type", "").endswith("_output")]
+        assert len(outs) == 2
+        assert any("hi tandem" in o["output"] for o in outs)
+
+        # tool pairing consumed all pending calls
+        assert ctx.pending_calls == {}
+```
+
+```python
+class TestCodexToClaude:
+    def test_golden(self):
+        entries, ctx = translate_file("codex-probe.jsonl", "codex->claude")
+
+        # chain integrity across mixed entry types
+        assert entries[0]["parentUuid"] == "seed-leaf"
+        for prev, cur in zip(entries, entries[1:]):
+            assert cur["parentUuid"] == prev["uuid"]
+        assert ctx.claude_leaf_uuid == entries[-1]["uuid"]
+        assert all(e["sessionId"] == ctx.claude_session_id for e in entries)
+
+        prompts = [e for e in entries if e["type"] == "user"
+                   and isinstance(e["message"]["content"], str)]
+        assert len(prompts) == 1
+        assert prompts[0]["message"]["content"].startswith(
+            "[via codex] Create a file named hello.txt"
+        )
+
+        texts = [
+            e["message"]["content"][0]["text"] for e in entries
+            if e["type"] == "assistant"
+            and e["message"]["content"][0]["type"] == "text"
+        ]
+        # 3 codex messages (2 commentary + 1 final), still tagged; no summaries
+        assert len(texts) == 3
+        assert all(t.startswith("[via codex]") for t in texts)
+
+        tool_uses = [
+            e["message"]["content"][0] for e in entries
+            if e["type"] == "assistant"
+            and e["message"]["content"][0]["type"] == "tool_use"
+        ]
+        # apply_patch add hello.txt -> Write; 3 exec_command -> Bash
+        # (count, not order: the probe's call order is not pinned here)
+        assert sorted(t["name"] for t in tool_uses) == ["Bash", "Bash", "Bash", "Write"]
+        write = next(t for t in tool_uses if t["name"] == "Write")
+        assert write["input"]["file_path"].endswith("hello.txt")
+        assert "hi tandem" in write["input"]["content"]
+        assert any(t["name"] == "Bash" and t["input"]["command"] == "cat hello.txt"
+                   for t in tool_uses)
+
+        results = [e for e in entries if e["type"] == "user"
+                   and isinstance(e["message"]["content"], list)]
+        assert len(results) == 4
+        cat = next(e for e in results
+                   if "hi tandem" in e["message"]["content"][0]["content"])
+        # exec header stripped from content, exit code in toolUseResult
+        assert "Original token count" not in cat["message"]["content"][0]["content"]
+        assert cat["toolUseResult"]["exitCode"] == 0
+        assert ctx.pending_calls == {}
+```
+
+Delete the old `test_exec_output_header_stripped` (folded into `test_golden` above). Keep `test_error_localized_to_entry` unchanged.
+
+In `tests/test_sync.py` line 36, replace:
+
+```python
+        assert any("ran `pytest -q`" in t and "3 failed" in t for t in texts)
+```
+
+with (add `read_jsonl` usage — it is already imported at the top):
+
+```python
+        rollout = read_jsonl(env.codex_shadow)
+        fcalls = [e["payload"] for e in rollout
+                  if e.get("type") == "response_item"
+                  and e["payload"].get("type") == "function_call"]
+        assert any('pytest -q' in f["arguments"] for f in fcalls)
+        outs = [e["payload"] for e in rollout
+                if e.get("type") == "response_item"
+                and e["payload"].get("type") == "function_call_output"]
+        assert any("3 failed" in o["output"] for o in outs)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_converter.py tests/test_sync.py -q`
+Expected: golden tests FAIL (converter still emits prose summaries)
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/converter.py`:
+- Imports: add `from . import toolmap`, `from .harness import get_adapter, other`; drop `summarize_pair` from the summarize import (keep `summarize_orphan_result`).
+- Replace the `ToolResult` branch of `_apply_policy`:
+
+```python
+            elif isinstance(ev, ToolCall):
+                ctx.pending_calls[ev.call_id] = ev.model_dump(exclude_none=True)
+            elif isinstance(ev, ToolResult):
+                stored = ctx.pending_calls.pop(ev.call_id or "", None)
+                if stored:
+                    stored.pop("_structured", None)
+                    call = ToolCall.model_validate(stored)
+                    out.extend(toolmap.map_pair(call, ev, other(source_id)))
+                else:
+                    out.append(
+                        AssistantMessage(
+                            source=ev.source,
+                            timestamp=ev.timestamp,
+                            turn_index=ev.turn_index,
+                            text=f"{tag} {summarize_orphan_result(ev)}",
+                            phase="commentary",
+                        )
+                    )
+```
+
+- Update the class docstring: tool calls are now rendered as native pairs in the shadow vocabulary (mapped via `toolmap`), not action summaries. Update the `ToolCall` docstring in `src/tandem/events.py` the same way (it still says "Never replayed as a real tool call").
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/converter.py src/tandem/events.py tests/test_converter.py tests/test_sync.py
+git commit -m "feat: converter emits native tool pairs via toolmap (pair-at-result)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: dangle flush — converter + SyncEngine + ops wiring
+
+**Files:**
+- Modify: `src/tandem/converter.py` (add `flush_dangling`)
+- Modify: `src/tandem/sync.py` (`SyncEngine.flush_dangling`, `_prepare` recovery)
+- Modify: `src/tandem/ops.py` (`drain_source` flag; `switch_session`, `run_oneoff`)
+- Test: `tests/test_toolmap.py` (append)
+
+**Interfaces:**
+- Consumes: `toolmap.map_pair`, `toolmap.PLACEHOLDER_OUTPUT`, `TailLoop.ctx` / `TailLoop.cursor` attributes, `ctx_to_cursor`.
+- Produces:
+  - `ReferenceConverter.flush_dangling(ctx: SessionContext) -> list[NormalizedEvent]` — mapped call+placeholder pairs for every pending call; clears `ctx.pending_calls`.
+  - `SyncEngine.flush_dangling(ctx, cursor) -> int` — renders+appends them exactly-once; returns entries appended.
+  - `ops.drain_source(store, session, source, flush_dangling=False)` — flushes after the drain when the flag is set; `switch_session` and `run_oneoff` pass `True` for their outgoing-source drains.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_toolmap.py`:
+
+```python
+from conftest import claude_assistant, claude_user, write_line
+from tandem.util import read_jsonl
+
+
+class TestDangleFlush:
+    def _pendings(self, env):
+        write_line(env.source_file, claude_user("do the thing"))
+        write_line(env.source_file, claude_assistant(
+            [{"type": "tool_use", "id": "dangling-1", "name": "Bash",
+              "input": {"command": "sleep 999"}}]
+        ))
+
+    def test_flush_closes_pending_call(self, env_factory):
+        env = env_factory()
+        loop, engine = env.loop()
+        self._pendings(env)
+        loop.drain()
+        assert loop.ctx.pending_calls  # the call is stashed, unpaired
+
+        n = engine.flush_dangling(loop.ctx, loop.cursor)
+        assert n == 2
+        assert loop.ctx.pending_calls == {}
+
+        rollout = read_jsonl(env.codex_shadow)
+        pl = [e["payload"] for e in rollout if e.get("type") == "response_item"]
+        fc = [p for p in pl if p.get("type") == "function_call"]
+        out = [p for p in pl if p.get("type") == "function_call_output"]
+        assert fc[-1]["name"] == "exec_command"
+        assert fc[-1]["call_id"] == "dangling-1"
+        assert out[-1] == {"type": "function_call_output",
+                           "call_id": "dangling-1",
+                           "output": "(tool result not recorded)"}
+
+    def test_flush_noop_when_nothing_pending(self, env_factory):
+        env = env_factory()
+        loop, engine = env.loop()
+        write_line(env.source_file, claude_user("hi"))
+        loop.drain()
+        before = env.codex_shadow.read_text()
+        assert engine.flush_dangling(loop.ctx, loop.cursor) == 0
+        assert env.codex_shadow.read_text() == before
+
+    def test_drain_source_flag_flushes(self, env_factory, monkeypatch):
+        from tandem import ops
+        env = env_factory()
+        self._pendings(env)
+        # route drain_source at the stand-in transcript
+        monkeypatch.setattr(
+            ops, "source_transcript", lambda session, source: env.source_file
+        )
+        ops.drain_source(env.store, env.session, "claude", flush_dangling=True)
+        rollout = read_jsonl(env.codex_shadow)
+        outs = [e["payload"]["output"] for e in rollout
+                if e.get("type") == "response_item"
+                and e["payload"].get("type") == "function_call_output"]
+        assert "(tool result not recorded)" in outs
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_toolmap.py -q`
+Expected: FAIL with `AttributeError: 'SyncEngine' object has no attribute 'flush_dangling'`
+
+- [ ] **Step 3: Implement**
+
+`src/tandem/converter.py`, on `ReferenceConverter`:
+
+```python
+    def flush_dangling(self, ctx: SessionContext) -> list[NormalizedEvent]:
+        """Mapped call + placeholder-result pairs for every pending call.
+        Both replay APIs reject a call without a result, so a drained source
+        must never leave one behind. Clears ctx.pending_calls."""
+        target_id = ctx.direction.split("->")[1]
+        out: list[NormalizedEvent] = []
+        for call_id, stored in list(ctx.pending_calls.items()):
+            stored.pop("_structured", None)
+            call = ToolCall.model_validate(stored)
+            placeholder = ToolResult(
+                source=call.source, turn_index=call.turn_index,
+                call_id=call_id, output=toolmap.PLACEHOLDER_OUTPUT,
+            )
+            out.extend(toolmap.map_pair(call, placeholder, target_id))
+        ctx.pending_calls.clear()
+        return out
+```
+
+`src/tandem/sync.py`, on `SyncEngine` (module constant `_FLUSH_LINE = -1` near the top):
+
+```python
+    def flush_dangling(self, ctx: SessionContext, cursor: SyncCursor) -> int:
+        """Close every pending tool call with a placeholder result. Called
+        after a drain when the source is being handed off (role switch,
+        one-off). Exactly-once via the same write-ahead intent as line
+        appends, keyed on the sentinel line index _FLUSH_LINE."""
+        if not self._prepared:
+            self._prepare(ctx, cursor)
+        fn = getattr(self.converter, "flush_dangling", None)
+        if fn is None or not ctx.pending_calls:
+            return 0
+        events = fn(ctx)
+        entries = self.target.render_events(events, ctx) if events else []
+        if not entries:
+            ctx_to_cursor(ctx, cursor)
+            self.store.save_cursor(cursor)
+            return 0
+        pre_size = self.shadow_path.stat().st_size
+        cursor.pending["intent"] = {"line": _FLUSH_LINE, "pre_size": pre_size}
+        self.store.save_cursor(cursor)
+        append_jsonl_fsync(self.shadow_path, entries)
+        cursor.pending.pop("intent", None)
+        ctx_to_cursor(ctx, cursor)
+        self.store.save_cursor(cursor)
+        return len(entries)
+```
+
+In `SyncEngine._prepare`, extend the intent recovery: a crashed *flush* whose append landed must not be replayed (the pending calls it closed were already written):
+
+```python
+        intent = cursor.pending.get("intent")
+        if intent:
+            try:
+                grew = self.shadow_path.stat().st_size > int(intent["pre_size"])
+            except OSError:
+                grew = False
+            if int(intent["line"]) == _FLUSH_LINE:
+                if grew:
+                    # the flush landed before the crash; its calls are closed
+                    ctx.pending_calls.clear()
+                cursor.pending.pop("intent", None)
+                ctx_to_cursor(ctx, cursor)
+                self.store.save_cursor(cursor)
+            elif grew:
+                self._skip_append_line = int(intent["line"])
+```
+
+(`ctx_to_cursor` is already imported in `sync.py` via `from .runner import ctx_to_cursor`.)
+
+`src/tandem/ops.py` — change `drain_source` signature and tail:
+
+```python
+def drain_source(
+    store: StateStore, session: PairedSession, source: str,
+    *, flush_dangling: bool = False,
+) -> int:
+    """Translate any unsynced tail of `source`'s file into the other file.
+    Pure local file I/O. Returns lines consumed. With flush_dangling=True,
+    close any still-unpaired tool calls with placeholder results afterwards
+    (required when the source is being handed off: both replay APIs reject
+    a dangling call)."""
+    transcript = source_transcript(session, source)
+    if transcript is None:
+        return 0
+    engine = SyncEngine(store, session, source)
+    loop = TailLoop(store, session, source, transcript, engine)
+    total = 0
+    while True:
+        n = loop.drain()
+        total += n
+        if n == 0:
+            break
+    if loop.errors:
+        raise SyncSetupError("; ".join(loop.errors))
+    if flush_dangling:
+        engine.flush_dangling(loop.ctx, loop.cursor)
+    return total
+```
+
+In `switch_session`: `drain_source(store, session, old_active, flush_dangling=True)`.
+In `run_oneoff`: both drains get `flush_dangling=True` (the initial `session.active` drain and the final `target` drain).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: all pass (existing switch/one-off tests in `test_ops.py` exercise the new flag with empty pending — no behavior change there)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/converter.py src/tandem/sync.py src/tandem/ops.py tests/test_toolmap.py
+git commit -m "feat: dangle flush - close unpaired tool calls on source handoff
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: shrink summarize.py to orphan-only
+
+**Files:**
+- Modify: `src/tandem/summarize.py`
+- Test: existing suites (`tests/test_converter.py` orphan path is covered via converter tests; no test currently imports the deleted functions — verify with grep)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `summarize.py` exports only `summarize_orphan_result` (and its `_clip_lines` helper). `summarize_pair`, `_summarize_claude`, `_summarize_codex`, `_codex_exec_output`, `_clip_diff`, `_compact_args` and their constants (`DIFF_MAX_LINES`, `ARGS_MAX_CHARS`) are deleted — the exec-header parser now lives in `toolmap.parse_exec_output`.
+
+- [ ] **Step 1: Confirm nothing else imports the dead code**
+
+Run: `grep -rn "summarize_pair\|_codex_exec_output\|_summarize_claude\|_summarize_codex\|_clip_diff\|_compact_args\|DIFF_MAX_LINES\|ARGS_MAX_CHARS" src/ tests/`
+Expected: no hits outside `src/tandem/summarize.py` itself. If `tests/` hits appear, delete those test cases in the same commit (they test retired behavior).
+
+- [ ] **Step 2: Rewrite `src/tandem/summarize.py`**
+
+```python
+"""Orphan tool-result fallback.
+
+Completed tool calls are translated natively (see toolmap.py / the
+converter policy). The only tool activity still rendered as prose is a
+result whose call was never seen (e.g. a restart lost the pairing): a bare
+native tool_result without its call would break Claude resume, so it
+becomes a one-line commentary instead.
+"""
+
+from __future__ import annotations
+
+from .events import ToolResult
+
+OUTPUT_HEAD_LINES = 25
+OUTPUT_TAIL_LINES = 10
+OUTPUT_MAX_CHARS = 4000
+
+
+def _clip_lines(text: str, head: int = OUTPUT_HEAD_LINES, tail: int = OUTPUT_TAIL_LINES) -> str:
+    text = text.rstrip("\n")
+    if len(text) > OUTPUT_MAX_CHARS * 2:
+        text = text[: OUTPUT_MAX_CHARS] + "\n…\n" + text[-OUTPUT_MAX_CHARS // 2 :]
+    lines = text.splitlines()
+    if len(lines) <= head + tail + 2:
+        out = text
+    else:
+        omitted = len(lines) - head - tail
+        out = "\n".join(lines[:head] + [f"… (+{omitted} lines omitted) …"] + lines[-tail:])
+    if len(out) > OUTPUT_MAX_CHARS:
+        out = out[:OUTPUT_MAX_CHARS] + "…"
+    return out
+
+
+def summarize_orphan_result(result: ToolResult) -> str:
+    """Result whose call was never seen (e.g. restart lost the pairing)."""
+    status = "error" if result.is_error else "ok"
+    return f"tool result ({status}): {_clip_lines(result.output)}"
+```
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: all pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tandem/summarize.py
+git commit -m "refactor: summarize.py shrinks to the orphan-result fallback
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: live validation (manual, doctor-style)
+
+No code — this validates the whole feature against the real CLIs, mirroring how M1–M5 were validated. Use a throwaway project dir.
+
+**Files:**
+- None (findings go in the final commit message / PR description; surprises get quarantined as spec amendments)
+
+- [ ] **Step 1: claude→codex live check**
+
+In a scratch dir: `tandem start` with claude active; run a short claude turn that uses at least one Bash, one Write, and one Edit. Then `tandem switch` (or the CLI's switch verb) and confirm:
+- the codex shadow rollout contains `function_call exec_command` / `custom_tool_call apply_patch` pairs (not prose), and
+- **interactive** `codex resume <codex-session-id>` opens and answers a question about the synced work (this also exercises the Task-1 `model_provider` fix).
+
+- [ ] **Step 2: codex→claude live check**
+
+Same pairing, codex active: run a codex turn with an `exec_command` and an `apply_patch`. Switch and confirm `claude --resume <claude-session-id>` opens, renders the history, and answers "what did the last patch change?" correctly from the synced `tool_use`/`tool_result` entries.
+
+- [ ] **Step 3: dangle check**
+
+Interrupt a claude turn mid-tool-call (Ctrl-C while a long `sleep` Bash runs), switch, and confirm the codex shadow's last two response_items are the mapped call plus `(tool result not recorded)`, and that codex still resumes cleanly.
+
+- [ ] **Step 4: Record outcomes**
+
+Append a dated "live validation" note to `docs/specs/2026-07-29-native-tool-call-translation-design.md` (Validation record section) stating CLI versions and the three outcomes; commit:
+
+```bash
+git add docs/specs/2026-07-29-native-tool-call-translation-design.md
+git commit -m "docs: record live validation of native tool-call translation
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: converter policy → Task 7; pairing invariant/flush → Task 8; mapping tables → Tasks 2–4; codex renderer + model_provider rider → Tasks 5 and 1; claude renderer + message.id runs + SessionContext → Task 6; summarize shrink → Task 9; golden/live testing → Tasks 7 and 10. Spec's "`_codex_exec_output` stays in summarize.py" is deliberately amended: it moves to `toolmap.parse_exec_output` (the mapper is its only consumer).
+- `pending_calls` keeps the full serialized ToolCall (spec requirement) — Task 7 leaves the stash line untouched.
+- Attribution: tags only on `UserMessage`/`AssistantMessage` text paths, never added in Tasks 2–8.

--- a/docs/specs/2026-07-29-native-tool-call-translation-design.md
+++ b/docs/specs/2026-07-29-native-tool-call-translation-design.md
@@ -1,0 +1,148 @@
+# Native tool-call translation — design
+
+2026-07-29. Replaces the summarize-to-prose policy for tool activity in the
+sync engine. Approved direction: native in **both** directions, no
+attribution tags on tool activity, no output clipping (both revisitable).
+
+## Why
+
+Tool activity is most of a session: in the session that built tandem M1–M5,
+93% of conversation bytes were tool results (92KB) vs 7KB of message text.
+The current policy (`converter.py` + `summarize.py`) flattens each completed
+call into clipped prose — `Read` results drop to `read <path>`, Bash output
+is head/tail sampled, and codex's `update_plan`/`write_stdin`/`js` fall into
+a generic clip. The shadow model gets a paraphrase of the work instead of
+the work.
+
+## Validation record (all live, this machine)
+
+- **claude→codex** — vibeshub spike (2026-07-25, codex 0.137; amended
+  2026-07-26, codex 0.145, see
+  `vibeshub/webapp/backend/app/claude_to_codex_rollout.py`): fabricated
+  rollouts resume; `function_call` items with foreign names (`Read`) and
+  Claude `toolu_*` call ids ride along verbatim and their output reaches the
+  model; `turn_context`/`base_instructions` optional; unpaired calls are
+  rejected by the Responses API and must be closed with a placeholder
+  output; `session_meta.model_provider` is required by the interactive
+  `thread/resume` path on codex ≥0.145. Field-proven by rollout
+  `019fa0eb-7438-…` (2026-07-27): a vibeshub export containing native
+  `Read`/`Edit`/`exec_command` calls that Codex Desktop resumed for two
+  full turns.
+- **codex→claude** — tandem spike (2026-07-29, claude 2.1.220): a
+  fabricated transcript with a synthetic uuid/parentUuid chain, codex-shaped
+  call ids (`call_…`), and foreign tool names (`update_plan`, `apply_patch`
+  as `tool_use` blocks) resumed cleanly via `claude --resume … -p`; all
+  three planted markers in `tool_result` content were quoted back verbatim
+  (exit 0, 3/3).
+
+## Converter policy (`converter.py`)
+
+`_apply_policy` changes for `ToolCall`/`ToolResult`; all other event kinds
+keep their current handling (text tagged with attribution, thinking dropped,
+compaction noted, system skipped).
+
+- **ToolCall**: emit natively (no longer stash-only). Also record
+  `ctx.pending_calls[call_id] = {"tool": name}` — needed for orphan
+  detection, `is_error` derivation, and the flush rule below.
+- **ToolResult**: if its call is pending, pop it and emit natively. If the
+  call was never seen (orphan — e.g. cursor started mid-turn), keep the
+  existing prose fallback (`summarize_orphan_result`): a bare `tool_result`
+  with no preceding `tool_use` would itself break Claude resume.
+- **Attribution**: tool calls and results carry no `[claude]`/`[codex]`
+  tag. Text messages keep their tags unchanged.
+- **No clipping**: outputs are carried verbatim. Revisit with a cap knob if
+  shadow context bloat shows up in practice.
+
+### Pairing invariant (dangle flush)
+
+Both replay APIs reject a call without a result. New invariant: **whenever
+tandem drains a source** (role switch, one-off routing, doctor repair), every
+entry left in `ctx.pending_calls` is closed by appending a native result
+with output `(tool result not recorded)` (same wording as vibeshub) to the
+shadow, then `pending_calls` is cleared. Similarly, when a ToolResult entry
+fails translation, its quarantine placeholder is accompanied by a native
+placeholder output for that `call_id`, so the shadow never holds a dangling
+call across a translation failure.
+
+## Tool-name mapping
+
+Verbatim pass-through is the default in both directions (spike-verified on
+both sides); only the shell tools get an argument-shape mapping.
+
+| direction | source | target |
+| --- | --- | --- |
+| claude→codex | `Bash {command}` | `function_call exec_command {"cmd": …}` |
+| claude→codex | any other tool | `function_call`, name verbatim, `arguments` = JSON-stringified input |
+| codex→claude | `exec_command {cmd}` | `tool_use Bash {"command": …}` |
+| codex→claude | `custom_tool_call` (`apply_patch`) | `tool_use`, name verbatim, `input {"input": <patch text>}` |
+| codex→claude | any other `function_call` | `tool_use`, name/args verbatim |
+
+## Codex rendering (`harness/codex.py`)
+
+- ToolCall → `response_item` `function_call` `{name, arguments, call_id}`
+  (call_id verbatim; `toolu_*` ids proven fine). ToolResult →
+  `response_item` `function_call_output` `{call_id, output}`.
+- No `event_msg` lines for tool activity (vibeshub-proven optional; codex's
+  own history replay uses only `response_item`).
+- **Bug-fix rider**: `create_shadow_transcript` gains
+  `"model_provider": "openai"` in `session_meta`. Without it, interactive
+  `codex resume` of a tandem-minted shadow fails on ≥0.145 with
+  ``Model provider `` not found`` (-32600); tandem's M1 validation used
+  `codex exec resume`, which tolerates the omission. (Codex caches
+  `model_provider` per thread in `~/.codex/state_5.sqlite`; fresh tandem ids
+  have no row, so the file value governs.)
+
+## Claude rendering (`harness/claude_code.py`)
+
+- ToolCall → `assistant` entry, one `tool_use` block, `stop_reason:
+  "tool_use"`. ToolResult → `user` entry with a `tool_result` block
+  (`is_error` when a codex exit-code header parses non-zero) plus a
+  `toolUseResult` sibling `{stdout, exitCode?}` — reuse the existing
+  `_codex_exec_output` header parser.
+- **`message.id` runs**: consecutive rendered `assistant` entries share one
+  `message.id` (new `ctx.claude_run_msg_id`, reset whenever a non-assistant
+  entry is rendered). Real transcripts share one id across all blocks of an
+  API response; per-entry ids would let a reader regroup blocks and strand a
+  `tool_use` away from its `tool_result` (vibeshub's `assistant_msg`
+  rationale, kept here).
+
+## `SessionContext` changes
+
+- `pending_calls` values shrink to `{"tool": name}`. The
+  `patch_apply_end`/`_structured` enrichment is dropped — outputs now ride
+  verbatim, so nothing downstream consumes it. Cursor migration: values are
+  read via `.get("tool")`, so full ToolCall dumps persisted by older cursors
+  load fine.
+- New field `claude_run_msg_id: str | None`.
+
+## `summarize.py` shrinks
+
+Retire `summarize_pair` and both per-harness summarizer families. Keep
+`summarize_orphan_result` and `_codex_exec_output` (used by the Claude
+renderer for `toolUseResult`/`is_error`). Module docstring updated to the
+orphan-only role.
+
+## Error handling
+
+Quarantine pipeline unchanged (raw entry quarantined, one placeholder per
+turn, sync continues) with the dangle-closing addition above.
+
+## Testing
+
+- Unit: argument-shape mapping both ways; verbatim pass-through incl.
+  `call_id` preservation; `custom_tool_call` → `{"input": …}`.
+- Pairing: drain flush closes pending calls with placeholder outputs;
+  orphan result renders as prose; result-translation failure closes its
+  call.
+- `message.id` runs: back-to-back tool calls share an id; a user entry
+  resets it.
+- Golden: regenerate converter goldens from `tests/golden/*-probe.jsonl`.
+- Live check (doctor-style, manual): after a synced session with tool
+  activity, resume both shadows — interactive `codex resume` (exercises the
+  `model_provider` fix) and `claude --resume`.
+
+## Out of scope (deliberate)
+
+Attribution notes for tool activity; output-clipping knobs; semantic
+mapping of `apply_patch` onto Claude's `Edit`/`Write`; `event_msg` fidelity
+for how foreign items display in the codex TUI transcript view.

--- a/docs/specs/2026-07-29-native-tool-call-translation-design.md
+++ b/docs/specs/2026-07-29-native-tool-call-translation-design.md
@@ -1,8 +1,10 @@
 # Native tool-call translation — design
 
 2026-07-29. Replaces the summarize-to-prose policy for tool activity in the
-sync engine. Approved direction: native in **both** directions, no
-attribution tags on tool activity, no output clipping (both revisitable).
+sync engine. Approved direction: native in **both** directions, with a
+semantic mapping layer that re-expresses common tools in the shadow's own
+vocabulary; no attribution tags on tool activity, no output clipping (both
+revisitable).
 
 ## Why
 
@@ -41,13 +43,18 @@ the work.
 keep their current handling (text tagged with attribution, thinking dropped,
 compaction noted, system skipped).
 
-- **ToolCall**: emit natively (no longer stash-only). Also record
-  `ctx.pending_calls[call_id] = {"tool": name}` — needed for orphan
-  detection, `is_error` derivation, and the flush rule below.
-- **ToolResult**: if its call is pending, pop it and emit natively. If the
-  call was never seen (orphan — e.g. cursor started mid-turn), keep the
-  existing prose fallback (`summarize_orphan_result`): a bare `tool_result`
-  with no preceding `tool_use` would itself break Claude resume.
+- **ToolCall**: stash in `ctx.pending_calls[call_id]` (unchanged from
+  today — full serialized call).
+- **ToolResult**: pop the pending call and emit the mapped **call + result
+  as an adjacent native pair** via `toolmap.py`. Pair-at-result emission
+  keeps the converter's existing flow, and it means the mapper sees the
+  result when rendering the call (needed for Write's `create` vs `update`,
+  and lets the Edit→`apply_patch` patch use the result's `structuredPatch`
+  context when present). Both replay APIs accept adjacent call/output
+  pairs; claude writes them adjacently itself. If the call was never seen
+  (orphan — e.g. cursor started mid-turn), keep the existing prose
+  fallback (`summarize_orphan_result`): a bare `tool_result` with no
+  preceding `tool_use` would itself break Claude resume.
 - **Attribution**: tool calls and results carry no `[claude]`/`[codex]`
   tag. Text messages keep their tags unchanged.
 - **No clipping**: outputs are carried verbatim. Revisit with a cap knob if
@@ -55,27 +62,67 @@ compaction noted, system skipped).
 
 ### Pairing invariant (dangle flush)
 
-Both replay APIs reject a call without a result. New invariant: **whenever
-tandem drains a source** (role switch, one-off routing, doctor repair), every
-entry left in `ctx.pending_calls` is closed by appending a native result
-with output `(tool result not recorded)` (same wording as vibeshub) to the
-shadow, then `pending_calls` is cleared. Similarly, when a ToolResult entry
-fails translation, its quarantine placeholder is accompanied by a native
-placeholder output for that `call_id`, so the shadow never holds a dangling
-call across a translation failure.
+Both replay APIs reject a call without a result. With pair-at-result
+emission a call is never in the shadow without its result under normal
+flow; the invariant covers the interrupted cases: **whenever tandem drains
+a source** (role switch, one-off routing, doctor repair), every entry left
+in `ctx.pending_calls` is emitted as its mapped call plus a placeholder
+result with output `(tool result not recorded)` (same wording as
+vibeshub), then `pending_calls` is cleared. Likewise, when a ToolResult
+entry fails translation, the pair is emitted as the mapped call plus that
+placeholder output alongside the quarantine placeholder, so the shadow
+never holds a dangling call.
 
-## Tool-name mapping
+## Tool mapping layer (`toolmap.py`)
 
-Verbatim pass-through is the default in both directions (spike-verified on
-both sides); only the shell tools get an argument-shape mapping.
+Two tiers, decided per call by a new policy module `toolmap.py` (the
+adapters stay dumb — they render whatever name/arguments the policy hands
+them):
 
-| direction | source | target |
-| --- | --- | --- |
-| claude→codex | `Bash {command}` | `function_call exec_command {"cmd": …}` |
-| claude→codex | any other tool | `function_call`, name verbatim, `arguments` = JSON-stringified input |
-| codex→claude | `exec_command {cmd}` | `tool_use Bash {"command": …}` |
-| codex→claude | `custom_tool_call` (`apply_patch`) | `tool_use`, name verbatim, `input {"input": <patch text>}` |
-| codex→claude | any other `function_call` | `tool_use`, name/args verbatim |
+- **Tier 1 — semantic map**: re-express the call in the shadow's own tool
+  vocabulary, so the history reads as work the shadow did with its own
+  tools rather than a foreign dialect.
+- **Tier 2 — verbatim pass-through**: name and arguments carried unchanged
+  (spike-verified safe on both sides). This is the fallback whenever a
+  Tier-1 rule doesn't apply cleanly.
+
+**Honesty rule**: a Tier-1 mapping is only allowed when the target-native
+rendering is a truthful description of what actually happened — arguments
+derivable from the source call's own arguments, result content carried
+verbatim. When a call instance doesn't fit (odd arguments, multi-file
+patch, ranged read we can't express honestly), that instance falls back to
+Tier 2. Mapping never fails an entry.
+
+### Tier 1: claude→codex
+
+| Claude call | Codex rendering |
+| --- | --- |
+| `Bash {command}` | `function_call exec_command {"cmd": …}`; output verbatim (no fake codex exit-code header) |
+| `Read {file_path}` (no offset/limit) | `function_call exec_command {"cmd": "cat -n '<path>'"}` — Claude's Read output is already `cat -n`-shaped, so output rides verbatim |
+| `Read` with offset/limit | equivalent `sed -n '<start>,<end>p'` pipe form; exact template an implementation choice — if it can't be expressed honestly, Tier 2 |
+| `Write {file_path, content}` (result type `create`) | `custom_tool_call apply_patch`: `*** Begin Patch / *** Add File: <path> / +<content> / *** End Patch`; overwrites (result type `update`) → Tier 2 |
+| `Edit {file_path, old_string, new_string}` | `custom_tool_call apply_patch`: `*** Update File: <path>` with `-`old / `+`new lines (V4A matches on context, so the strings map directly) |
+| `Grep {pattern, …}` / `Glob {pattern}` | `function_call exec_command` with the equivalent `rg -n …` / `rg --files -g …` command |
+| `TodoWrite {todos}` | `function_call update_plan {plan: [{step, status}]}` — the status vocabularies (`pending/in_progress/completed`) already coincide |
+
+### Tier 1: codex→claude
+
+| Codex call | Claude rendering |
+| --- | --- |
+| `exec_command {cmd}` | `tool_use Bash {"command": …}`; exit-code header stripped into `toolUseResult {stdout, exitCode}`, `is_error` when non-zero |
+| `apply_patch`, single `Add File` | `tool_use Write {file_path, content}`; `toolUseResult {type: "create", filePath, content}` |
+| `apply_patch`, single `Update File` | `tool_use Edit {file_path, old_string, new_string}` — old = context+deleted lines, new = context+added lines, reconstructed from the hunk; `patch_apply_end` enrichment (success/changes), when seen, feeds `toolUseResult` |
+| `apply_patch`, anything else (multi-file, `Delete File`, malformed) | Tier 2: `tool_use apply_patch {"input": <patch text>}` |
+| `update_plan {plan}` | `tool_use TodoWrite {todos: [{content, status}]}`; result content verbatim |
+
+### Tier 2 residue (measured, fine to leave verbatim)
+
+Claude side: `Agent`/`Task`, `TaskCreate`/`TaskUpdate`, `AskUserQuestion`,
+`SendMessage`, `Skill`, `ToolSearch`, `WebFetch`… Codex side: `js`,
+`write_stdin`, `spawn_agent`/`wait_agent`/`close_agent`, `view_image`….
+On the traces on this machine, Tier 1 covers ~87% of Claude-side call
+volume (Bash+Edit+Write+Read of 152 calls in the M1–M5 session) and ~97%
+of codex-side (exec_command+apply_patch+update_plan of ~930 calls).
 
 ## Codex rendering (`harness/codex.py`)
 
@@ -95,10 +142,12 @@ both sides); only the shell tools get an argument-shape mapping.
 ## Claude rendering (`harness/claude_code.py`)
 
 - ToolCall → `assistant` entry, one `tool_use` block, `stop_reason:
-  "tool_use"`. ToolResult → `user` entry with a `tool_result` block
-  (`is_error` when a codex exit-code header parses non-zero) plus a
-  `toolUseResult` sibling `{stdout, exitCode?}` — reuse the existing
-  `_codex_exec_output` header parser.
+  "tool_use"`. ToolResult → `user` entry with a `tool_result` block plus a
+  `toolUseResult` sibling. Both `is_error` and the `toolUseResult` shape
+  come from the mapper: `{stdout, exitCode?}` for exec_command (via the
+  existing `_codex_exec_output` header parser, `is_error` on non-zero),
+  `{type: "create", filePath, content}`-style for the patch mappings,
+  `{stdout}` for Tier-2 pass-through.
 - **`message.id` runs**: consecutive rendered `assistant` entries share one
   `message.id` (new `ctx.claude_run_msg_id`, reset whenever a non-assistant
   entry is rendered). Real transcripts share one id across all blocks of an
@@ -108,11 +157,10 @@ both sides); only the shell tools get an argument-shape mapping.
 
 ## `SessionContext` changes
 
-- `pending_calls` values shrink to `{"tool": name}`. The
-  `patch_apply_end`/`_structured` enrichment is dropped — outputs now ride
-  verbatim, so nothing downstream consumes it. Cursor migration: values are
-  read via `.get("tool")`, so full ToolCall dumps persisted by older cursors
-  load fine.
+- `pending_calls` keeps its current shape (serialized ToolCall per
+  `call_id`), including the `patch_apply_end`/`_structured` enrichment —
+  the `apply_patch → Edit/Write` mapping consumes it for `toolUseResult`.
+  No cursor migration needed.
 - New field `claude_run_msg_id: str | None`.
 
 ## `summarize.py` shrinks
@@ -129,8 +177,11 @@ turn, sync continues) with the dangle-closing addition above.
 
 ## Testing
 
-- Unit: argument-shape mapping both ways; verbatim pass-through incl.
-  `call_id` preservation; `custom_tool_call` → `{"input": …}`.
+- Unit: Tier-1 mappings both ways (Bash↔exec_command; Edit/Write↔
+  apply_patch incl. old/new-string ↔ hunk reconstruction round-trips;
+  Read→cat -n; TodoWrite↔update_plan status vocab); honesty-rule fallbacks
+  (overwrite Write, multi-file patch → Tier 2); verbatim pass-through incl.
+  `call_id` preservation.
 - Pairing: drain flush closes pending calls with placeholder outputs;
   orphan result renders as prose; result-translation failure closes its
   call.
@@ -143,6 +194,7 @@ turn, sync continues) with the dangle-closing addition above.
 
 ## Out of scope (deliberate)
 
-Attribution notes for tool activity; output-clipping knobs; semantic
-mapping of `apply_patch` onto Claude's `Edit`/`Write`; `event_msg` fidelity
-for how foreign items display in the codex TUI transcript view.
+Attribution notes for tool activity; output-clipping knobs; Tier-1
+mappings beyond the table above (e.g. `js`, `write_stdin`, subagent
+tools); `event_msg` fidelity for how foreign items display in the codex
+TUI transcript view.

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -18,8 +18,21 @@ def _cwd() -> str:
     return str(Path.cwd())
 
 
+# Set by the tandem prompt (shell.py) around each dispatched command so it
+# acts on that shell's own session. Without it, a second `tandem` in the same
+# directory becomes the cwd-MRU and silently steals `status`/`sync`/`run --on`
+# typed in the first shell.
+_SESSION_ID: str | None = None
+
+
+def _resolve_session(store: StateStore) -> PairedSession | None:
+    if _SESSION_ID is not None:
+        return store.get_session(_SESSION_ID)
+    return store.latest_session_for_cwd(_cwd())
+
+
 def _require_session(store: StateStore) -> PairedSession:
-    session = store.latest_session_for_cwd(_cwd())
+    session = _resolve_session(store)
     if session is None:
         click.echo(
             "No tandem session for this directory. Run `tandem` to start one.",
@@ -206,6 +219,29 @@ def _default_sink_factory(store, session, source):
     return SyncEngine(store, session, source)
 
 
+def _report_switch(old: str, new_active: str, problems, mem) -> None:
+    """Report the outcome of a role flip. Shared by the one-shot `switch`
+    command and the tandem prompt's `switch`, so neither path drops
+    memory-sync actions or the may-not-resume advisory."""
+    click.echo(
+        f"active harness: {get_adapter(old).display_name} -> "
+        f"{get_adapter(new_active).display_name}"
+    )
+    for a in mem.actions:
+        click.echo(f"  memory: {a}")
+    for w in mem.warnings:
+        click.secho(f"  memory: {w}", fg="yellow", err=True)
+    for p in problems:
+        click.secho(f"  warning: {p}", fg="yellow", err=True)
+    if problems:
+        click.secho(
+            "  the newly active session may not resume cleanly; "
+            "run `tandem doctor` for details.",
+            fg="yellow",
+            err=True,
+        )
+
+
 @main.command()
 def switch() -> None:
     """Make the shadow harness active (instant; no re-conversion)."""
@@ -219,23 +255,7 @@ def switch() -> None:
         except Exception as exc:
             click.secho(f"switch failed: {exc}", fg="red", err=True)
             sys.exit(1)
-        click.echo(
-            f"active harness: {get_adapter(old).display_name} -> "
-            f"{get_adapter(new_active).display_name}"
-        )
-        for a in mem.actions:
-            click.echo(f"  memory: {a}")
-        for w in mem.warnings:
-            click.secho(f"  memory: {w}", fg="yellow", err=True)
-        for p in problems:
-            click.secho(f"  warning: {p}", fg="yellow", err=True)
-        if problems:
-            click.secho(
-                "  the newly active session may not resume cleanly; "
-                "run `tandem doctor` for details.",
-                fg="yellow",
-                err=True,
-            )
+        _report_switch(old, new_active, problems, mem)
         click.echo("Run `tandem resume` to continue in the new harness.")
 
 
@@ -280,7 +300,7 @@ def doctor(live: bool) -> None:
     from .doctor import run_doctor
 
     with StateStore() as store:
-        session = store.latest_session_for_cwd(_cwd())
+        session = _resolve_session(store)
         report = run_doctor(store, session, live=live)
     icons = {"ok": ("✓", "green"), "warn": ("!", "yellow"), "fail": ("✗", "red")}
     for check in report.checks:

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -158,6 +158,41 @@ def status() -> None:
             click.echo(f"  quarantine: {qdir} (has entries)")
 
 
+@main.command()
+@click.argument("tandem_id", required=False)
+def resume(tandem_id: str | None) -> None:
+    """Resume a paired session (most recent for this directory by default).
+
+    The id is printed when you leave a session, and shown by `tandem status`.
+    """
+    cwd = _cwd()
+    _check_versions(warn_only=True)
+    with StateStore() as store:
+        if tandem_id is None:
+            session = store.latest_session_for_cwd(cwd)
+            if session is None:
+                click.echo(
+                    "No tandem session for this directory. Run `tandem` to start one.",
+                    err=True,
+                )
+                sys.exit(1)
+        else:
+            session = store.get_session(tandem_id)
+            if session is None:
+                click.secho(f"error: no tandem session {tandem_id!r}.", fg="red", err=True)
+                sys.exit(1)
+            if session.cwd != cwd:
+                click.secho(
+                    f"error: session {tandem_id} belongs to {session.cwd}; "
+                    "run `tandem resume` from there.",
+                    fg="red",
+                    err=True,
+                )
+                sys.exit(1)
+        store.touch_used(session.tandem_id)
+    sys.exit(_enter_session(session))
+
+
 def _default_sink_factory(store, session, source):
     """Sync engine by default; TANDEM_LOG_EVENTS=1 switches to the debug
     event logger (no shadow writes)."""

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -236,7 +236,7 @@ def switch() -> None:
                 fg="yellow",
                 err=True,
             )
-        click.echo("Run `tandem` to continue in the new harness.")
+        click.echo("Run `tandem resume` to continue in the new harness.")
 
 
 @main.command(name="run")

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -21,8 +21,12 @@ def _cwd() -> str:
 def _require_session(store: StateStore) -> PairedSession:
     session = store.latest_session_for_cwd(_cwd())
     if session is None:
-        click.echo("No tandem session for this directory. Run `tandem start` first.", err=True)
+        click.echo(
+            "No tandem session for this directory. Run `tandem` to start one.",
+            err=True,
+        )
         sys.exit(1)
+    store.touch_used(session.tandem_id)
     return session
 
 
@@ -53,93 +57,69 @@ def _check_versions(warn_only: bool = False) -> dict[str, str | None]:
 
 @click.group(invoke_without_command=True)
 @click.version_option(package_name="tandem")
-@click.pass_context
-def main(ctx: click.Context) -> None:
-    """Work in Claude Code or Codex and switch at any time.
-
-    Run with no arguments to enter the active harness interactively.
-    """
-    if ctx.invoked_subcommand is None:
-        _interactive()
-
-
-@main.command()
 @click.option(
     "--active",
     type=click.Choice(["claude", "codex"]),
-    default=None,
-    help="Initially active harness (prompted if omitted).",
+    default="claude",
+    show_default=True,
+    help="Initially active harness for the fresh session.",
 )
-def start(active: str | None) -> None:
-    """Initialize a paired session for the current directory."""
-    cwd = _cwd()
-    _check_versions()
-    with StateStore() as store:
-        existing = store.latest_session_for_cwd(cwd)
-        if existing is not None:
-            click.echo(
-                f"A tandem session already exists here ({existing.tandem_id}, "
-                f"active: {existing.active})."
-            )
-            if not click.confirm("Archive it and start a new one?", default=False):
-                sys.exit(1)
-            store.archive_session(existing.tandem_id)
+@click.pass_context
+def main(ctx: click.Context, active: str) -> None:
+    """Run Claude Code and Codex as one paired session.
 
-        if active is None:
-            active = click.prompt(
-                "Initially active harness",
-                type=click.Choice(["claude", "codex"]),
-                default="claude",
-            )
-        shadow = other(active)
+    With no subcommand, pairs a fresh session and enters the active
+    harness; `tandem resume` continues an earlier one.
+    """
+    if ctx.invoked_subcommand is None:
+        _interactive(active)
 
-        claude_sid = get_adapter("claude").mint_session_id()
-        codex_sid = None if active == "codex" else get_adapter("codex").mint_session_id()
 
-        session = store.create_session(cwd, active, claude_sid, codex_sid)
+def _pair_session(store: StateStore, cwd: str, active: str) -> PairedSession:
+    """Create a fresh paired session: state row, seeded shadow transcript,
+    write-ahead cursor, memory sync. Echoes what it did."""
+    shadow = other(active)
+    claude_sid = get_adapter("claude").mint_session_id()
+    codex_sid = None if active == "codex" else get_adapter("codex").mint_session_id()
+    session = store.create_session(cwd, active, claude_sid, codex_sid)
 
-        ctx = SessionContext(
-            tandem_id=session.tandem_id,
-            cwd=cwd,
-            direction="claude->codex" if active == "claude" else "codex->claude",
-            claude_session_id=claude_sid,
-            codex_session_id=codex_sid,
-        )
-        note = SEED_NOTE.format(
-            tandem_id=session.tandem_id,
-            other=get_adapter(active).display_name,
-        )
-        # The shadow transcript is created now so it is resume-ready from the
-        # first turn. The active side's file is created by the harness itself
-        # at first launch (claude is pinned via --session-id; codex mints its
-        # own id which tandem captures on first run).
-        shadow_adapter = get_adapter(shadow)
-        if shadow == "claude":
-            shadow_path = shadow_adapter.create_shadow_transcript(cwd, claude_sid, ctx, note)
-            cursor_updates = {"claude_leaf_uuid": ctx.claude_leaf_uuid}
-        else:
-            shadow_path = shadow_adapter.create_shadow_transcript(cwd, codex_sid, ctx, note)
-            cursor_updates = {}
-        cursor = store.get_cursor(session.tandem_id, active)
-        cursor.pending.update(cursor_updates)
-        store.save_cursor(cursor)
+    ctx = SessionContext(
+        tandem_id=session.tandem_id,
+        cwd=cwd,
+        direction="claude->codex" if active == "claude" else "codex->claude",
+        claude_session_id=claude_sid,
+        codex_session_id=codex_sid,
+    )
+    note = SEED_NOTE.format(
+        tandem_id=session.tandem_id,
+        other=get_adapter(active).display_name,
+    )
+    # The shadow transcript is created now so it is resume-ready from the
+    # first turn. The active side's file is created by the harness itself
+    # at first launch (claude is pinned via --session-id; codex mints its
+    # own id which tandem captures on first run).
+    shadow_adapter = get_adapter(shadow)
+    if shadow == "claude":
+        shadow_adapter.create_shadow_transcript(cwd, claude_sid, ctx, note)
+        cursor_updates = {"claude_leaf_uuid": ctx.claude_leaf_uuid}
+    else:
+        shadow_adapter.create_shadow_transcript(cwd, codex_sid, ctx, note)
+        cursor_updates = {}
+    cursor = store.get_cursor(session.tandem_id, active)
+    cursor.pending.update(cursor_updates)
+    store.save_cursor(cursor)
 
-        from .memory_sync import sync_memory_files
+    from .memory_sync import sync_memory_files
 
-        mem = sync_memory_files(cwd)
-        for a in mem.actions:
-            click.echo(f"  memory: {a}")
-        for w in mem.warnings:
-            click.secho(f"  memory: {w}", fg="yellow", err=True)
-
-        click.echo(f"Paired session {session.tandem_id} created in {cwd}")
-        click.echo(f"  active:  {get_adapter(active).display_name}")
-        click.echo(f"  shadow:  {shadow_adapter.display_name} -> {shadow_path}")
-        if active == "codex":
-            click.echo(
-                "  note: codex session id will be captured on first `tandem` run"
-            )
-        click.echo("Run `tandem` to begin.")
+    mem = sync_memory_files(cwd)
+    click.echo(f"paired {session.tandem_id} ({active} active, {shadow} shadow)")
+    for a in mem.actions:
+        click.echo(f"  memory: {a}")
+    for w in mem.warnings:
+        click.secho(f"  memory: {w}", fg="yellow", err=True)
+    if active == "codex":
+        click.echo("  note: codex session id will be captured on first run")
+    return session
 
 
 @main.command()
@@ -305,14 +285,19 @@ def sync() -> None:
         click.echo(f"synced {n} new transcript lines from {session.active}.")
 
 
-def _interactive() -> None:
+def _interactive(active: str) -> None:
+    cwd = _cwd()
+    _check_versions()  # hard: pairing needs both binaries on PATH
+    with StateStore() as store:
+        session = _pair_session(store, cwd, active)
+    sys.exit(_enter_session(session))
+
+
+def _enter_session(session: PairedSession) -> int:
     from .runner import InteractiveRunner
 
-    with StateStore() as store:
-        session = _require_session(store)
-    _check_versions(warn_only=True)
     runner = InteractiveRunner(session, sink_factory=_default_sink_factory)
-    sys.exit(runner.run())
+    return runner.run()
 
 
 if __name__ == "__main__":

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -329,10 +329,9 @@ def _interactive(active: str) -> None:
 
 
 def _enter_session(session: PairedSession) -> int:
-    from .runner import InteractiveRunner
+    from .shell import run_shell
 
-    runner = InteractiveRunner(session, sink_factory=_default_sink_factory)
-    return runner.run()
+    return run_shell(session.tandem_id, _default_sink_factory)
 
 
 if __name__ == "__main__":

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -19,7 +19,7 @@ def _cwd() -> str:
 
 
 def _require_session(store: StateStore) -> PairedSession:
-    session = store.session_for_cwd(_cwd())
+    session = store.latest_session_for_cwd(_cwd())
     if session is None:
         click.echo("No tandem session for this directory. Run `tandem start` first.", err=True)
         sys.exit(1)
@@ -75,7 +75,7 @@ def start(active: str | None) -> None:
     cwd = _cwd()
     _check_versions()
     with StateStore() as store:
-        existing = store.session_for_cwd(cwd)
+        existing = store.latest_session_for_cwd(cwd)
         if existing is not None:
             click.echo(
                 f"A tandem session already exists here ({existing.tandem_id}, "
@@ -265,7 +265,7 @@ def doctor(live: bool) -> None:
     from .doctor import run_doctor
 
     with StateStore() as store:
-        session = store.session_for_cwd(_cwd())
+        session = store.latest_session_for_cwd(_cwd())
         report = run_doctor(store, session, live=live)
     icons = {"ok": ("✓", "green"), "warn": ("!", "yellow"), "fail": ("✗", "red")}
     for check in report.checks:

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -163,7 +163,7 @@ def run_doctor(store, session, live: bool = False) -> DoctorReport:
             report.ok(f"{adapter.display_name}: {v}")
 
     if session is None:
-        report.fail("no tandem session for this directory (run `tandem start`)")
+        report.fail("no tandem session for this directory (run `tandem` to start one)")
         return report
 
     report.ok(

--- a/src/tandem/shell.py
+++ b/src/tandem/shell.py
@@ -35,87 +35,161 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
 
             return InteractiveRunner(session, sink_factory=sink_factory).run()
 
-    code = _enter(tandem_id, run_harness)
-    while True:
+    # The resume hint is the only place the id is shown, so it prints from a
+    # finally: no failure inside the loop may cost the user their session.
+    code = 1
+    try:
+        code = _enter(tandem_id, run_harness, code)
+        while True:
+            with StateStore() as store:
+                session = store.get_session(tandem_id)
+            if session is None:
+                click.secho(
+                    f"session {tandem_id} is no longer in the state store.",
+                    fg="red",
+                    err=True,
+                )
+                break
+            try:
+                line = input_fn(f"tandem ({session.active})> ").strip()
+            except EOFError:
+                break
+            except KeyboardInterrupt:
+                click.echo()
+                continue
+            if line in ("exit", "quit"):
+                break
+            if line in ("", "resume"):
+                code = _enter(tandem_id, run_harness, code)
+                continue
+            if line.split(maxsplit=1)[0] == "run":
+                parsed = _split_run_line(line)
+                if parsed is not None:
+                    target, prompt = parsed
+                    # `--` keeps a prompt that starts with `-` an argument
+                    _dispatch(["run", "--on", target, "--", prompt], tandem_id)
+                    continue
+                # Malformed: fall through and let click report the usage error.
+            try:
+                argv = shlex.split(line)
+            except ValueError as exc:  # e.g. an unbalanced quote
+                click.secho(f"could not parse: {exc}", fg="yellow")
+                continue
+            if argv[0].startswith("-") and argv[0] not in ("--help", "--version"):
+                # Options with no subcommand would hit the group's
+                # invoke_without_command path: a fresh pairing plus a shell
+                # nested inside this one. Launching is an OS-shell concern.
+                click.secho(
+                    f"{argv[0]} is a `tandem` launch option, not a prompt command"
+                    " — `exit` first, then re-run tandem.",
+                    fg="yellow",
+                )
+                click.echo(HELP)
+                continue
+            if argv[0] == "resume":
+                click.secho(
+                    "resume takes no id at this prompt — `exit` first, then"
+                    " `tandem resume <id>`.",
+                    fg="yellow",
+                )
+                continue
+            if argv == ["switch"]:
+                code = _switch(tandem_id, run_harness, code)
+                continue
+            _dispatch(argv, tandem_id)
+    finally:
+        # Hint first: state bookkeeping must not be able to swallow it.
+        click.echo(f"to continue this session: tandem resume {tandem_id}")
         with StateStore() as store:
-            active = store.get_session(tandem_id).active
-        try:
-            line = input_fn(f"tandem ({active})> ").strip()
-        except EOFError:
-            break
-        except KeyboardInterrupt:
-            click.echo()
-            continue
-        if line in ("exit", "quit"):
-            break
-        if line in ("", "resume"):
-            code = _enter(tandem_id, run_harness)
-            continue
-        try:
-            argv = shlex.split(line)
-        except ValueError as exc:  # e.g. an unbalanced quote
-            click.secho(f"could not parse: {exc}", fg="yellow")
-            continue
-        if argv[0].startswith("-") and argv[0] not in ("--help", "--version"):
-            # Options with no subcommand would hit the group's
-            # invoke_without_command path: a fresh pairing plus a shell
-            # nested inside this one. Launching is an OS-shell concern.
-            click.secho(
-                f"{argv[0]} is a `tandem` launch option, not a prompt command"
-                " — `exit` first, then re-run tandem.",
-                fg="yellow",
-            )
-            click.echo(HELP)
-            continue
-        if argv[0] == "resume":
-            click.secho(
-                "resume takes no id at this prompt — `exit` first, then"
-                " `tandem resume <id>`.",
-                fg="yellow",
-            )
-            continue
-        if argv == ["switch"]:
-            code = _switch(tandem_id, run_harness, code)
-            continue
-        _dispatch(argv)
-
-    with StateStore() as store:
-        store.touch_used(tandem_id)
-    click.echo(f"to continue this session: tandem resume {tandem_id}")
+            store.touch_used(tandem_id)
     return code
+
+
+def _split_run_line(line: str) -> tuple[str, str] | None:
+    """Peel `--on <harness>` off a `run` line typed at the prompt and return
+    (harness, prompt). None means the line does not have that shape — dispatch
+    it normally so click reports the usage error.
+
+    The prompt is taken verbatim from the raw line instead of being
+    shlex-split, so an apostrophe ("what's wrong") is literal text rather
+    than an unbalanced quote. A prompt wrapped in matching quotes keeps its
+    one-shot meaning: the outer quotes are stripped.
+    """
+    rest = line[len("run") :].strip()
+    for prefix in ("--on=", "--on "):
+        if rest.startswith(prefix):
+            target, _, prompt = rest[len(prefix) :].strip().partition(" ")
+            break
+    else:
+        return None
+    target, prompt = target.strip(), prompt.strip()
+    if not target or not prompt:
+        return None
+    if len(prompt) > 1 and prompt[0] == prompt[-1] and prompt[0] in "\"'":
+        inner = prompt[1:-1]
+        if prompt[0] not in inner:
+            prompt = inner
+    return target, prompt
 
 
 def _switch(tandem_id: str, run_harness, code: int) -> int:
     """Flip roles and re-enter the newly active harness. Returns the exit
     code to carry forward (unchanged if the flip failed)."""
+    from .cli import _report_switch
+
     with StateStore() as store:
         session = store.get_session(tandem_id)
+        if session is None:
+            click.secho(
+                f"switch failed: session {tandem_id} is no longer in the"
+                " state store.",
+                fg="red",
+                err=True,
+            )
+            return code
         old = session.active
         try:
             new_active, problems, mem = ops.switch_session(store, session)
         except Exception as exc:
-            click.secho(f"switch failed: {exc}", fg="red", err=True)
+            click.secho(
+                f"switch failed: {type(exc).__name__}: {exc}", fg="red", err=True
+            )
             return code
-    click.echo(f"active harness: {old} -> {new_active}")
-    for w in list(mem.warnings) + list(problems):
-        click.secho(f"  warning: {w}", fg="yellow", err=True)
-    return _enter(tandem_id, run_harness)
+    _report_switch(old, new_active, problems, mem)
+    return _enter(tandem_id, run_harness, code)
 
 
-def _enter(tandem_id: str, run_harness) -> int:
-    with StateStore() as store:
-        session = store.get_session(tandem_id)
-        store.touch_used(tandem_id)
-    return run_harness(session)
+def _enter(tandem_id: str, run_harness, code: int) -> int:
+    """Run the active harness and return its exit code. A failed launch (or a
+    session row that vanished) is reported and `code` is carried forward, so
+    the caller returns to the prompt instead of losing the session."""
+    try:
+        with StateStore() as store:
+            session = store.get_session(tandem_id)
+            if session is None:
+                raise LookupError(f"session {tandem_id} is not in the state store")
+            store.touch_used(tandem_id)
+        return run_harness(session)
+    except Exception as exc:
+        click.secho(
+            f"could not run the harness: {type(exc).__name__}: {exc}",
+            fg="red",
+            err=True,
+        )
+        return code
 
 
-def _dispatch(argv: list[str]) -> None:
+def _dispatch(argv: list[str], tandem_id: str) -> None:
     # Late import: cli imports shell (via _enter_session), so importing cli
     # at module level would be circular.
-    from .cli import main as cli_group
+    from . import cli
 
+    previous = cli._SESSION_ID
+    # Commands typed here act on THIS session, not on whatever is the
+    # most-recently-used session for the cwd.
+    cli._SESSION_ID = tandem_id
     try:
-        cli_group.main(args=argv, prog_name="tandem", standalone_mode=False)
+        cli.main.main(args=argv, prog_name="tandem", standalone_mode=False)
     except click.exceptions.UsageError as exc:
         exc.show()
         click.echo(HELP)
@@ -127,4 +201,7 @@ def _dispatch(argv: list[str]) -> None:
         pass  # one-shot commands sys.exit(); the prompt continues
     except Exception as exc:
         # A failing command must never take the live session down with it.
-        click.secho(f"command failed: {exc}", fg="red", err=True)
+        # The type name matters: str(KeyError()) and friends are empty.
+        click.secho(f"command failed: {type(exc).__name__}: {exc}", fg="red", err=True)
+    finally:
+        cli._SESSION_ID = previous

--- a/src/tandem/shell.py
+++ b/src/tandem/shell.py
@@ -1,0 +1,116 @@
+"""Persistent tandem prompt between harness sessions.
+
+Bare `tandem` / `tandem resume` enter here: run the active harness on its
+PTY; when the user exits it, offer a prompt instead of returning to the OS
+shell. `switch` flips roles and re-enters immediately; other lines are
+dispatched through the click group so one-shot and prompt behavior never
+drift apart.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+import click
+
+from . import ops
+from .state import StateStore
+
+HELP = (
+    "commands: switch | resume (or Enter) | status | sync | doctor |"
+    " run --on <harness> <prompt> | sync-mcp | exit"
+)
+
+
+def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> int:
+    """Loop: harness session -> prompt -> harness session. Returns the last
+    harness exit code. `input_fn`/`run_harness` are injection points for
+    tests (real: `input` and an InteractiveRunner)."""
+    if input_fn is None:  # pragma: no cover - interactive default
+        input_fn = input
+    if run_harness is None:  # pragma: no cover - interactive default
+
+        def run_harness(session):
+            from .runner import InteractiveRunner
+
+            return InteractiveRunner(session, sink_factory=sink_factory).run()
+
+    code = _enter(tandem_id, run_harness)
+    while True:
+        with StateStore() as store:
+            active = store.get_session(tandem_id).active
+        try:
+            line = input_fn(f"tandem ({active})> ").strip()
+        except EOFError:
+            break
+        except KeyboardInterrupt:
+            click.echo()
+            continue
+        if line in ("exit", "quit"):
+            break
+        if line in ("", "resume"):
+            code = _enter(tandem_id, run_harness)
+            continue
+        try:
+            argv = shlex.split(line)
+        except ValueError as exc:  # e.g. an unbalanced quote
+            click.secho(f"could not parse: {exc}", fg="yellow")
+            continue
+        if argv[0] == "resume":
+            click.secho(
+                "resume takes no id at this prompt — `exit` first, then"
+                " `tandem resume <id>`.",
+                fg="yellow",
+            )
+            continue
+        if argv == ["switch"]:
+            code = _switch(tandem_id, run_harness, code)
+            continue
+        _dispatch(argv)
+
+    with StateStore() as store:
+        store.touch_used(tandem_id)
+    click.echo(f"to continue this session: tandem resume {tandem_id}")
+    return code
+
+
+def _switch(tandem_id: str, run_harness, code: int) -> int:
+    """Flip roles and re-enter the newly active harness. Returns the exit
+    code to carry forward (unchanged if the flip failed)."""
+    with StateStore() as store:
+        session = store.get_session(tandem_id)
+        old = session.active
+        try:
+            new_active, problems, mem = ops.switch_session(store, session)
+        except Exception as exc:
+            click.secho(f"switch failed: {exc}", fg="red", err=True)
+            return code
+    click.echo(f"active harness: {old} -> {new_active}")
+    for w in list(mem.warnings) + list(problems):
+        click.secho(f"  warning: {w}", fg="yellow", err=True)
+    return _enter(tandem_id, run_harness)
+
+
+def _enter(tandem_id: str, run_harness) -> int:
+    with StateStore() as store:
+        session = store.get_session(tandem_id)
+        store.touch_used(tandem_id)
+    return run_harness(session)
+
+
+def _dispatch(argv: list[str]) -> None:
+    # Late import: cli imports shell (via _enter_session), so importing cli
+    # at module level would be circular.
+    from .cli import main as cli_group
+
+    try:
+        cli_group.main(args=argv, prog_name="tandem", standalone_mode=False)
+    except click.exceptions.UsageError as exc:
+        exc.show()
+        click.echo(HELP)
+    except click.ClickException as exc:
+        exc.show()
+    except click.exceptions.Abort:
+        click.echo()
+    except SystemExit:
+        pass  # one-shot commands sys.exit(); the prompt continues

--- a/src/tandem/shell.py
+++ b/src/tandem/shell.py
@@ -56,6 +56,17 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
         except ValueError as exc:  # e.g. an unbalanced quote
             click.secho(f"could not parse: {exc}", fg="yellow")
             continue
+        if argv[0].startswith("-") and argv[0] not in ("--help", "--version"):
+            # Options with no subcommand would hit the group's
+            # invoke_without_command path: a fresh pairing plus a shell
+            # nested inside this one. Launching is an OS-shell concern.
+            click.secho(
+                f"{argv[0]} is a `tandem` launch option, not a prompt command"
+                " — `exit` first, then re-run tandem.",
+                fg="yellow",
+            )
+            click.echo(HELP)
+            continue
         if argv[0] == "resume":
             click.secho(
                 "resume takes no id at this prompt — `exit` first, then"
@@ -114,3 +125,6 @@ def _dispatch(argv: list[str]) -> None:
         click.echo()
     except SystemExit:
         pass  # one-shot commands sys.exit(); the prompt continues
+    except Exception as exc:
+        # A failing command must never take the live session down with it.
+        click.secho(f"command failed: {exc}", fg="red", err=True)

--- a/src/tandem/state.py
+++ b/src/tandem/state.py
@@ -176,10 +176,13 @@ class StateStore:
             )
 
     def archive_session(self, tandem_id: str) -> None:
-        with self._conn:
-            self._conn.execute(
-                "UPDATE sessions SET archived = 1 WHERE tandem_id = ?", (tandem_id,)
-            )
+        """No-op: archiving is vestigial.
+
+        Sessions are no longer hidden from a cwd -- `archived` is gone from the
+        schema and `latest_session_for_cwd` does not filter on it. `start`'s only
+        caller gets the same observable result by creating a new session, which
+        wins the `last_used_at DESC` ordering. Removed with `start`.
+        """
 
     # -- sync cursors --------------------------------------------------------
 

--- a/src/tandem/state.py
+++ b/src/tandem/state.py
@@ -137,10 +137,16 @@ class StateStore:
         return self._row_to_session(row) if row else None
 
     def latest_session_for_cwd(self, cwd: str) -> PairedSession | None:
-        """Most recently used paired session for a working directory."""
+        """Most recently used paired session for a working directory.
+
+        COALESCE keeps the ordering NULL-immune: a row whose last_used_at was
+        never backfilled (a crash between the ALTER and its commit) falls back
+        to its creation time instead of sorting behind every older row.
+        """
         row = self._conn.execute(
             "SELECT * FROM sessions WHERE cwd = ?"
-            " ORDER BY last_used_at DESC, created_at DESC LIMIT 1",
+            " ORDER BY COALESCE(last_used_at, created_at) DESC, created_at DESC"
+            " LIMIT 1",
             (cwd,),
         ).fetchone()
         return self._row_to_session(row) if row else None

--- a/src/tandem/state.py
+++ b/src/tandem/state.py
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     codex_session_id TEXT,
     created_at TEXT NOT NULL,
     last_sync_at TEXT,
-    archived INTEGER NOT NULL DEFAULT 0
+    last_used_at TEXT
 );
 CREATE TABLE IF NOT EXISTS sync_cursors (
     tandem_id TEXT NOT NULL,
@@ -55,6 +55,7 @@ class PairedSession:
     codex_session_id: str | None
     created_at: str
     last_sync_at: str | None
+    last_used_at: str | None = None
 
     @property
     def shadow(self) -> str:
@@ -80,6 +81,10 @@ class StateStore:
         self._conn = sqlite3.connect(self.db_path)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(_SCHEMA)
+        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(sessions)")}
+        if "last_used_at" not in cols:
+            self._conn.execute("ALTER TABLE sessions ADD COLUMN last_used_at TEXT")
+            self._conn.execute("UPDATE sessions SET last_used_at = created_at")
         self._conn.commit()
 
     def close(self) -> None:
@@ -105,11 +110,12 @@ class StateStore:
         with self._conn:
             self._conn.execute(
                 "INSERT INTO sessions (tandem_id, cwd, active, claude_session_id,"
-                " codex_session_id, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-                (tandem_id, cwd, active, claude_session_id, codex_session_id, now),
+                " codex_session_id, created_at, last_used_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (tandem_id, cwd, active, claude_session_id, codex_session_id, now, now),
             )
         return PairedSession(
-            tandem_id, cwd, active, claude_session_id, codex_session_id, now, None
+            tandem_id, cwd, active, claude_session_id, codex_session_id, now, None, now
         )
 
     def _row_to_session(self, row: sqlite3.Row) -> PairedSession:
@@ -121,6 +127,7 @@ class StateStore:
             codex_session_id=row["codex_session_id"],
             created_at=row["created_at"],
             last_sync_at=row["last_sync_at"],
+            last_used_at=row["last_used_at"],
         )
 
     def get_session(self, tandem_id: str) -> PairedSession | None:
@@ -129,14 +136,21 @@ class StateStore:
         ).fetchone()
         return self._row_to_session(row) if row else None
 
-    def session_for_cwd(self, cwd: str) -> PairedSession | None:
-        """Newest non-archived paired session for a working directory."""
+    def latest_session_for_cwd(self, cwd: str) -> PairedSession | None:
+        """Most recently used paired session for a working directory."""
         row = self._conn.execute(
-            "SELECT * FROM sessions WHERE cwd = ? AND archived = 0"
-            " ORDER BY created_at DESC LIMIT 1",
+            "SELECT * FROM sessions WHERE cwd = ?"
+            " ORDER BY last_used_at DESC, created_at DESC LIMIT 1",
             (cwd,),
         ).fetchone()
         return self._row_to_session(row) if row else None
+
+    def touch_used(self, tandem_id: str) -> None:
+        with self._conn:
+            self._conn.execute(
+                "UPDATE sessions SET last_used_at = ? WHERE tandem_id = ?",
+                (_now(), tandem_id),
+            )
 
     def set_active(self, tandem_id: str, active: str) -> None:
         with self._conn:

--- a/src/tandem/state.py
+++ b/src/tandem/state.py
@@ -175,15 +175,6 @@ class StateStore:
                 (_now(), tandem_id),
             )
 
-    def archive_session(self, tandem_id: str) -> None:
-        """No-op: archiving is vestigial.
-
-        Sessions are no longer hidden from a cwd -- `archived` is gone from the
-        schema and `latest_session_for_cwd` does not filter on it. `start`'s only
-        caller gets the same observable result by creating a new session, which
-        wins the `last_used_at DESC` ordering. Removed with `start`.
-        """
-
     # -- sync cursors --------------------------------------------------------
 
     def get_cursor(self, tandem_id: str, source: str) -> SyncCursor:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """Shared fixtures: a paired session under tmp homes with both shadow files
-seeded the way `tandem start` does, plus fake native entry builders."""
+seeded the way a fresh `tandem` launch does, plus fake native entry builders."""
 
 import json
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,3 +137,28 @@ def test_resume_warns_but_proceeds_without_binaries(homes, entered, monkeypatch)
     assert r.exit_code == 0  # warn-only: resume is not blocked like pairing
     assert "warning:" in r.stderr
     assert entered[0].tandem_id == s.tandem_id
+
+
+def test_doctor_no_session_hints_tandem(homes, ok_versions):
+    r = click.testing.CliRunner().invoke(cli.main, ["doctor"])
+    assert r.exit_code == 1
+    assert "tandem start" not in r.output
+    assert "run `tandem` to start one" in r.output
+
+
+def test_one_shot_switch_hints_resume(homes, ok_versions, monkeypatch):
+    class Mem:
+        actions: list = []
+        warnings: list = []
+
+    s = _mk_session(homes)
+
+    def fake_switch(store, session):
+        store.set_active(session.tandem_id, "codex")
+        return "codex", [], Mem()
+
+    monkeypatch.setattr("tandem.ops.switch_session", fake_switch)
+    r = click.testing.CliRunner().invoke(cli.main, ["switch"])
+    assert r.exit_code == 0
+    assert "tandem resume" in r.output
+    assert "Run `tandem` to continue" not in r.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,81 @@
+"""CLI-level tests: pairing, resume, one-shot plumbing. The interactive
+entry (`_enter_session`) is monkeypatched; pairing runs for real under
+tmp homes (same env vars as conftest.Env)."""
+
+import click.testing
+import pytest
+
+from tandem import cli
+from tandem.state import StateStore
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.setattr(cli, "_cwd", lambda: str(proj))
+    return proj
+
+
+@pytest.fixture
+def ok_versions(monkeypatch):
+    monkeypatch.setattr(
+        cli, "_check_versions",
+        lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+    )
+
+
+@pytest.fixture
+def entered(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "_enter_session", lambda s: (calls.append(s), 0)[1])
+    return calls
+
+
+def test_bare_tandem_pairs_fresh_each_launch(homes, ok_versions, entered):
+    runner = click.testing.CliRunner()
+    r1 = runner.invoke(cli.main, [])
+    r2 = runner.invoke(cli.main, [])
+    assert r1.exit_code == 0 and r2.exit_code == 0
+    assert "paired" in r1.output and "claude active, codex shadow" in r1.output
+    ids = {s.tandem_id for s in entered}
+    assert len(ids) == 2  # two launches -> two distinct sessions
+
+
+def test_active_codex_flips_roles(homes, ok_versions, entered):
+    r = click.testing.CliRunner().invoke(cli.main, ["--active", "codex"])
+    assert r.exit_code == 0
+    assert entered[0].active == "codex"
+    assert "codex active, claude shadow" in r.output
+
+
+class _NoBin:
+    display_name = "Claude Code"
+    binary = "claude"
+
+    def detect_version(self):
+        return None
+
+
+def test_missing_binary_blocks_pairing(homes, entered, monkeypatch):
+    monkeypatch.setattr(cli, "get_adapter", lambda hid: _NoBin())
+    r = click.testing.CliRunner().invoke(cli.main, [])
+    assert r.exit_code == 1
+    assert entered == []  # never paired, never entered
+    with StateStore() as store:
+        assert store.latest_session_for_cwd(cli._cwd()) is None
+
+
+def test_start_is_gone(homes):
+    r = click.testing.CliRunner().invoke(cli.main, ["start"])
+    assert r.exit_code == 2  # click usage error: no such command
+
+
+def test_one_shot_without_session_hints_tandem(homes, ok_versions):
+    r = click.testing.CliRunner().invoke(cli.main, ["status"])
+    assert r.exit_code == 1
+    # click >= 8.2 (repo has 8.4.2): err=True output lands in r.stderr
+    assert "Run `tandem` to start one" in r.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,3 +79,61 @@ def test_one_shot_without_session_hints_tandem(homes, ok_versions):
     assert r.exit_code == 1
     # click >= 8.2 (repo has 8.4.2): err=True output lands in r.stderr
     assert "Run `tandem` to start one" in r.stderr
+
+
+def _mk_session(cwd, active="claude", n=0):
+    with StateStore() as store:
+        return store.create_session(str(cwd), active, f"c-{n}", f"x-{n}")
+
+
+def test_resume_picks_most_recently_used(homes, ok_versions, entered):
+    s1 = _mk_session(homes, n=1)
+    _mk_session(homes, n=2)
+    with StateStore() as store:
+        store.touch_used(s1.tandem_id)
+    r = click.testing.CliRunner().invoke(cli.main, ["resume"])
+    assert r.exit_code == 0
+    assert entered[0].tandem_id == s1.tandem_id
+
+
+def test_resume_by_id(homes, ok_versions, entered):
+    s1 = _mk_session(homes, n=1)
+    _mk_session(homes, n=2)
+    r = click.testing.CliRunner().invoke(cli.main, ["resume", s1.tandem_id])
+    assert r.exit_code == 0
+    assert entered[0].tandem_id == s1.tandem_id
+    with StateStore() as store:  # resume bumps last_used_at
+        assert (
+            store.latest_session_for_cwd(str(homes)).tandem_id == s1.tandem_id
+        )
+
+
+def test_resume_unknown_id_errors(homes, ok_versions, entered):
+    r = click.testing.CliRunner().invoke(cli.main, ["resume", "nope00000000"])
+    assert r.exit_code == 1
+    assert entered == []
+
+
+def test_resume_id_from_other_directory_errors(homes, ok_versions, entered, tmp_path):
+    other_dir = tmp_path / "elsewhere"
+    other_dir.mkdir()
+    s = _mk_session(other_dir)
+    r = click.testing.CliRunner().invoke(cli.main, ["resume", s.tandem_id])
+    assert r.exit_code == 1
+    assert str(other_dir) in r.stderr  # tells the user where it lives
+    assert entered == []
+
+
+def test_resume_with_no_sessions_hints_tandem(homes, ok_versions, entered):
+    r = click.testing.CliRunner().invoke(cli.main, ["resume"])
+    assert r.exit_code == 1
+    assert "Run `tandem` to start one" in r.stderr
+
+
+def test_resume_warns_but_proceeds_without_binaries(homes, entered, monkeypatch):
+    s = _mk_session(homes)
+    monkeypatch.setattr(cli, "get_adapter", lambda hid: _NoBin())
+    r = click.testing.CliRunner().invoke(cli.main, ["resume"])
+    assert r.exit_code == 0  # warn-only: resume is not blocked like pairing
+    assert "warning:" in r.stderr
+    assert entered[0].tandem_id == s.tandem_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ tmp homes (same env vars as conftest.Env)."""
 import click.testing
 import pytest
 
-from tandem import cli
+from tandem import cli, compat
 from tandem.state import StateStore
 
 
@@ -139,7 +139,13 @@ def test_resume_warns_but_proceeds_without_binaries(homes, entered, monkeypatch)
     assert entered[0].tandem_id == s.tandem_id
 
 
-def test_doctor_no_session_hints_tandem(homes, ok_versions):
+def test_doctor_no_session_hints_tandem(homes, monkeypatch):
+    # run_doctor probes versions through the adapters, not cli._check_versions,
+    # so patch the detection itself: no real `claude`/`codex` subprocess.
+    monkeypatch.setattr(
+        compat, "detect_cli_version",
+        lambda binary: {"claude": "2.1.220", "codex": "0.145.0"}.get(binary),
+    )
     r = click.testing.CliRunner().invoke(cli.main, ["doctor"])
     assert r.exit_code == 1
     assert "tandem start" not in r.output

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,8 +1,10 @@
 """Shell loop tests with a fake harness runner and scripted input."""
 
+import sqlite3
+
 import pytest
 
-from tandem import shell
+from tandem import paths, shell
 from tandem.state import StateStore
 
 
@@ -114,7 +116,7 @@ def test_unknown_input_prints_command_list(sess, capsys):
 def test_unbalanced_quote_does_not_kill_the_prompt(sess, capsys):
     log = []
     shell.run_shell(
-        sess.tandem_id, None, input_fn=scripted('run --on codex "oops'),
+        sess.tandem_id, None, input_fn=scripted('status "oops'),
         run_harness=fake_runner(log),
     )
     out = capsys.readouterr().out
@@ -160,7 +162,8 @@ def test_non_click_exception_keeps_the_prompt_alive(sess, capsys, monkeypatch):
         run_harness=fake_runner(log),
     )
     cap = capsys.readouterr()
-    assert "command failed: transcript directory vanished" in cap.err
+    # the exception type is part of the message: str(KeyError()) is empty
+    assert "command failed: OSError: transcript directory vanished" in cap.err
     assert log == ["claude", "claude"]  # loop survived, Enter still re-enters
     assert f"to continue this session: tandem resume {sess.tandem_id}" in cap.out
 
@@ -192,3 +195,208 @@ def test_prompt_shows_active_harness(sess):
     shell.run_shell(sess.tandem_id, None, input_fn=input_fn,
                     run_harness=fake_runner([]))
     assert prompts == ["tandem (claude)> "]
+
+
+class Rival:
+    """A second `tandem` in the same directory, started while this shell sits
+    inside its harness: by the time the user types a command it — not the
+    shell's own session — is the most-recently-used session for the cwd."""
+
+    def __init__(self, cwd):
+        with StateStore() as store:
+            self.tandem_id = store.create_session(cwd, "codex", "c-2", "x-2").tandem_id
+        self.mru_at_prompt = None
+
+    def take_over(self, session):
+        """Stands in for run_harness: the rival launches while we are busy."""
+        with StateStore() as store:
+            store.touch_used(self.tandem_id)
+            self.mru_at_prompt = store.latest_session_for_cwd(session.cwd).tandem_id
+        return 0
+
+
+def test_dispatch_targets_this_shell_not_the_cwd_mru(sess, capsys, monkeypatch):
+    """A second `tandem` in the same directory becomes the most-recently-used
+    session for that cwd; commands typed in the older shell must keep acting
+    on the older session (`run --on` there would otherwise inject a model turn
+    into someone else's transcripts)."""
+    from tandem import cli
+
+    monkeypatch.setattr(cli, "_cwd", lambda: sess.cwd)
+    monkeypatch.setattr(cli, "_check_versions", lambda warn_only=False: {})
+    rival = Rival(sess.cwd)
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("status"),
+        run_harness=rival.take_over,
+    )
+    out = capsys.readouterr().out
+    assert rival.mru_at_prompt == rival.tandem_id  # the setup really did shadow us
+    assert f"tandem session {sess.tandem_id}" in out
+    assert rival.tandem_id not in out
+    assert cli._SESSION_ID is None  # override cleared after dispatch
+
+
+def test_doctor_at_the_prompt_targets_this_shell(sess, capsys, monkeypatch):
+    from tandem import cli
+
+    monkeypatch.setattr(cli, "_cwd", lambda: sess.cwd)
+    monkeypatch.setattr(
+        "tandem.compat.detect_cli_version",
+        lambda binary: {"claude": "2.1.220", "codex": "0.145.0"}.get(binary),
+    )
+    rival = Rival(sess.cwd)
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("doctor"),
+        run_harness=rival.take_over,
+    )
+    out = capsys.readouterr().out
+    assert rival.mru_at_prompt == rival.tandem_id
+    assert f"paired session {sess.tandem_id}" in out
+    assert rival.tandem_id not in out
+
+
+def test_failed_reentry_returns_to_the_prompt(sess, capsys):
+    """The harness binary vanishing mid-shell must not kill the session."""
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        if len(calls) == 2:
+            raise FileNotFoundError("claude: command not found")
+        return 0
+
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("", "", "exit"),
+        run_harness=run_harness,
+    )
+    cap = capsys.readouterr()
+    assert len(calls) == 3  # entry, failed re-entry, then a working one
+    assert "could not run the harness: FileNotFoundError" in cap.err
+    assert f"to continue this session: tandem resume {sess.tandem_id}" in cap.out
+
+
+def test_resume_hint_prints_even_when_the_loop_raises(sess, capsys):
+    """The hint is the only place the id is shown, so it must survive an
+    unexpected exception escaping the loop body."""
+    def input_fn(prompt):
+        raise RuntimeError("terminal went away")
+
+    with pytest.raises(RuntimeError):
+        shell.run_shell(sess.tandem_id, None, input_fn=input_fn,
+                        run_harness=fake_runner([]))
+    assert f"to continue this session: tandem resume {sess.tandem_id}" in (
+        capsys.readouterr().out
+    )
+
+
+def test_vanished_session_row_leaves_the_loop_cleanly(sess, capsys):
+    def run_harness(session):
+        conn = sqlite3.connect(paths.state_db_path())
+        with conn:
+            conn.execute(
+                "DELETE FROM sessions WHERE tandem_id = ?", (sess.tandem_id,)
+            )
+        conn.close()
+        return 0
+
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("", "exit"),
+        run_harness=run_harness,
+    )
+    cap = capsys.readouterr()
+    assert "no longer in the state store" in cap.err  # not an AttributeError
+    assert f"tandem resume {sess.tandem_id}" in cap.out
+
+
+def _capture_oneoff(monkeypatch, sess):
+    from tandem import cli, ops
+
+    seen = []
+    monkeypatch.setattr(cli, "_cwd", lambda: sess.cwd)
+    monkeypatch.setattr(
+        ops, "run_oneoff",
+        lambda store, session, target, prompt: seen.append(
+            (session.tandem_id, target, prompt)
+        ) or 0,
+    )
+    return seen
+
+
+def test_run_prompt_with_an_apostrophe_is_literal_text(sess, capsys, monkeypatch):
+    seen = _capture_oneoff(monkeypatch, sess)
+    rival = Rival(sess.cwd)  # a real model turn must not land in its files
+    shell.run_shell(
+        sess.tandem_id, None,
+        input_fn=scripted("run --on codex what's wrong with test_foo?"),
+        run_harness=rival.take_over,
+    )
+    assert rival.mru_at_prompt == rival.tandem_id
+    assert seen == [(sess.tandem_id, "codex", "what's wrong with test_foo?")]
+    assert "could not parse" not in capsys.readouterr().out
+
+
+def test_run_quoted_prompt_keeps_one_shot_meaning(sess, monkeypatch):
+    seen = _capture_oneoff(monkeypatch, sess)
+    shell.run_shell(
+        sess.tandem_id, None,
+        input_fn=scripted(
+            'run --on codex "why is this flaky?"',
+            "run --on=codex second opinion, please",
+        ),
+        run_harness=fake_runner([]),
+    )
+    assert [p for _, _, p in seen] == [
+        "why is this flaky?",          # outer quotes stripped, as one-shot
+        "second opinion, please",      # --on=<harness> form
+    ]
+
+
+def test_run_prompt_starting_with_a_dash_is_not_read_as_an_option(sess, monkeypatch):
+    seen = _capture_oneoff(monkeypatch, sess)
+    shell.run_shell(
+        sess.tandem_id, None,
+        input_fn=scripted("run --on codex --help me read this stack trace"),
+        run_harness=fake_runner([]),
+    )
+    assert [p for _, _, p in seen] == ["--help me read this stack trace"]
+
+
+def test_malformed_run_still_gets_click_usage_error(sess, capsys, monkeypatch):
+    from tandem import cli
+
+    monkeypatch.setattr(cli, "_cwd", lambda: sess.cwd)
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("run", "run --on codex"),
+        run_harness=fake_runner([]),
+    )
+    cap = capsys.readouterr()
+    assert "--on" in cap.err or "--on" in cap.out  # click's own usage error
+    assert "commands:" in cap.out
+
+
+def test_prompt_switch_reports_like_the_one_shot(sess, capsys, monkeypatch):
+    """Display names, memory actions and the doctor advisory — the prompt is
+    the primary switch path, so it must not report less than `tandem switch`."""
+    class Mem:
+        actions = ["wrote shared block into AGENTS.md"]
+        warnings = ["CLAUDE.md has no tandem markers; read-only"]
+
+    problems = ["transcript for newly active harness does not exist yet"]
+
+    def fake_switch(store, session):
+        store.set_active(session.tandem_id, "codex")
+        return "codex", problems, Mem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("switch", "exit"),
+        run_harness=fake_runner([]),
+    )
+    cap = capsys.readouterr()
+    assert "active harness: Claude Code -> Codex CLI" in cap.out
+    assert "memory: wrote shared block into AGENTS.md" in cap.out
+    assert "memory: CLAUDE.md has no tandem markers" in cap.err
+    assert "transcript for newly active harness does not exist yet" in cap.err
+    assert "run `tandem doctor` for details." in cap.err
+    # the prompt re-enters the harness itself; no resume instruction
+    assert "Run `tandem resume` to continue" not in cap.out

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,151 @@
+"""Shell loop tests with a fake harness runner and scripted input."""
+
+import pytest
+
+from tandem import shell
+from tandem.state import StateStore
+
+
+class FakeMem:
+    actions: list = []
+    warnings: list = []
+
+
+@pytest.fixture
+def sess(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    with StateStore() as store:
+        return store.create_session(str(tmp_path / "proj"), "claude", "c-id", "x-id")
+
+
+def scripted(*lines):
+    it = iter(lines)
+
+    def input_fn(prompt):
+        item = next(it, EOFError)
+        if item is EOFError:
+            raise EOFError
+        if item is KeyboardInterrupt:
+            raise KeyboardInterrupt
+        return item
+
+    return input_fn
+
+
+def fake_runner(log, codes=None):
+    codes = list(codes or [])
+
+    def run_harness(session):
+        log.append(session.active)
+        return codes.pop(0) if codes else 0
+
+    return run_harness
+
+
+def test_switch_flips_and_reenters(sess, monkeypatch):
+    def fake_switch(store, session):
+        new = "codex" if session.active == "claude" else "claude"
+        store.set_active(session.tandem_id, new)
+        return new, [], FakeMem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+    log = []
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("switch", "exit"),
+        run_harness=fake_runner(log),
+    )
+    assert log == ["claude", "codex"]
+    assert code == 0
+
+
+def test_enter_and_resume_reenter_without_flip(sess):
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("", "resume", "exit"),
+        run_harness=fake_runner(log),
+    )
+    assert log == ["claude", "claude", "claude"]
+
+
+def test_resume_with_id_rejected_at_prompt(sess, capsys):
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("resume abc123"),
+        run_harness=fake_runner(log),
+    )
+    out = capsys.readouterr().out
+    assert "tandem resume <id>" in out
+    assert log == ["claude"]  # only the initial entry
+
+
+def test_exit_prints_resume_hint_and_last_code(sess, capsys):
+    log = []
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("exit"),
+        run_harness=fake_runner(log, codes=[7]),
+    )
+    assert code == 7
+    assert f"to continue this session: tandem resume {sess.tandem_id}" in (
+        capsys.readouterr().out
+    )
+
+
+def test_eof_exits_and_ctrl_c_does_not(sess):
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None,
+        input_fn=scripted(KeyboardInterrupt, ""),  # ^C, then Enter, then EOF
+        run_harness=fake_runner(log),
+    )
+    assert log == ["claude", "claude"]  # survived ^C, re-entered on Enter
+
+
+def test_unknown_input_prints_command_list(sess, capsys):
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("frobnicate"),
+        run_harness=fake_runner(log),
+    )
+    assert "commands:" in capsys.readouterr().out
+
+
+def test_unbalanced_quote_does_not_kill_the_prompt(sess, capsys):
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted('run --on codex "oops'),
+        run_harness=fake_runner(log),
+    )
+    out = capsys.readouterr().out
+    assert "could not parse" in out
+    assert f"tandem resume {sess.tandem_id}" in out  # survived to a clean exit
+
+
+def test_status_dispatches_through_cli(sess, capsys, monkeypatch):
+    from tandem import cli
+
+    monkeypatch.setattr(cli, "_cwd", lambda: sess.cwd)
+    monkeypatch.setattr(
+        cli, "_check_versions",
+        lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+    )
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("status"),
+        run_harness=fake_runner([]),
+    )
+    # the one-shot status implementation ran (ops.unsynced_lines returns 0
+    # for a missing transcript, so no files are needed)
+    assert f"tandem session {sess.tandem_id}" in capsys.readouterr().out
+
+
+def test_prompt_shows_active_harness(sess):
+    prompts = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        raise EOFError
+
+    shell.run_shell(sess.tandem_id, None, input_fn=input_fn,
+                    run_harness=fake_runner([]))
+    assert prompts == ["tandem (claude)> "]

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -122,6 +122,49 @@ def test_unbalanced_quote_does_not_kill_the_prompt(sess, capsys):
     assert f"tandem resume {sess.tandem_id}" in out  # survived to a clean exit
 
 
+def test_launch_options_neither_pair_nor_nest(sess, capsys, monkeypatch):
+    """`--active codex` at the prompt must not re-enter the group's
+    invoke_without_command path (pairing a fresh session and nesting a
+    second shell inside this one)."""
+    from tandem import cli
+
+    monkeypatch.setattr(cli, "_cwd", lambda: sess.cwd)
+    monkeypatch.setattr(cli, "_check_versions", lambda warn_only=False: {})
+    nested = []
+    monkeypatch.setattr(cli, "_enter_session", lambda s: (nested.append(s), 0)[1])
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None,
+        input_fn=scripted("--active codex", "--active=codex", "--"),
+        run_harness=fake_runner(log),
+    )
+    out = capsys.readouterr().out
+    assert nested == []  # no shell nested inside the shell
+    assert "paired" not in out  # no orphan session
+    assert log == ["claude"]  # only the initial entry
+    assert "commands:" in out  # the user gets the command list instead
+    with StateStore() as store:
+        assert store.latest_session_for_cwd(sess.cwd).tandem_id == sess.tandem_id
+
+
+def test_non_click_exception_keeps_the_prompt_alive(sess, capsys, monkeypatch):
+    from tandem import cli
+
+    def boom(store):
+        raise OSError("transcript directory vanished")
+
+    monkeypatch.setattr(cli, "_require_session", boom)
+    log = []
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("status", ""),
+        run_harness=fake_runner(log),
+    )
+    cap = capsys.readouterr()
+    assert "command failed: transcript directory vanished" in cap.err
+    assert log == ["claude", "claude"]  # loop survived, Enter still re-enters
+    assert f"to continue this session: tandem resume {sess.tandem_id}" in cap.out
+
+
 def test_status_dispatches_through_cli(sess, capsys, monkeypatch):
     from tandem import cli
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,5 @@
 import json
+import sqlite3
 
 from tandem.state import StateStore, SyncCursor
 
@@ -11,23 +12,21 @@ def test_create_and_lookup_session(tmp_path):
     with make_store(tmp_path) as store:
         s = store.create_session("/proj", "claude", "c-id", "x-id")
         assert s.shadow == "codex"
-        found = store.session_for_cwd("/proj")
+        found = store.latest_session_for_cwd("/proj")
         assert found is not None
         assert found.tandem_id == s.tandem_id
         assert found.active == "claude"
         assert found.claude_session_id == "c-id"
-        assert store.session_for_cwd("/other") is None
+        assert store.latest_session_for_cwd("/other") is None
 
 
-def test_set_active_and_archive(tmp_path):
+def test_set_active(tmp_path):
     with make_store(tmp_path) as store:
         s = store.create_session("/proj", "claude", "c-id", None)
         store.set_active(s.tandem_id, "codex")
-        assert store.session_for_cwd("/proj").active == "codex"
+        assert store.latest_session_for_cwd("/proj").active == "codex"
         store.set_native_session_id(s.tandem_id, "codex", "new-x")
-        assert store.session_for_cwd("/proj").codex_session_id == "new-x"
-        store.archive_session(s.tandem_id)
-        assert store.session_for_cwd("/proj") is None
+        assert store.latest_session_for_cwd("/proj").codex_session_id == "new-x"
 
 
 def test_cursor_roundtrip_and_upsert(tmp_path):
@@ -61,3 +60,66 @@ def test_cursor_survives_reopen(tmp_path):
         tid = s.tandem_id
     with make_store(tmp_path) as store:
         assert store.get_cursor(tid, "codex").line_index == 42
+
+
+def test_create_sets_last_used(tmp_path):
+    with make_store(tmp_path) as store:
+        s = store.create_session("/proj", "claude", "c-id", "x-id")
+        assert s.last_used_at == s.created_at
+
+
+def test_latest_prefers_most_recently_used(tmp_path):
+    with make_store(tmp_path) as store:
+        s1 = store.create_session("/proj", "claude", "c-1", "x-1")
+        s2 = store.create_session("/proj", "claude", "c-2", "x-2")
+        assert store.latest_session_for_cwd("/proj").tandem_id == s2.tandem_id
+        store.touch_used(s1.tandem_id)
+        assert store.latest_session_for_cwd("/proj").tandem_id == s1.tandem_id
+        # both sessions coexist for one cwd
+        assert store.get_session(s2.tandem_id) is not None
+
+
+V1_SCHEMA = """
+CREATE TABLE sessions (
+    tandem_id TEXT PRIMARY KEY,
+    cwd TEXT NOT NULL,
+    active TEXT NOT NULL CHECK (active IN ('claude', 'codex')),
+    claude_session_id TEXT,
+    codex_session_id TEXT,
+    created_at TEXT NOT NULL,
+    last_sync_at TEXT,
+    archived INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE sync_cursors (
+    tandem_id TEXT NOT NULL,
+    source TEXT NOT NULL CHECK (source IN ('claude', 'codex')),
+    byte_offset INTEGER NOT NULL DEFAULT 0,
+    line_index INTEGER NOT NULL DEFAULT 0,
+    turn_index INTEGER NOT NULL DEFAULT 0,
+    pending TEXT NOT NULL DEFAULT '{}',
+    failed_turns INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT,
+    PRIMARY KEY (tandem_id, source)
+);
+"""
+
+
+def test_v1_db_migrates_in_place(tmp_path):
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(V1_SCHEMA)
+    conn.execute(
+        "INSERT INTO sessions (tandem_id, cwd, active, claude_session_id,"
+        " codex_session_id, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("oldid0000001", "/proj", "claude", "c-id", "x-id",
+         "2026-01-01T00:00:00+00:00"),
+    )
+    conn.commit()
+    conn.close()
+    with StateStore(db_path=db) as store:
+        s = store.latest_session_for_cwd("/proj")
+        assert s is not None and s.tandem_id == "oldid0000001"
+        # last_used_at backfilled from created_at
+        assert s.last_used_at == "2026-01-01T00:00:00+00:00"
+        store.touch_used(s.tandem_id)
+        assert store.get_session(s.tandem_id).last_used_at != s.last_used_at

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -29,16 +29,6 @@ def test_set_active(tmp_path):
         assert store.latest_session_for_cwd("/proj").codex_session_id == "new-x"
 
 
-def test_archive_session_is_a_harmless_noop(tmp_path):
-    # Archiving is vestigial: the `archived` column is gone from the schema and
-    # no query filters on it. It must not crash on a fresh DB (Task 2 removes it
-    # along with `start`).
-    with make_store(tmp_path) as store:
-        s = store.create_session("/proj", "claude", "c-id", "x-id")
-        store.archive_session(s.tandem_id)
-        assert store.latest_session_for_cwd("/proj").tandem_id == s.tandem_id
-
-
 def test_cursor_roundtrip_and_upsert(tmp_path):
     with make_store(tmp_path) as store:
         s = store.create_session("/proj", "claude", "c-id", "x-id")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -79,6 +79,28 @@ def test_latest_prefers_most_recently_used(tmp_path):
         assert store.get_session(s2.tandem_id) is not None
 
 
+def test_latest_is_immune_to_null_last_used(tmp_path):
+    """A crash between the ALTER and its backfill commit leaves last_used_at
+    NULL forever (the migration only runs when the column is absent). Such a
+    row must fall back to created_at, not sort behind every older session."""
+    with make_store(tmp_path) as store:
+        older = store.create_session("/proj", "claude", "c-1", "x-1")
+        newer = store.create_session("/proj", "claude", "c-2", "x-2")
+        store._conn.execute(
+            "UPDATE sessions SET last_used_at = ?, created_at = ?"
+            " WHERE tandem_id = ?",
+            ("2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00",
+             older.tandem_id),
+        )
+        store._conn.execute(
+            "UPDATE sessions SET last_used_at = NULL, created_at = ?"
+            " WHERE tandem_id = ?",
+            ("2026-06-01T00:00:00+00:00", newer.tandem_id),
+        )
+        store._conn.commit()
+        assert store.latest_session_for_cwd("/proj").tandem_id == newer.tandem_id
+
+
 V1_SCHEMA = """
 CREATE TABLE sessions (
     tandem_id TEXT PRIMARY KEY,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -29,6 +29,16 @@ def test_set_active(tmp_path):
         assert store.latest_session_for_cwd("/proj").codex_session_id == "new-x"
 
 
+def test_archive_session_is_a_harmless_noop(tmp_path):
+    # Archiving is vestigial: the `archived` column is gone from the schema and
+    # no query filters on it. It must not crash on a fresh DB (Task 2 removes it
+    # along with `start`).
+    with make_store(tmp_path) as store:
+        s = store.create_session("/proj", "claude", "c-id", "x-id")
+        store.archive_session(s.tandem_id)
+        assert store.latest_session_for_cwd("/proj").tandem_id == s.tandem_id
+
+
 def test_cursor_roundtrip_and_upsert(tmp_path):
     with make_store(tmp_path) as store:
         s = store.create_session("/proj", "claude", "c-id", "x-id")

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -119,7 +119,7 @@ class TestTailLoop:
 
         # restart: new store + loop resume from the persisted cursor
         with StateStore(db_path=db) as store:
-            session = store.session_for_cwd(str(tmp_path))
+            session = store.latest_session_for_cwd(str(tmp_path))
             write_line(transcript, claude_user("second prompt"))
             sink2 = CollectSink()
             loop2 = TailLoop(store, session, "claude", transcript, sink2)


### PR DESCRIPTION
## Summary

Reworks tandem's session lifecycle to match the claude/codex model, replacing the two-step `tandem start` + `tandem` flow:

- **Bare `tandem` always pairs a fresh session** (claude active by default, `--active codex` to flip) — `tandem start` is removed
- **`tandem resume [<id>]`** continues earlier conversations (most-recently-used for the directory when no id; exit prints `to continue this session: tandem resume <id>`)
- **Persistent prompt between harness sessions**: exiting the harness lands at `tandem (claude)>` instead of the OS shell — `switch` flips roles and immediately enters the other harness, Enter re-enters, one-shot subcommands dispatch through the click group, `exit`/Ctrl-D returns to the OS shell
- **State store**: `sessions` gains `last_used_at` (in-place migration backfills existing DBs), drops the archived flow, and allows many sessions per cwd

Prompt-dispatched commands are scoped to the shell's own session id, the REPL survives command/launch failures (resume hint always prints), and `run --on <harness>` passes free text verbatim so apostrophes work.

Spec: `docs/superpowers/specs/2026-07-29-tandem-shell-design.md` (gitignored dir, local only)

## Test plan

- 87 tests passing (`uv run pytest`), 38 new across `test_cli.py`, `test_shell.py`, `test_state.py`
- v1 → v2 SQLite migration covered (backfill, idempotency, NULL-immune ordering)
- Shell loop covered via injection seams: switch re-entry, exception survival, option-guard against nested shells, exact exit-hint format
- Known follow-up (parked, low likelihood): tail-thread join timeout vs immediate re-entry could briefly overlap two sync engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)