### PR TITLE
release: 0.1.1 — PyPI-safe README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ spend: only one model runs per turn; the other stays in sync through pure
 local file translation.
 
 [![PyPI](https://img.shields.io/pypi/v/tandem-cli)](https://pypi.org/project/tandem-cli/)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](pyproject.toml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://github.com/Bhavya6187/tandem/blob/main/pyproject.toml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/Bhavya6187/tandem/blob/main/LICENSE)
 
 ```bash
 uv tool install tandem-cli
@@ -164,7 +164,7 @@ between the tools).
 
 Session formats are internal to the CLIs and drift between releases.
 tandem pins what it was built against (observed formats documented in
-[docs/formats.md](docs/formats.md)):
+[docs/formats.md](https://github.com/Bhavya6187/tandem/blob/main/docs/formats.md)):
 
 | CLI | Tested | Accepted range |
 | --- | --- | --- |
@@ -215,4 +215,4 @@ passthrough); state is stdlib `sqlite3`.
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/Bhavya6187/tandem/blob/main/LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps the version to 0.1.1 so the rewritten README can be republished to PyPI (PyPI refuses re-uploads of an existing version), and converts the README's relative links to absolute GitHub URLs so they resolve on the PyPI project page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)