### PR TITLE
build: exclude demo gif from sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/tandem"]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["docs/demo.gif"]


### PR DESCRIPTION
The 0.1.2 sdist came out at 4.9MB because hatchling bundled `docs/demo.gif`. The README image on PyPI loads from the absolute raw.githubusercontent.com URL, so the file doesn't need to ship. Excluding it brings the sdist back to ~tens of KB. Wheel was already unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)