### PR TITLE
ci: run pytest on 3.11–3.13 via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --locked
+      - run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ switch at any moment, and pick up exactly where you left off. No double
 spend: only one model runs per turn; the other stays in sync through pure
 local file translation.
 
+[![CI](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml/badge.svg)](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tandem-cli)](https://pypi.org/project/tandem-cli/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://github.com/Bhavya6187/tandem/blob/main/pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/Bhavya6187/tandem/blob/main/LICENSE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,17 @@ class Env:
         monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
         monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+        # hermetic version checks: run_doctor must not shell out to real CLIs
+        from tandem.compat import COMPAT
+        from tandem.harness.claude_code import ClaudeCodeAdapter
+        from tandem.harness.codex import CodexAdapter
+
+        monkeypatch.setattr(
+            ClaudeCodeAdapter, "detect_version", lambda self: COMPAT["claude"].tested
+        )
+        monkeypatch.setattr(
+            CodexAdapter, "detect_version", lambda self: COMPAT["codex"].tested
+        )
         self.cwd = str(tmp_path / "proj")
         Path(self.cwd).mkdir()
         self.store = StateStore(db_path=tmp_path / ".tandem" / "state.db")


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the test suite with uv on Python 3.11, 3.12, and 3.13 for every push to main and every PR, plus a CI badge in the README.

All 137 tests pass locally in ~1.3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)