### PR TITLE
fix: derive __version__ from installed package metadata

### DIFF
--- a/src/tandem/__init__.py
+++ b/src/tandem/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("tandem-cli")
+except PackageNotFoundError:  # source tree without an installed dist
+    __version__ = "0.0.0.dev0"


### PR DESCRIPTION
`__version__` in `src/tandem/__init__.py` was hardcoded to `0.1.0` and has been stale since — release bumps only touch `pyproject.toml`. This reads it from `importlib.metadata` (keyed on the `tandem-cli` dist) so it always matches the installed version, falling back to `0.0.0.dev0` in an uninstalled source tree.

Verified locally: `tandem.__version__` now reports `0.1.5`; all 137 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)