### PR TITLE
fix: accept claude 2.1.220 metadata entry types in transcript validation

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -36,6 +36,11 @@ home), `TANDEM_HOME` (tandem state).
     Not conversation content.
   - `queue-operation` (enqueue/dequeue of the prompt), `last-prompt`
     (`leafUuid` pointer), `summary`, `system` — bookkeeping.
+  - `permission-mode`, `ai-title`, `pr-link`, `relocated`, `worktree-state`,
+    `file-history-snapshot` + `file-history-delta` — uuid-less session
+    metadata (permission mode, AI-generated title, linked PR, worktree
+    moves, file-backup tracking). Not conversation content; claude resumes
+    transcripts containing them without complaint.
 - Resume: `claude --resume <sessionId>` (from the same cwd). A new session
   can be pinned to a chosen id with `claude --session-id <uuid>`.
 - Turn boundary: a `user` entry with string content starts a turn; an

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -18,6 +18,9 @@ _CLAUDE_ENTRY_TYPES = {
     "user", "assistant", "attachment", "system", "summary",
     "queue-operation", "last-prompt", "progress", "file-history-snapshot",
     "mode",  # {"type":"mode","mode":"normal",...} observed on --resume runs
+    # uuid-less metadata entries claude 2.1.220 interleaves with conversation
+    "permission-mode", "ai-title", "file-history-delta", "pr-link",
+    "relocated", "worktree-state",
 }
 _CODEX_LINE_TYPES = {
     "session_meta", "response_item", "event_msg", "turn_context",

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -262,3 +262,25 @@ class TestValidate:
                                    env.session.codex_session_id) == []
         assert validate_transcript("claude", env.claude_shadow,
                                    env.session.claude_session_id) == []
+
+    def test_claude_metadata_entry_types_validate(self, env_factory):
+        """claude 2.1.220 interleaves uuid-less metadata entries with the
+        conversation; a healthy transcript containing them must validate."""
+        from tandem.doctor import validate_transcript
+
+        env = env_factory()
+        sid = env.session.claude_session_id
+        for meta in [
+            {"type": "permission-mode", "permissionMode": "bypassPermissions",
+             "sessionId": sid},
+            {"type": "ai-title", "aiTitle": "Fix switch warnings",
+             "sessionId": sid},
+            {"type": "file-history-delta", "messageId": "m-1",
+             "snapshotMessageId": "s-1", "trackingPath": "pyproject.toml"},
+            {"type": "pr-link", "sessionId": sid, "prNumber": 3,
+             "prUrl": "https://github.com/x/y/pull/3", "prRepository": "x/y"},
+            {"type": "relocated", "sessionId": sid, "relocatedCwd": "/tmp/wt"},
+            {"type": "worktree-state", "worktreeSession": {"worktreeName": "wt"}},
+        ]:
+            write_line(env.claude_shadow, obj=meta)
+        assert validate_transcript("claude", env.claude_shadow, sid) == []


### PR DESCRIPTION
## Summary
- `tandem switch` (and `doctor`) printed a wall of `unknown entry type 'permission-mode'/'ai-title'/'file-history-delta'` warnings plus a spurious "may not resume cleanly" hint on healthy sessions.
- Root cause: `_CLAUDE_ENTRY_TYPES` in `doctor.py` was incomplete for claude 2.1.220 (the exact pinned/tested version) — it was missing six uuid-less metadata entry types claude interleaves with the conversation: `permission-mode`, `ai-title`, `file-history-delta`, `pr-link`, `relocated`, `worktree-state`. Verified against every real session file on a live machine: those six were the only unlisted types, none carry `uuid`s, and claude resumes transcripts containing them without complaint.
- Fix: admit the six types to the allowlist; the unknown-type check still catches genuinely alien types as a corruption/drift signal. Recorded the types in `docs/formats.md` (the pinned format-observation record compat.py points at).

## Test plan
- New test appends all six real-world-shaped entries to a healthy seeded shadow and asserts `validate_transcript` returns no problems (watched it fail with exactly the six warnings before the fix).
- Full suite: 137 passed.
- Ran the fixed validator on the real transcript that produced the warnings — zero problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)