### PR TITLE
release: 0.1.3 — outage resilience in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ continues the **same conversation** a second later — same files, same
 history, same plan. Your two subscriptions become one long runway instead
 of two separate walls.
 
+### 🌩️ Immune to outages.
+
+An Anthropic or OpenAI outage doesn't stop your work. If the active
+model's API goes down, `switch` — the same session continues seamlessly
+in the other harness, and you can switch back whenever the outage clears.
+
 ### 💳 Subscriptions, not API bills.
 
 tandem wraps the official CLIs under the auth you already have — your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Adds an "Immune to outages" point to the Why tandem? section: if the active model's API goes down, `switch` continues the same session in the other harness — and you can switch back when the outage clears.

Bumped straight to 0.1.3: 0.1.2 was built but never uploaded to PyPI, so this release ships both the demo gif (#8, #10) and this README point in one publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)