### PR TITLE
feat: codex-model subagents — plugin + hook reroute + tandem sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,27 +61,33 @@ tandem run --on codex "second opinion: why is this test flaky?"
 
 ### 🐣 Subagents on the cheap model.
 
-Load tandem's Claude Code plugin and Claude's subagent dispatches run on a
-cheap codex model instead — automatically, with the task brief forwarded
-verbatim and the result returned through Claude's own machinery. Claude
-orchestrates; codex does the legwork; your Claude quota stays on the main
-thread. The plugin lives in this repo (not in the wheel), so point Claude
-at a clone:
+Load tandem's Claude Code plugin and Claude's subagent dispatches run on
+the codex model you choose instead — automatically, with the task brief
+forwarded verbatim and the result returned through Claude's own machinery.
+Claude orchestrates; codex does the legwork; your Claude quota stays on the
+main thread. The plugin lives in this repo (not in the wheel), so point
+Claude at a clone:
 
 ```bash
 git clone https://github.com/Bhavya6187/tandem
 claude --plugin-dir /path/to/tandem/plugin
 ```
 
-Routing policy lives in `~/.tandem/config.toml`, never in prompts:
+Then create `~/.tandem/config.toml` and pick your plan's cheap model (ids
+are listed in `~/.codex/models_cache.json`):
 
 ```toml
 [subagents]
+model = "gpt-5.6-luna"  # ← the whole point: set this
 route = "all"           # all | off
-model = "gpt-5.6-luna"  # any codex model id ("" = codex's own default)
 context = "match"       # match | task | full
 keep_forks = false      # keep each worker's rollout for debugging
 ```
+
+**Without `model`, workers run on your codex account's default model —
+probably not the cheap one.** Every other key above is already the default;
+that one is not, and routing is on as soon as the plugin loads, so
+`tandem doctor` warns until you set it.
 
 Fork dispatches stay on Claude, each worker's full codex log is kept under
 `~/.tandem/subagents/`, and `tandem status` lists the workers running right

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ text between terminals:
 tandem run --on codex "second opinion: why is this test flaky?"
 ```
 
+### 🐣 Subagents on the cheap model.
+
+Load tandem's Claude Code plugin and Claude's subagent dispatches run on a
+cheap codex model instead — automatically, with the task brief forwarded
+verbatim and the result returned through Claude's own machinery. Claude
+orchestrates; codex does the legwork; your Claude quota stays on the main
+thread. The plugin lives in this repo (not in the wheel), so point Claude
+at a clone:
+
+```bash
+git clone https://github.com/Bhavya6187/tandem
+claude --plugin-dir /path/to/tandem/plugin
+```
+
+Routing policy lives in `~/.tandem/config.toml`, never in prompts:
+
+```toml
+[subagents]
+route = "all"           # all | off
+model = "gpt-5.6-luna"  # any codex model id ("" = codex's own default)
+context = "match"       # match | task | full
+keep_forks = false      # keep each worker's rollout for debugging
+```
+
+Fork dispatches stay on Claude, each worker's full codex log is kept under
+`~/.tandem/subagents/`, and `tandem status` lists the workers running right
+now. Drop the `--plugin-dir` flag and Claude is byte-for-byte stock again.
+
 ### 🏠 Every model in its native harness.
 
 This is not a lowest-common-denominator wrapper UI. Claude runs in real
@@ -114,6 +142,7 @@ tandem resume a1b2c3d4e5f6   # a specific one (id from the exit hint)
 | `switch` | Flip active/shadow and enter the other agent — at the tandem prompt, or one-shot from your shell (one-shot only flips, it doesn't enter) |
 | `tandem resume [id]` | Continue the most recent (or a specific) session |
 | `tandem run --on codex "…"` | One-off prompt to the *other* agent, with full context |
+| `tandem sub "…"` | Run one delegated task on a codex model (used by the plugin's reroute hook) |
 | `tandem status` | Show pairing, roles, and sync position |
 
 There are also three maintenance commands — `tandem doctor` (health

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -89,6 +89,14 @@ def test_broken_toml_falls_back(tmp_path, monkeypatch):
     (home / "config.toml").write_text("[subagents\nnot toml")
     monkeypatch.setenv("TANDEM_HOME", str(home))
     assert load_subagents_config() == SubagentsConfig()
+
+
+def test_non_utf8_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_bytes(b'[subagents]\nmodel = "caf\xe9"\n')
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    assert load_subagents_config() == SubagentsConfig()
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -131,7 +139,9 @@ def load_subagents_config() -> SubagentsConfig:
     try:
         with open(paths.tandem_home() / "config.toml", "rb") as f:
             data = tomllib.load(f)
-    except (OSError, tomllib.TOMLDecodeError):
+    # ValueError covers TOMLDecodeError (a subclass), the UnicodeDecodeError
+    # tomllib raises when the file is not UTF-8, and open()'s embedded-NUL path.
+    except (OSError, ValueError):
         return SubagentsConfig()
     raw = data.get("subagents")
     if not isinstance(raw, dict):
@@ -156,7 +166,7 @@ def load_subagents_config() -> SubagentsConfig:
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `uv run pytest tests/test_config.py -v`
-Expected: 4 passed
+Expected: 5 passed
 
 - [ ] **Step 5: Commit**
 

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -321,7 +321,7 @@ git commit -m "feat: fork_shadow — ephemeral codex rollout copies for subagent
 
 **Interfaces:**
 - Consumes: `fork_shadow`, `_sub_lock`, `_run` seam (Task 2); `load_subagents_config`, `SubagentsConfig` (Task 1); `get_adapter`, `paths.tandem_home`.
-- Produces: `run_sub(store, session, task, *, model: str = "", context: str = "task", fanout_feature: str = "", keep_forks: bool = False) -> int`, `seed_sub_rollout(session) -> tuple[str, Path]`, and the `tandem sub` command (`-m/--model`, `--context task|full`, task from argument or stdin). The bridge agent (Task 5) and status (Task 6) rely on: exit code mirrors codex exec; running-marker files under `$TANDEM_HOME/subagents/<tandem-id>/running/<run-id>.json` with keys `model`, `context`, `task_preview`, `pid`; retained sub rollouts moved to `$TANDEM_HOME/subagents/<tandem-id>/`.
+- Produces: `run_sub(store, session, task, *, model: str = "", context: str = "task", fanout_feature: str = "", keep_forks: bool = False, quiet: bool = False) -> int`, `seed_sub_rollout(session) -> tuple[str, Path]`, and the `tandem sub` command (`-m/--model`, `--context task|full`, `-q/--quiet`, task from argument or stdin). The bridge agent (Task 5) and status (Task 6) rely on: exit code mirrors codex exec; running-marker files under `$TANDEM_HOME/subagents/<tandem-id>/running/<run-id>.json` with keys `model`, `context`, `task_preview`, `pid`; retained sub rollouts moved to `$TANDEM_HOME/subagents/<tandem-id>/`.
 
 **Both contexts resume a tandem-authored rollout.** A cold `codex exec` would write an ordinary rollout in the session cwd (non-tandem originator, fresh mtime) — exactly what `await_codex_rollout` looks for — so the next codex-id capture would bind the pair's `codex_session_id` to a throwaway worker transcript that `run_sub` then deletes. `context='task'` therefore seeds its own minimal `originator: "tandem-sub"` rollout and resumes that; Task 2's discovery guard then covers every sub rollout, fork or seed.
 
@@ -480,9 +480,79 @@ class TestRunSub:
         assert len(seen["during"]) == 1
         assert seen["payload"][0]["task_preview"] == "watch me"
         assert seen["during"][0].exists() is False  # removed on completion
+
+
+class TestQuietRelay:
+    """Quiet mode exists for the bridge agent: with inherited stdio the Bash
+    output is codex's ENTIRE exec log (header, actions, token counts), and
+    "return the final message verbatim" is not something a haiku relay can do
+    reliably. Quiet mode makes the command's whole output BE the final
+    message, via codex's own `-o/--output-last-message`."""
+
+    def test_quiet_relays_only_the_last_message(self, env_factory, monkeypatch,
+                                                capsys):
+        env = env_factory(active="claude")
+        calls = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            calls["argv"], calls["kw"] = argv, kw
+            i = argv.index("-o")
+            calls["o_before_resume"] = i < argv.index("resume")
+            calls["last"] = Path(argv[i + 1])
+            calls["last"].write_text("FINAL ANSWER")
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+
+        assert code == 0
+        # -o is an exec-level flag: it must precede the `resume` subcommand
+        assert calls["o_before_resume"]
+        # stdout carries the worker's answer and nothing else
+        assert capsys.readouterr().out == "FINAL ANSWER\n"
+        # the raw transcript is redirected to a retained log for debugging
+        logs = (paths.tandem_home() / "subagents" / env.session.tandem_id
+                / "logs")
+        assert calls["last"].parent == logs
+        assert calls["kw"]["stderr"] == subprocess.STDOUT
+        assert list(logs.glob("*.log")) != []
+
+    def test_quiet_falls_back_to_the_log_tail(self, env_factory, monkeypatch,
+                                              capsys):
+        """A codex run that dies before writing a last message must still
+        relay something — otherwise the bridge reports an empty failure."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, stdout=None, **kw):
+            stdout.write(b"boom: auth failed\nstack line\n")
+            stdout.flush()
+            return _R(1)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "boom: auth failed" in out
+        assert "stack line" in out
+
+    def test_non_quiet_streams_with_inherited_stdio(self, env_factory,
+                                                    monkeypatch, capsys):
+        """Manual `tandem sub` keeps streaming: no -o, no redirection."""
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv, kw=kw) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t")
+        assert "-o" not in calls["argv"]
+        assert calls["kw"] == {}
+        assert capsys.readouterr().out == ""
 ```
 
-(`tests/test_sub.py` imports `paths` alongside `ops` at module level for these.)
+(`tests/test_sub.py` imports `paths` alongside `ops` at module level for these,
+plus `subprocess` and `pathlib.Path` for the quiet-mode tests.)
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -528,6 +598,7 @@ def run_sub(
     context: str = "task",
     fanout_feature: str = "",
     keep_forks: bool = False,
+    quiet: bool = False,
 ) -> int:
     """Execute one delegated subagent task on codex. context='task' resumes
     a freshly seeded empty rollout in the session cwd (claude wrote a
@@ -535,7 +606,15 @@ def run_sub(
     and resumes that instead. Either way the worker runs in a tandem-authored
     'tandem-sub' rollout that is never a sync source and never adoptable as
     the pair's own codex session, and is disposed of on exit. The brief is
-    passed through verbatim. Exit code mirrors codex."""
+    passed through verbatim. Exit code mirrors codex.
+
+    quiet=True is the bridge-agent mode: codex's raw transcript goes to a log
+    file and this command's ENTIRE stdout becomes the worker's final message
+    (via codex's own `-o/--output-last-message`). With inherited stdio the
+    caller would instead get the whole exec log — header, actions, token
+    counts — and asking a cheap relay model to extract "the final message"
+    from that is unreliable. quiet=False is byte-for-byte unchanged: stdio is
+    inherited so manual runs still stream live."""
     adapter = get_adapter("codex")
     argv = [adapter.binary, "exec", "--skip-git-repo-check"]
     if model:
@@ -547,9 +626,17 @@ def run_sub(
             sub_id, sub_path = fork_shadow(store, session)
     else:
         sub_id, sub_path = seed_sub_rollout(session)
-    argv += ["resume", sub_id, task]
 
     sub_root = paths.tandem_home() / "subagents" / session.tandem_id
+    last_path = log_path = None
+    if quiet:
+        logs = sub_root / "logs"
+        logs.mkdir(parents=True, exist_ok=True)
+        last_path, log_path = logs / f"{sub_id}.last", logs / f"{sub_id}.log"
+        # exec-level flag: must precede the `resume` subcommand, like -m
+        argv += ["-o", str(last_path)]
+    argv += ["resume", sub_id, task]
+
     marker = sub_root / "running" / f"{sub_id}.json"
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps({
@@ -557,7 +644,12 @@ def run_sub(
         "task_preview": task[:120],
     }))
     try:
-        code = _run(argv, cwd=session.cwd).returncode
+        if quiet:
+            with open(log_path, "wb") as fh:
+                code = _run(argv, cwd=session.cwd, stdout=fh,
+                            stderr=subprocess.STDOUT).returncode
+        else:
+            code = _run(argv, cwd=session.cwd).returncode
     finally:
         marker.unlink(missing_ok=True)
         if keep_forks:
@@ -565,7 +657,32 @@ def run_sub(
             sub_path.rename(sub_root / sub_path.name)
         else:
             sub_path.unlink(missing_ok=True)
+        if quiet:
+            _relay_last_message(last_path, log_path)
     return code
+
+
+def _relay_last_message(last_path: Path, log_path: Path, tail: int = 50) -> None:
+    """Print exactly what the bridge should return as its final message: the
+    worker's last message, or — when codex died before writing one — the tail
+    of its log, so a failed relay still carries the error text instead of
+    reporting an empty failure. Never prefixes or wraps: the caller's whole
+    stdout is the payload. Both files are retained as the debugging trail."""
+    text = ""
+    try:
+        text = last_path.read_text(errors="replace")
+    except OSError:
+        pass
+    if not text.strip():
+        try:
+            lines = log_path.read_text(errors="replace").splitlines()
+        except OSError:
+            lines = []
+        text = "\n".join(lines[-tail:])
+    if not text:
+        return
+    sys.stdout.write(text if text.endswith("\n") else text + "\n")
+    sys.stdout.flush()
 ```
 
 Add `SUB_SEED_NOTE` to `src/tandem/constants.py`:
@@ -624,6 +741,28 @@ class TestSubCli:
         assert r.exit_code == 0
         assert calls["kw"]["model"] == "gpt-x-mini"
         assert calls["kw"]["context"] == "full"
+        assert calls["kw"]["quiet"] is False
+
+    def test_sub_quiet_flag_forwards(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(cli.main, ["sub", "-q", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["quiet"] is True
+
+    def test_sub_empty_task_errors(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        r = click.testing.CliRunner().invoke(cli.main, ["sub"], input="  \n")
+        assert r.exit_code == 1
+        assert "empty task" in r.output
 
     def test_sub_empty_task_errors(self, env_factory, monkeypatch):
         import click.testing
@@ -649,8 +788,13 @@ In `src/tandem/cli.py`, add after `run_cmd`:
               type=click.Choice(["task", "full"]), default=None,
               help="Worker context: cold task-only, or a full fork of the "
                    "paired session (config policy decides by default).")
+@click.option("-q", "--quiet", is_flag=True,
+              help="Print only the worker's final message (raw codex output "
+                   "goes to a log under ~/.tandem/subagents/<id>/logs). Used "
+                   "by the bridge agent, which relays stdout verbatim.")
 @click.argument("task", required=False)
-def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
+def sub(model: str | None, context_mode: str | None, quiet: bool,
+        task: str | None) -> None:
     """Run one delegated subagent task on codex (task argument or stdin).
 
     Used by the tandem plugin's codex-worker bridge; also works manually."""
@@ -672,6 +816,7 @@ def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
             context=context_mode or ("full" if cfg.context == "full" else "task"),
             fanout_feature=cfg.fanout_feature,
             keep_forks=cfg.keep_forks,
+            quiet=quiet,
         )
     sys.exit(code)
 ```
@@ -1033,7 +1178,7 @@ git commit -m "feat: tandem hook-route — PreToolUse reroute of Agent dispatche
 - Test: `tests/test_plugin.py`
 
 **Interfaces:**
-- Consumes: the CLI commands `tandem hook-route` (Task 4) and `tandem sub` (Task 3).
+- Consumes: the CLI commands `tandem hook-route` (Task 4) and `tandem sub -q` (Task 3) — the bridge depends on quiet mode, where the command's entire stdout is the worker's final message.
 - Produces: an installable local plugin. Loaded for development/E2E with `claude --plugin-dir /Users/bhavya/git/tandem/plugin` (verify the flag spelling with `claude --help`; the plugins doc also documents marketplace installs for distribution later).
 
 - [ ] **Step 1: Write the failing tests**
@@ -1075,6 +1220,14 @@ def test_bridge_agent_definition():
     assert "tandem sub" in body
     assert "verbatim" in body
     assert "[tandem-sub failed]" in body
+    # quiet mode: the command's whole output IS the final message, so the
+    # relay has nothing to extract (inherited stdio would hand it codex's
+    # entire exec log instead)
+    assert "tandem sub -q" in body
+    # a fixed heredoc delimiter is a shell-injection hazard: a task message
+    # containing that line truncates the brief and runs the rest as shell
+    assert "TANDEM_TASK_EOF_" in body
+    assert re.search(r"unless .*appears|appears .*in the task", body)
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -1124,19 +1277,27 @@ tools: Bash(tandem sub:*)
 
 You are a relay between this session and a codex worker. Do exactly this:
 
-1. Run ONE command: `tandem sub` with your ENTIRE task message — every
+1. Run ONE command: `tandem sub -q` with your ENTIRE task message — every
    line, byte-for-byte, nothing added or removed — on stdin, via heredoc:
 
    ```
-   tandem sub <<'TANDEM_TASK_EOF'
+   tandem sub -q <<'TANDEM_TASK_EOF'
    <your entire task message here>
    TANDEM_TASK_EOF
    ```
 
+   Choose the delimiter BEFORE writing the command: use `TANDEM_TASK_EOF`
+   unless that string appears anywhere in the task message; in that case
+   append random digits (e.g. `TANDEM_TASK_EOF_84613`) and check again,
+   until the delimiter appears nowhere in the message. A delimiter that
+   collides with a line of the task ends the heredoc early — the brief is
+   truncated and the rest of it runs as shell commands.
+
    Set the Bash tool's timeout parameter to 600000 (codex runs are long).
 
-2. If the command exits 0: return its final message as your final message,
-   verbatim — no summary, no commentary, no added headers.
+2. If the command exits 0: its entire output IS the worker's final message.
+   Return that output as your final message, verbatim — no summary, no
+   commentary, no added headers, nothing trimmed.
 
 3. If it exits nonzero: return its output prefixed with
    `[tandem-sub failed]` and stop. Do not attempt the task yourself.

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -314,41 +314,108 @@ git commit -m "feat: fork_shadow — ephemeral codex rollout copies for subagent
 
 **Files:**
 - Modify: `src/tandem/ops.py` (append after `fork_shadow`)
-- Modify: `src/tandem/cli.py` (new command after `run_cmd`; add `import json` to module imports)
+- Modify: `src/tandem/cli.py` (new command after `run_cmd`)
+- Modify: `src/tandem/harness/codex.py` (extract `session_meta` / `rollout_path` so a rollout can be authored with a different originator)
+- Modify: `src/tandem/constants.py` (`SUB_SEED_NOTE`)
 - Test: `tests/test_sub.py` (extend)
 
 **Interfaces:**
 - Consumes: `fork_shadow`, `_sub_lock`, `_run` seam (Task 2); `load_subagents_config`, `SubagentsConfig` (Task 1); `get_adapter`, `paths.tandem_home`.
-- Produces: `run_sub(store, session, task, *, model: str = "", context: str = "task", fanout_feature: str = "", keep_forks: bool = False) -> int` and the `tandem sub` command (`-m/--model`, `--context task|full`, task from argument or stdin). The bridge agent (Task 5) and status (Task 6) rely on: exit code mirrors codex exec; running-marker files under `$TANDEM_HOME/subagents/<tandem-id>/running/<run-id>.json` with keys `model`, `context`, `task_preview`, `pid`; retained forks moved to `$TANDEM_HOME/subagents/<tandem-id>/`.
+- Produces: `run_sub(store, session, task, *, model: str = "", context: str = "task", fanout_feature: str = "", keep_forks: bool = False) -> int`, `seed_sub_rollout(session) -> tuple[str, Path]`, and the `tandem sub` command (`-m/--model`, `--context task|full`, task from argument or stdin). The bridge agent (Task 5) and status (Task 6) rely on: exit code mirrors codex exec; running-marker files under `$TANDEM_HOME/subagents/<tandem-id>/running/<run-id>.json` with keys `model`, `context`, `task_preview`, `pid`; retained sub rollouts moved to `$TANDEM_HOME/subagents/<tandem-id>/`.
+
+**Both contexts resume a tandem-authored rollout.** A cold `codex exec` would write an ordinary rollout in the session cwd (non-tandem originator, fresh mtime) — exactly what `await_codex_rollout` looks for — so the next codex-id capture would bind the pair's `codex_session_id` to a throwaway worker transcript that `run_sub` then deletes. `context='task'` therefore seeds its own minimal `originator: "tandem-sub"` rollout and resumes that; Task 2's discovery guard then covers every sub rollout, fork or seed.
 
 - [ ] **Step 1: Write the failing op tests**
 
 Append to `tests/test_sub.py`:
 
 ```python
+class TestSeedSubRollout:
+    def test_seed_is_a_resumable_tandem_sub_rollout(self, env_factory):
+        from tandem.doctor import validate_transcript
+
+        env = env_factory(active="claude")
+        seed_id, seed_path = ops.seed_sub_rollout(env.session)
+
+        assert validate_transcript("codex", seed_path, seed_id) == []
+        entries = read_jsonl(seed_path)
+        meta = entries[0]
+        assert meta["payload"]["id"] == seed_id
+        assert meta["payload"]["session_id"] == seed_id
+        assert meta["payload"]["cwd"] == env.cwd
+        assert meta["payload"]["originator"] == "tandem-sub"
+        assert meta["payload"]["model_provider"] == "openai"
+        # minimal: the meta plus one note (response_item + event_msg)
+        assert len(entries) == 3
+
+    def test_seed_carries_no_history_and_drains_nothing(self, env_factory):
+        env = env_factory(active="claude")
+        write_line(env.claude_shadow, claude_user("pair-only context"))
+        before_bytes = env.codex_shadow.read_bytes()
+        before = env.store.get_cursor(env.session.tandem_id, "claude")
+
+        _, seed_path = ops.seed_sub_rollout(env.session)
+
+        assert "pair-only context" not in seed_path.read_text()
+        assert env.codex_shadow.read_bytes() == before_bytes
+        after = env.store.get_cursor(env.session.tandem_id, "claude")
+        assert after.byte_offset == before.byte_offset
+        assert after.line_index == before.line_index
+
+    def test_seed_is_not_adopted_as_a_freshly_minted_codex_session(self, env_factory):
+        env = env_factory(active="claude")
+        started = time.time()
+        ops.seed_sub_rollout(env.session)
+        assert await_codex_rollout(env.cwd, started, timeout=0) is None
+
+
 class _R:
     def __init__(self, code=0):
         self.returncode = code
 
 
 class TestRunSub:
-    def test_task_context_is_cold_exec(self, env_factory, monkeypatch):
+    def test_task_context_resumes_a_tandem_sub_seed(self, env_factory, monkeypatch):
+        """A cold worker resumes its own seeded rollout rather than exec-ing
+        fresh: a plain `codex exec` writes an ordinary rollout in the session
+        cwd, and rollout discovery would then bind the pair's codex id to that
+        throwaway (which run_sub deletes on the way out)."""
         env = env_factory(active="claude")
         calls = {}
+        started = time.time()
 
         def fake_run(argv, cwd=None, **kw):
             calls["argv"], calls["cwd"] = argv, cwd
+            seed = paths.find_codex_rollout(argv[argv.index("resume") + 1])
+            calls["meta"] = read_jsonl(seed)[0]
+            # while the worker runs, the seed must not look like a fresh codex
+            calls["adopted"] = await_codex_rollout(env.cwd, started, timeout=0)
             return _R(0)
 
         monkeypatch.setattr(ops, "_run", fake_run)
         code = ops.run_sub(env.store, env.session, "audit the README",
                            model="gpt-x-mini", context="task")
         assert code == 0
-        assert calls["argv"] == [
-            "codex", "exec", "--skip-git-repo-check",
-            "-m", "gpt-x-mini", "audit the README",
-        ]
+        argv = calls["argv"]
+        assert argv[:5] == ["codex", "exec", "--skip-git-repo-check",
+                            "-m", "gpt-x-mini"]
+        assert argv[5] == "resume"
+        seed_id = argv[6]
+        assert seed_id != env.session.codex_session_id
+        assert argv[7:] == ["audit the README"]
         assert calls["cwd"] == env.cwd
+        assert calls["meta"]["payload"]["originator"] == "tandem-sub"
+        assert calls["meta"]["payload"]["cwd"] == env.cwd
+        assert calls["adopted"] is None
+        assert paths.find_codex_rollout(seed_id) is None  # cleaned up after
+
+    def test_task_context_keep_forks_retains_seed(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(0))
+        ops.run_sub(env.store, env.session, "t", keep_forks=True)
+        kept = list((paths.tandem_home() / "subagents"
+                     / env.session.tandem_id).glob("rollout-*.jsonl"))
+        assert len(kept) == 1
 
     def test_no_model_omits_flag_and_fanout_adds_enable(self, env_factory,
                                                         monkeypatch):
@@ -377,7 +444,6 @@ class TestRunSub:
         fork_id = argv[argv.index("resume") + 1]
         assert fork_id != env.session.codex_session_id
         # the fork was cleaned up (keep_forks=False)
-        from tandem import paths
         assert paths.find_codex_rollout(fork_id) is None
         kept = list((paths.tandem_home() / "subagents").rglob("*.jsonl"))
         assert kept == []
@@ -388,7 +454,6 @@ class TestRunSub:
         monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(0))
         ops.run_sub(env.store, env.session, "deep task", context="full",
                     keep_forks=True)
-        from tandem import paths
         kept = list((paths.tandem_home() / "subagents"
                      / env.session.tandem_id).glob("rollout-*.jsonl"))
         assert len(kept) == 1
@@ -399,7 +464,6 @@ class TestRunSub:
         assert ops.run_sub(env.store, env.session, "t") == 3
 
     def test_running_marker_lifecycle(self, env_factory, monkeypatch):
-        from tandem import paths
         env = env_factory(active="claude")
         seen = {}
 
@@ -407,15 +471,18 @@ class TestRunSub:
             run_dir = (paths.tandem_home() / "subagents"
                        / env.session.tandem_id / "running")
             seen["during"] = list(run_dir.glob("*.json"))
+            # read the marker while the run is in flight; it is gone after
+            seen["payload"] = [json.loads(p.read_text()) for p in seen["during"]]
             return _R(0)
 
         monkeypatch.setattr(ops, "_run", fake_run)
         ops.run_sub(env.store, env.session, "watch me")
         assert len(seen["during"]) == 1
-        assert json.loads(seen["during"][0].read_text())["task_preview"] \
-            == "watch me"
+        assert seen["payload"][0]["task_preview"] == "watch me"
         assert seen["during"][0].exists() is False  # removed on completion
 ```
+
+(`tests/test_sub.py` imports `paths` alongside `ops` at module level for these.)
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -424,9 +491,34 @@ Expected: `TestRunSub` FAILs with `AttributeError: ... no attribute 'run_sub'`; 
 
 - [ ] **Step 3: Implement `run_sub`**
 
-Append to `src/tandem/ops.py` (add `import os` to module imports):
+Append to `src/tandem/ops.py` (add `import os` to module imports). `seed_sub_rollout` builds its rollout from two small pieces factored out of `CodexAdapter.create_shadow_transcript` — `session_meta(cwd, session_id, originator="tandem")` and `rollout_path(session_id)` — so the seed differs from a shadow only in its originator (`fork_shadow` uses `rollout_path` too):
 
 ```python
+def seed_sub_rollout(session: PairedSession) -> tuple[str, Path]:
+    """Author the minimal rollout a cold (`context='task'`) worker resumes:
+    fresh uuid7 identity, originator 'tandem-sub', one seed note and no
+    shared history.
+
+    Cold runs resume this instead of `codex exec`-ing fresh because a plain
+    exec writes an ordinary rollout — non-tandem originator, session cwd,
+    fresh mtime — which `await_codex_rollout` would hand to the next
+    codex-id capture, binding the pair's codex_session_id to a throwaway
+    worker transcript tandem then deletes. Seeding keeps every sub rollout
+    behind the same discovery guard as forks.
+
+    Touches no cursor and no shadow: no drain, no `_sub_lock` needed.
+    Returns (seed_session_id, seed_path)."""
+    from .constants import SUB_SEED_NOTE
+
+    adapter = get_adapter("codex")
+    seed_id = adapter.mint_session_id()
+    seed_path = adapter.rollout_path(seed_id)
+    entries = [adapter.session_meta(session.cwd, seed_id, originator="tandem-sub")]
+    entries += adapter.render_note(SUB_SEED_NOTE)
+    append_jsonl_fsync(seed_path, entries)
+    return seed_id, seed_path
+
+
 def run_sub(
     store: StateStore,
     session: PairedSession,
@@ -437,26 +529,28 @@ def run_sub(
     fanout_feature: str = "",
     keep_forks: bool = False,
 ) -> int:
-    """Execute one delegated subagent task on codex. context='task' is a
-    cold `codex exec` in the session cwd (claude wrote a self-contained
-    brief for a cold worker); context='full' forks the shadow and resumes
-    it. The brief is passed through verbatim. Exit code mirrors codex."""
+    """Execute one delegated subagent task on codex. context='task' resumes
+    a freshly seeded empty rollout in the session cwd (claude wrote a
+    self-contained brief for a cold worker); context='full' forks the shadow
+    and resumes that instead. Either way the worker runs in a tandem-authored
+    'tandem-sub' rollout that is never a sync source and never adoptable as
+    the pair's own codex session, and is disposed of on exit. The brief is
+    passed through verbatim. Exit code mirrors codex."""
     adapter = get_adapter("codex")
     argv = [adapter.binary, "exec", "--skip-git-repo-check"]
     if model:
         argv += ["-m", model]
     if fanout_feature:
         argv += ["--enable", fanout_feature]
-    fork_path: Path | None = None
-    fork_id = ""
     if context == "full":
         with _sub_lock():
-            fork_id, fork_path = fork_shadow(store, session)
-        argv += ["resume", fork_id]
-    argv.append(task)
+            sub_id, sub_path = fork_shadow(store, session)
+    else:
+        sub_id, sub_path = seed_sub_rollout(session)
+    argv += ["resume", sub_id, task]
 
     sub_root = paths.tandem_home() / "subagents" / session.tandem_id
-    marker = sub_root / "running" / f"{fork_id or uuid7()}.json"
+    marker = sub_root / "running" / f"{sub_id}.json"
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps({
         "model": model, "context": context, "pid": os.getpid(),
@@ -466,13 +560,18 @@ def run_sub(
         code = _run(argv, cwd=session.cwd).returncode
     finally:
         marker.unlink(missing_ok=True)
-        if fork_path is not None:
-            if keep_forks:
-                sub_root.mkdir(parents=True, exist_ok=True)
-                fork_path.rename(sub_root / fork_path.name)
-            else:
-                fork_path.unlink(missing_ok=True)
+        if keep_forks:
+            sub_root.mkdir(parents=True, exist_ok=True)
+            sub_path.rename(sub_root / sub_path.name)
+        else:
+            sub_path.unlink(missing_ok=True)
     return code
+```
+
+Add `SUB_SEED_NOTE` to `src/tandem/constants.py`:
+
+```python
+SUB_SEED_NOTE = "[tandem] Delegated subagent worker session (no shared history)."
 ```
 
 - [ ] **Step 4: Run op tests to verify they pass**
@@ -540,7 +639,7 @@ Expected: FAIL with `Error: No such command 'sub'`
 
 - [ ] **Step 6: Implement the CLI command**
 
-In `src/tandem/cli.py`, add `import json` to the module imports, and add after `run_cmd`:
+In `src/tandem/cli.py`, add after `run_cmd`:
 
 ```python
 @main.command()
@@ -585,7 +684,8 @@ Expected: all pass
 - [ ] **Step 8: Commit**
 
 ```bash
-git add src/tandem/ops.py src/tandem/cli.py tests/test_sub.py
+git add src/tandem/ops.py src/tandem/cli.py src/tandem/harness/codex.py \
+        src/tandem/constants.py tests/test_sub.py
 git commit -m "feat: tandem sub — execute delegated subagent tasks on codex"
 ```
 

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -4,14 +4,14 @@
 
 **Goal:** Native Claude Code subagent dispatches transparently execute on a cheap Codex model, via a PreToolUse reroute hook + a `codex-worker` bridge agent + a `tandem sub` execution engine.
 
-**Architecture:** A Claude plugin (static files, never a process) registers a PreToolUse hook running `tandem hook-route`, which rewrites `Agent` dispatches to a Bash-only bridge agent; the bridge runs `tandem sub`, which executes the task on codex — cold `codex exec` by default, or a fork of the shadow rollout for full context. Results return through Claude's native tool-result/task-notification machinery; tandem's existing sync mirrors everything. Spec: `docs/specs/2026-07-31-codex-subagents-design.md`.
+**Architecture:** A Claude plugin (static files, never a process) registers a PreToolUse hook running `tandem hook-route`, which rewrites `Agent` dispatches to a Bash-only bridge agent; the bridge runs `tandem sub`, which executes the task on codex — resuming a freshly seeded empty `tandem-sub` rollout by default, or a fork of the shadow rollout for full context. Results return through Claude's native tool-result/task-notification machinery; tandem's existing sync mirrors everything. Spec: `docs/specs/2026-07-31-codex-subagents-design.md`.
 
 **Tech Stack:** Python 3.11+, click, stdlib `tomllib`/`fcntl`/`sqlite3`, pytest (+ `click.testing.CliRunner`), existing tandem modules (`ops`, `paths`, `state`, `harness`, `doctor`).
 
 ## Global Constraints
 
 - Python ≥3.11; **no new dependencies** (config uses stdlib `tomllib`, locking uses `fcntl`).
-- `tandem hook-route` must **never exit 2** (exit 2 blocks the dispatch); every failure path exits 0 — failure mode is "no savings", never "broken subagents".
+- `tandem hook-route` must **never exit 2** (exit 2 blocks the dispatch); every failure path exits 0 — failure mode is "no savings", never "broken subagents". Caveat: click exits 2 on a usage error *before* our code runs (older tandem on PATH without the subcommand), so the hook is registered as `tandem hook-route || true` — the shell guard is the load-bearing half of the guarantee.
 - The task brief is forwarded **verbatim — no truncation, no summarization** at any step (stdin transport, not argv).
 - Fork rollouts are **never registered as sync sources**: no cursors created, no echo-suppression changes, shadow untouched.
 - `updatedInput` replaces the **entire** input object: carry every original field, rewrite exactly `subagent_type`, `model`, `prompt`.
@@ -755,14 +755,6 @@ class TestSubCli:
         r = click.testing.CliRunner().invoke(cli.main, ["sub", "-q", "brief"])
         assert r.exit_code == 0
         assert calls["kw"]["quiet"] is True
-
-    def test_sub_empty_task_errors(self, env_factory, monkeypatch):
-        import click.testing
-        env = env_factory(active="claude")
-        cli = self._cli_env(env, monkeypatch)
-        r = click.testing.CliRunner().invoke(cli.main, ["sub"], input="  \n")
-        assert r.exit_code == 1
-        assert "empty task" in r.output
 
     def test_sub_empty_task_errors(self, env_factory, monkeypatch):
         import click.testing

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -1367,8 +1367,46 @@ class TestDoctorAndStatus:
              "task_preview": "audit the README", "pid": 1}))
         (sub_root / "rollout-x-1.jsonl").write_text("{}\n")
         r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert r.exit_code == 0
         assert "subagent running: gpt-x-mini (task) audit the README" in r.output
         assert "retained forks: 1" in r.output
+
+    def test_doctor_survives_non_object_auth_json(self, env_factory, monkeypatch):
+        """auth.json that is valid JSON but not an object must not crash
+        doctor: `.get` on a list raises AttributeError, not ValueError."""
+        from tandem import paths
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        auth = paths.codex_home() / "auth.json"
+        auth.parent.mkdir(parents=True, exist_ok=True)
+        auth.write_text("[]")
+        report = run_doctor(env.store, env.session, live=False)
+        assert not any("API-key" in c.message for c in report.checks)
+        assert not any("OPENAI_API_KEY" in c.message for c in report.checks)
+
+    def test_status_skips_non_object_marker(self, env_factory, monkeypatch):
+        """A marker holding valid-but-non-object JSON is skipped, not fatal."""
+        import click.testing
+        from tandem import cli, paths
+        env = env_factory(active="claude")
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        run_dir = (paths.tandem_home() / "subagents" / env.session.tandem_id
+                   / "running")
+        run_dir.mkdir(parents=True)
+        # sorts first, so it would crash before the good marker is reached
+        (run_dir / "bad.json").write_text('"3"')
+        (run_dir / "good.json").write_text(json.dumps(
+            {"model": "gpt-x-mini", "context": "task",
+             "task_preview": "audit the README", "pid": 1}))
+        r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert r.exit_code == 0
+        assert "subagent running: gpt-x-mini (task) audit the README" in r.output
+        assert r.output.count("subagent running:") == 1
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -1397,13 +1435,16 @@ def _subagent_checks(report: DoctorReport, session) -> None:
     auth_path = paths.codex_home() / "auth.json"
     try:
         auth = json.loads(auth_path.read_text())
-        if auth.get("OPENAI_API_KEY") and not auth.get("tokens"):
-            report.warn(
-                "subagents: codex auth is API-key based — subagent runs "
-                "will bill the API, not the subscription"
-            )
     except (OSError, ValueError):
-        pass
+        auth = None
+    # valid JSON that is not an object would make .get raise AttributeError,
+    # which no doctor check may do: an unreadable auth.json is a skipped
+    # check, never a traceback.
+    if isinstance(auth, dict) and auth.get("OPENAI_API_KEY") and not auth.get("tokens"):
+        report.warn(
+            "subagents: codex auth is API-key based — subagent runs "
+            "will bill the API, not the subscription"
+        )
     claude_md = Path(session.cwd) / "CLAUDE.md"
     try:
         if "tandem:shared:begin" not in claude_md.read_text():
@@ -1424,13 +1465,13 @@ In `src/tandem/cli.py` `status()`, after the quarantine block:
         sub_root = paths.tandem_home() / "subagents" / session.tandem_id
         run_dir = sub_root / "running"
         if run_dir.is_dir():
-            import json as _json
-
             for m in sorted(run_dir.glob("*.json")):
                 try:
-                    d = _json.loads(m.read_text())
+                    d = json.loads(m.read_text())
                 except (OSError, ValueError):
                     continue
+                if not isinstance(d, dict):
+                    continue  # non-object marker: skip it, never traceback
                 click.echo(
                     f"  subagent running: {d.get('model') or 'default-model'} "
                     f"({d.get('context')}) {d.get('task_preview', '')}"

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -1334,6 +1334,24 @@ Append to `tests/test_sub.py`:
 
 ```python
 class TestDoctorAndStatus:
+    def test_doctor_warns_when_no_model_is_configured(self, env_factory,
+                                                      monkeypatch):
+        """The shipped defaults are route="all" + model="" — everything is
+        rerouted, but with no `-m` the worker runs on the codex account's
+        default, which is the frontier tier (S1: gpt-5.6-sol)."""
+        from tandem import paths
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        report = run_doctor(env.store, env.session, live=False)
+        assert any("no model configured" in c.message for c in report.checks
+                   if c.status == "warn")
+        (paths.tandem_home() / "config.toml").write_text(
+            '[subagents]\nmodel = "gpt-5.6-luna"\n')
+        report = run_doctor(env.store, env.session, live=False)
+        assert not any("no model configured" in c.message
+                       for c in report.checks)
+
     def test_doctor_warns_on_api_key_env(self, env_factory, monkeypatch):
         from tandem.doctor import run_doctor
         env = env_factory(active="claude")
@@ -1420,13 +1438,26 @@ Append to `src/tandem/doctor.py` (add `import os` to module imports), and call `
 
 ```python
 def _subagent_checks(report: DoctorReport, session) -> None:
-    """Subagent routing hygiene: billing follows codex auth, and codex
-    workers only see CLAUDE.md content inside the tandem:shared block."""
+    """Subagent routing hygiene: routing is on by default but the model is
+    not chosen for you, billing follows codex auth, and codex workers only
+    see CLAUDE.md content inside the tandem:shared block."""
     from . import paths
     from .config import load_subagents_config
 
-    if load_subagents_config().route == "off":
+    cfg = load_subagents_config()
+    if cfg.route == "off":
         return
+    # model="" means no `-m`, i.e. the codex account default — the frontier
+    # tier on every plan seen so far. Combined with the route="all" default
+    # that silently sends every dispatch to the most expensive model, so it
+    # is a warning, not a note. The dataclass default stays empty on
+    # purpose: a baked-in id would 400 on accounts that lack it.
+    if not cfg.model:
+        report.warn(
+            "subagents: no model configured — workers will use your codex "
+            "account's default (set [subagents] model in "
+            "~/.tandem/config.toml to a cheap tier)"
+        )
     if os.environ.get("OPENAI_API_KEY"):
         report.warn(
             "subagents: OPENAI_API_KEY is set — codex may bill the API "

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -757,6 +757,12 @@ class TestRewrite:
         assert ui["description"] == "short label"   # untouched
         assert ui["run_in_background"] is True      # unknown fields carried
 
+    def test_task_alias_is_rerouted(self):
+        payload = _payload()
+        payload["tool_name"] = "Task"  # the documented alias of Agent
+        ui = _route(payload)["hookSpecificOutput"]["updatedInput"]
+        assert ui["subagent_type"] == BRIDGE_AGENT
+
     def test_named_agent_body_is_inlined(self, tmp_path):
         agents = tmp_path / "proj" / ".claude" / "agents"
         agents.mkdir(parents=True)
@@ -785,8 +791,15 @@ class TestPassthrough:
         assert _route(_payload(), has_session=False) is None
         assert _route(_payload(), codex_ok=False) is None
 
+    def test_other_tool_names_pass_through(self):
+        payload = _payload()          # otherwise fully rewritable
+        payload["tool_name"] = "Bash"
+        assert _route(payload) is None
+        del payload["tool_name"]
+        assert _route(payload) is None
+
     def test_malformed_input(self):
-        assert _route({"tool_input": "not a dict"}) is None
+        assert _route({"tool_name": "Agent", "tool_input": "not a dict"}) is None
         assert _route(_payload(prompt="")) is None
 
 
@@ -876,6 +889,10 @@ def route(
     has_session: bool,
     codex_ok: bool,
 ) -> dict | None:
+    # defense in depth: the plugin's matcher is `Agent|Task`, but a matcher is
+    # config we do not control at call time — never rewrite another tool's input
+    if payload.get("tool_name") not in ("Agent", "Task"):
+        return None
     if cfg.route != "all" or not has_session or not codex_ok:
         return None
     tool_input = payload.get("tool_input")
@@ -961,9 +978,15 @@ In `src/tandem/cli.py`, after `sub`:
 def hook_route_cmd() -> None:
     """Claude Code PreToolUse hook: reroute subagent dispatches to codex.
 
-    Reads hook JSON on stdin; prints a decision or nothing. ALWAYS exits 0
-    — exit 2 would block the dispatch, and any failure here must degrade
-    to native behavior."""
+    Reads hook JSON on stdin; prints a decision or nothing. This function
+    ALWAYS exits 0 — exit 2 would block the dispatch, and any failure here
+    must degrade to native behavior.
+
+    The function body is not the whole story: click's usage-error path exits
+    2 before this ever runs (version skew — plugin installed, an older
+    tandem on PATH without this subcommand — or a stray argument). So the
+    hook MUST be registered as `tandem hook-route || true`; that shell guard
+    is what makes exit 2 unreachable in practice."""
     try:
         from .config import load_subagents_config
         from .hookroute import route
@@ -1037,7 +1060,9 @@ def test_hooks_register_hook_route():
     entries = h["hooks"]["PreToolUse"]
     assert entries[0]["matcher"] == "Agent|Task"
     cmds = [hk["command"] for hk in entries[0]["hooks"]]
-    assert cmds == ["tandem hook-route"]
+    # `|| true` is load-bearing: click exits 2 on a usage error (older
+    # tandem on PATH without the subcommand), and exit 2 blocks dispatches
+    assert cmds == ["tandem hook-route || true"]
 
 
 def test_bridge_agent_definition():
@@ -1079,7 +1104,7 @@ Expected: FAIL with `FileNotFoundError`
       {
         "matcher": "Agent|Task",
         "hooks": [
-          {"type": "command", "command": "tandem hook-route"}
+          {"type": "command", "command": "tandem hook-route || true"}
         ]
       }
     ]

--- a/docs/plans/2026-07-31-codex-subagents.md
+++ b/docs/plans/2026-07-31-codex-subagents.md
@@ -1,0 +1,1236 @@
+# Codex-Model Subagents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Native Claude Code subagent dispatches transparently execute on a cheap Codex model, via a PreToolUse reroute hook + a `codex-worker` bridge agent + a `tandem sub` execution engine.
+
+**Architecture:** A Claude plugin (static files, never a process) registers a PreToolUse hook running `tandem hook-route`, which rewrites `Agent` dispatches to a Bash-only bridge agent; the bridge runs `tandem sub`, which executes the task on codex — cold `codex exec` by default, or a fork of the shadow rollout for full context. Results return through Claude's native tool-result/task-notification machinery; tandem's existing sync mirrors everything. Spec: `docs/specs/2026-07-31-codex-subagents-design.md`.
+
+**Tech Stack:** Python 3.11+, click, stdlib `tomllib`/`fcntl`/`sqlite3`, pytest (+ `click.testing.CliRunner`), existing tandem modules (`ops`, `paths`, `state`, `harness`, `doctor`).
+
+## Global Constraints
+
+- Python ≥3.11; **no new dependencies** (config uses stdlib `tomllib`, locking uses `fcntl`).
+- `tandem hook-route` must **never exit 2** (exit 2 blocks the dispatch); every failure path exits 0 — failure mode is "no savings", never "broken subagents".
+- The task brief is forwarded **verbatim — no truncation, no summarization** at any step (stdin transport, not argv).
+- Fork rollouts are **never registered as sync sources**: no cursors created, no echo-suppression changes, shadow untouched.
+- `updatedInput` replaces the **entire** input object: carry every original field, rewrite exactly `subagent_type`, `model`, `prompt`.
+- Run tests with `uv run pytest`; commit after every task; follow existing patterns (`Check`/`DoctorReport`, `_run` seam, `env_factory` fixture, `append_jsonl_fsync`).
+- **Documented deviation from the spec:** the spec's `allow_fanout = true` boolean is implemented as a `fanout_feature` string (the `--enable <name>` feature name; empty = don't pass the flag) because spike S2 has not yet pinned the name. Task 7 runs S2 and updates the spec.
+
+## File Structure
+
+- Create `src/tandem/config.py` — read `[subagents]` from `$TANDEM_HOME/config.toml`; defaults on any error.
+- Create `src/tandem/hookroute.py` — pure reroute decision logic + agent-definition lookup (no I/O beyond reading agent files).
+- Modify `src/tandem/ops.py` — add `fork_shadow()`, `run_sub()`, `_sub_lock()`.
+- Modify `src/tandem/cli.py` — add `sub` and `hook-route` commands; extend `status`.
+- Modify `src/tandem/doctor.py` — subagent auth/shared-block checks.
+- Create `plugin/` — `.claude-plugin/plugin.json`, `hooks/hooks.json`, `agents/codex-worker.md`.
+- Create tests: `tests/test_config.py`, `tests/test_hookroute.py`, `tests/test_sub.py`, `tests/test_plugin.py`.
+
+---
+
+### Task 1: Subagents config module
+
+**Files:**
+- Create: `src/tandem/config.py`
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Produces: `SubagentsConfig` frozen dataclass with fields `route: str = "all"`, `model: str = ""`, `context: str = "match"`, `fanout_feature: str = ""`, `keep_forks: bool = False`; and `load_subagents_config() -> SubagentsConfig`. Later tasks import both from `tandem.config`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_config.py
+"""[subagents] config: defaults on missing/broken file, validated values."""
+
+from tandem.config import SubagentsConfig, load_subagents_config
+
+
+def test_defaults_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+    cfg = load_subagents_config()
+    assert cfg == SubagentsConfig()
+    assert (cfg.route, cfg.model, cfg.context) == ("all", "", "match")
+    assert (cfg.fanout_feature, cfg.keep_forks) == ("", False)
+
+
+def test_reads_values(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text(
+        '[subagents]\nroute = "off"\nmodel = "gpt-x-mini"\n'
+        'context = "full"\nfanout_feature = "collab"\nkeep_forks = true\n'
+    )
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    cfg = load_subagents_config()
+    assert cfg.route == "off"
+    assert cfg.model == "gpt-x-mini"
+    assert cfg.context == "full"
+    assert cfg.fanout_feature == "collab"
+    assert cfg.keep_forks is True
+
+
+def test_invalid_values_fall_back(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text(
+        '[subagents]\nroute = "sometimes"\ncontext = 7\nkeep_forks = "yes"\n'
+    )
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    cfg = load_subagents_config()
+    assert cfg == SubagentsConfig()  # every bad value -> default
+
+
+def test_broken_toml_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text("[subagents\nnot toml")
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    assert load_subagents_config() == SubagentsConfig()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tandem.config'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/tandem/config.py
+"""User configuration: $TANDEM_HOME/config.toml, [subagents] table only.
+
+Unknown keys are ignored and every error yields defaults — configuration
+must never be the reason subagent routing breaks (the hook's failure mode
+is 'dispatch natively', and this module upholds it)."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+
+from . import paths
+
+
+@dataclass(frozen=True)
+class SubagentsConfig:
+    route: str = "all"          # "all" | "off"
+    model: str = ""             # "" -> omit -m; codex's configured default
+    context: str = "match"      # "match" | "task" | "full"
+    fanout_feature: str = ""    # --enable <name>; "" -> flag not passed
+    keep_forks: bool = False
+
+
+_ROUTES = ("all", "off")
+_CONTEXTS = ("match", "task", "full")
+
+
+def load_subagents_config() -> SubagentsConfig:
+    try:
+        with open(paths.tandem_home() / "config.toml", "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return SubagentsConfig()
+    raw = data.get("subagents")
+    if not isinstance(raw, dict):
+        return SubagentsConfig()
+    d = SubagentsConfig()
+
+    def pick(key: str, kind: type, default, allowed=None):
+        v = raw.get(key, default)
+        if not isinstance(v, kind) or (allowed and v not in allowed):
+            return default
+        return v
+
+    return SubagentsConfig(
+        route=pick("route", str, d.route, _ROUTES),
+        model=pick("model", str, d.model),
+        context=pick("context", str, d.context, _CONTEXTS),
+        fanout_feature=pick("fanout_feature", str, d.fanout_feature),
+        keep_forks=pick("keep_forks", bool, d.keep_forks),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/config.py tests/test_config.py
+git commit -m "feat: subagents config table in ~/.tandem/config.toml"
+```
+
+---
+
+### Task 2: Shadow fork op
+
+**Files:**
+- Modify: `src/tandem/ops.py` (append after `run_oneoff`; extend module imports)
+- Test: `tests/test_sub.py` (new file)
+
+**Interfaces:**
+- Consumes: `drain_source(store, session, source, flush_dangling=True)`, `_create_codex_shadow_late(store, session)`, `source_transcript(session, "codex")` — all already in `ops.py`.
+- Produces: `fork_shadow(store: StateStore, session: PairedSession) -> tuple[str, Path]` returning `(fork_session_id, fork_rollout_path)`, and `_sub_lock()` context manager. Task 3 calls both.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_sub.py
+"""tandem sub: shadow forking and the subagent execution op."""
+
+import json
+
+from tandem import ops
+from tandem.util import read_jsonl
+
+from conftest import claude_user, write_line
+
+
+class TestForkShadow:
+    def test_fork_copies_shadow_with_new_identity(self, env_factory):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        write_line(env.claude_shadow, claude_user("context before fork"))
+
+        fork_id, fork_path = ops.fork_shadow(env.store, env.session)
+
+        assert fork_id != env.session.codex_session_id
+        assert fork_path.name.endswith(f"-{fork_id}.jsonl")
+        entries = read_jsonl(fork_path)
+        meta = entries[0]
+        assert meta["type"] == "session_meta"
+        assert meta["payload"]["id"] == fork_id
+        assert meta["payload"]["session_id"] == fork_id
+        assert meta["payload"]["originator"] == "tandem-sub"
+        assert meta["payload"]["model_provider"] == "openai"
+        # the pre-fork drain landed the claude turn in the fork's history
+        dump = json.dumps(entries)
+        assert "context before fork" in dump
+
+    def test_fork_is_structurally_resumable(self, env_factory):
+        from tandem.doctor import validate_transcript
+
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        fork_id, fork_path = ops.fork_shadow(env.store, env.session)
+        assert validate_transcript("codex", fork_path, fork_id) == []
+
+    def test_fork_leaves_shadow_and_cursors_alone(self, env_factory):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        before_bytes = env.codex_shadow.read_bytes()
+        before_cursor = env.store.get_cursor(env.session.tandem_id, "codex")
+
+        ops.fork_shadow(env.store, env.session)
+
+        assert env.codex_shadow.read_bytes() == before_bytes
+        after = env.store.get_cursor(env.session.tandem_id, "codex")
+        assert after.byte_offset == before_cursor.byte_offset
+        assert after.line_index == before_cursor.line_index
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sub.py -v`
+Expected: FAIL with `AttributeError: module 'tandem.ops' has no attribute 'fork_shadow'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `src/tandem/ops.py` module imports: `import fcntl`, `import json`, `from contextlib import contextmanager`, `from datetime import datetime, timezone`, and extend the `from .util import` needs by adding `from .util import append_jsonl_fsync, read_jsonl, uuid7`. Then append after `_file_size`:
+
+```python
+@contextmanager
+def _sub_lock():
+    """Serializes drain-then-fork across parallel `tandem sub` processes.
+    The cold task path never takes this lock — it touches no shared state."""
+    lock_path = paths.tandem_home() / "sub.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def fork_shadow(store: StateStore, session: PairedSession) -> tuple[str, Path]:
+    """Copy the codex shadow rollout into a fresh ephemeral rollout for one
+    subagent worker: same history, new uuid7 identity, originator
+    'tandem-sub'. The fork is NEVER registered as a sync source. Returns
+    (fork_session_id, fork_path)."""
+    if not session.codex_session_id:
+        _create_codex_shadow_late(store, session)
+        session = store.get_session(session.tandem_id) or session
+    drain_source(store, session, session.active, flush_dangling=True)
+    src = source_transcript(session, "codex")
+    if src is None:
+        raise SyncSetupError("codex shadow rollout not found")
+    entries = read_jsonl(src)
+    if not entries or entries[0].get("type") != "session_meta":
+        raise SyncSetupError("shadow rollout has no session_meta first line")
+    fork_id = uuid7()
+    meta = json.loads(json.dumps(entries[0]))  # deep copy
+    meta["payload"]["id"] = fork_id
+    meta["payload"]["session_id"] = fork_id
+    meta["payload"]["originator"] = "tandem-sub"
+    now = datetime.now(timezone.utc)
+    day_dir = paths.codex_sessions_dir() / now.strftime("%Y/%m/%d")
+    fname = f"rollout-{now.strftime('%Y-%m-%dT%H-%M-%S')}-{fork_id}.jsonl"
+    fork_path = day_dir / fname
+    append_jsonl_fsync(fork_path, [meta] + entries[1:])
+    return fork_id, fork_path
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sub.py tests/test_ops.py -v`
+Expected: all pass (existing ops tests must stay green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/ops.py tests/test_sub.py
+git commit -m "feat: fork_shadow — ephemeral codex rollout copies for subagents"
+```
+
+---
+
+### Task 3: `run_sub` op and the `tandem sub` CLI command
+
+**Files:**
+- Modify: `src/tandem/ops.py` (append after `fork_shadow`)
+- Modify: `src/tandem/cli.py` (new command after `run_cmd`; add `import json` to module imports)
+- Test: `tests/test_sub.py` (extend)
+
+**Interfaces:**
+- Consumes: `fork_shadow`, `_sub_lock`, `_run` seam (Task 2); `load_subagents_config`, `SubagentsConfig` (Task 1); `get_adapter`, `paths.tandem_home`.
+- Produces: `run_sub(store, session, task, *, model: str = "", context: str = "task", fanout_feature: str = "", keep_forks: bool = False) -> int` and the `tandem sub` command (`-m/--model`, `--context task|full`, task from argument or stdin). The bridge agent (Task 5) and status (Task 6) rely on: exit code mirrors codex exec; running-marker files under `$TANDEM_HOME/subagents/<tandem-id>/running/<run-id>.json` with keys `model`, `context`, `task_preview`, `pid`; retained forks moved to `$TANDEM_HOME/subagents/<tandem-id>/`.
+
+- [ ] **Step 1: Write the failing op tests**
+
+Append to `tests/test_sub.py`:
+
+```python
+class _R:
+    def __init__(self, code=0):
+        self.returncode = code
+
+
+class TestRunSub:
+    def test_task_context_is_cold_exec(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            calls["argv"], calls["cwd"] = argv, cwd
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "audit the README",
+                           model="gpt-x-mini", context="task")
+        assert code == 0
+        assert calls["argv"] == [
+            "codex", "exec", "--skip-git-repo-check",
+            "-m", "gpt-x-mini", "audit the README",
+        ]
+        assert calls["cwd"] == env.cwd
+
+    def test_no_model_omits_flag_and_fanout_adds_enable(self, env_factory,
+                                                        monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t", fanout_feature="collab")
+        assert "-m" not in calls["argv"]
+        assert ["--enable", "collab"] == calls["argv"][3:5]
+
+    def test_full_context_forks_resumes_and_deletes(self, env_factory,
+                                                    monkeypatch):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "deep task", context="full")
+        argv = calls["argv"]
+        assert "resume" in argv
+        fork_id = argv[argv.index("resume") + 1]
+        assert fork_id != env.session.codex_session_id
+        # the fork was cleaned up (keep_forks=False)
+        from tandem import paths
+        assert paths.find_codex_rollout(fork_id) is None
+        kept = list((paths.tandem_home() / "subagents").rglob("*.jsonl"))
+        assert kept == []
+
+    def test_full_context_keep_forks_retains(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(0))
+        ops.run_sub(env.store, env.session, "deep task", context="full",
+                    keep_forks=True)
+        from tandem import paths
+        kept = list((paths.tandem_home() / "subagents"
+                     / env.session.tandem_id).glob("rollout-*.jsonl"))
+        assert len(kept) == 1
+
+    def test_exit_code_mirrors_codex(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(3))
+        assert ops.run_sub(env.store, env.session, "t") == 3
+
+    def test_running_marker_lifecycle(self, env_factory, monkeypatch):
+        from tandem import paths
+        env = env_factory(active="claude")
+        seen = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            run_dir = (paths.tandem_home() / "subagents"
+                       / env.session.tandem_id / "running")
+            seen["during"] = list(run_dir.glob("*.json"))
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "watch me")
+        assert len(seen["during"]) == 1
+        assert json.loads(seen["during"][0].read_text())["task_preview"] \
+            == "watch me"
+        assert seen["during"][0].exists() is False  # removed on completion
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sub.py -v`
+Expected: `TestRunSub` FAILs with `AttributeError: ... no attribute 'run_sub'`; `TestForkShadow` stays green.
+
+- [ ] **Step 3: Implement `run_sub`**
+
+Append to `src/tandem/ops.py` (add `import os` to module imports):
+
+```python
+def run_sub(
+    store: StateStore,
+    session: PairedSession,
+    task: str,
+    *,
+    model: str = "",
+    context: str = "task",
+    fanout_feature: str = "",
+    keep_forks: bool = False,
+) -> int:
+    """Execute one delegated subagent task on codex. context='task' is a
+    cold `codex exec` in the session cwd (claude wrote a self-contained
+    brief for a cold worker); context='full' forks the shadow and resumes
+    it. The brief is passed through verbatim. Exit code mirrors codex."""
+    adapter = get_adapter("codex")
+    argv = [adapter.binary, "exec", "--skip-git-repo-check"]
+    if model:
+        argv += ["-m", model]
+    if fanout_feature:
+        argv += ["--enable", fanout_feature]
+    fork_path: Path | None = None
+    fork_id = ""
+    if context == "full":
+        with _sub_lock():
+            fork_id, fork_path = fork_shadow(store, session)
+        argv += ["resume", fork_id]
+    argv.append(task)
+
+    sub_root = paths.tandem_home() / "subagents" / session.tandem_id
+    marker = sub_root / "running" / f"{fork_id or uuid7()}.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps({
+        "model": model, "context": context, "pid": os.getpid(),
+        "task_preview": task[:120],
+    }))
+    try:
+        code = _run(argv, cwd=session.cwd).returncode
+    finally:
+        marker.unlink(missing_ok=True)
+        if fork_path is not None:
+            if keep_forks:
+                sub_root.mkdir(parents=True, exist_ok=True)
+                fork_path.rename(sub_root / fork_path.name)
+            else:
+                fork_path.unlink(missing_ok=True)
+    return code
+```
+
+- [ ] **Step 4: Run op tests to verify they pass**
+
+Run: `uv run pytest tests/test_sub.py -v`
+Expected: all pass
+
+- [ ] **Step 5: Write the failing CLI tests**
+
+Append to `tests/test_sub.py`:
+
+```python
+class TestSubCli:
+    def _cli_env(self, env, monkeypatch):
+        from tandem import cli
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        return cli
+
+    def test_sub_reads_task_from_stdin(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(
+                task=task, kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="line one\nline two\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "line one\nline two"
+        assert calls["kw"]["context"] == "task"   # config default: match->task
+
+    def test_sub_flags_override_config(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-m", "gpt-x-mini", "--context", "full", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "gpt-x-mini"
+        assert calls["kw"]["context"] == "full"
+
+    def test_sub_empty_task_errors(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        r = click.testing.CliRunner().invoke(cli.main, ["sub"], input="  \n")
+        assert r.exit_code == 1
+        assert "empty task" in r.output
+```
+
+Run: `uv run pytest tests/test_sub.py::TestSubCli -v`
+Expected: FAIL with `Error: No such command 'sub'`
+
+- [ ] **Step 6: Implement the CLI command**
+
+In `src/tandem/cli.py`, add `import json` to the module imports, and add after `run_cmd`:
+
+```python
+@main.command()
+@click.option("-m", "--model", default=None,
+              help="Codex model for this worker (config default otherwise).")
+@click.option("--context", "context_mode",
+              type=click.Choice(["task", "full"]), default=None,
+              help="Worker context: cold task-only, or a full fork of the "
+                   "paired session (config policy decides by default).")
+@click.argument("task", required=False)
+def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
+    """Run one delegated subagent task on codex (task argument or stdin).
+
+    Used by the tandem plugin's codex-worker bridge; also works manually."""
+    from . import ops
+    from .config import load_subagents_config
+
+    if task is None or task == "-":
+        task = sys.stdin.read()
+    task = task.strip()
+    if not task:
+        click.secho("error: empty task brief.", fg="red", err=True)
+        sys.exit(1)
+    cfg = load_subagents_config()
+    with StateStore() as store:
+        session = _require_session(store)
+        code = ops.run_sub(
+            store, session, task,
+            model=model if model is not None else cfg.model,
+            context=context_mode or ("full" if cfg.context == "full" else "task"),
+            fanout_feature=cfg.fanout_feature,
+            keep_forks=cfg.keep_forks,
+        )
+    sys.exit(code)
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `uv run pytest`
+Expected: all pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tandem/ops.py src/tandem/cli.py tests/test_sub.py
+git commit -m "feat: tandem sub — execute delegated subagent tasks on codex"
+```
+
+---
+
+### Task 4: Hook routing — `hookroute.py` and `tandem hook-route`
+
+**Files:**
+- Create: `src/tandem/hookroute.py`
+- Modify: `src/tandem/cli.py` (new command after `sub`)
+- Test: `tests/test_hookroute.py`
+
+**Interfaces:**
+- Consumes: `SubagentsConfig` (Task 1).
+- Produces: `route(payload: dict, cfg: SubagentsConfig, cwd: str, claude_home: Path, has_session: bool, codex_ok: bool) -> dict | None`, `find_agent_body(subagent_type: str, cwd: str, claude_home: Path) -> str`, constants `BRIDGE_AGENT = "codex-worker"` and `BRIDGE_MODEL = "haiku"`. The plugin (Task 5) invokes the CLI command `tandem hook-route`.
+
+The emitted JSON shape (verify field names against
+https://code.claude.com/docs/en/hooks#pretooluse-decision-control before
+implementing):
+
+```json
+{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+  "permissionDecision": "allow",
+  "permissionDecisionReason": "tandem: rerouted to codex-worker",
+  "updatedInput": {"...": "every original field, three rewritten"}}}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_hookroute.py
+"""hook-route: reroute native Agent dispatches to the codex-worker bridge.
+Failure discipline: any problem -> None (native dispatch), CLI always exit 0."""
+
+import json
+from pathlib import Path
+
+from tandem.config import SubagentsConfig
+from tandem.hookroute import BRIDGE_AGENT, BRIDGE_MODEL, find_agent_body, route
+
+
+def _payload(subagent_type="Explore", prompt="find the tests", **extra):
+    ti = {"subagent_type": subagent_type, "prompt": prompt,
+          "description": "short label", "model": "opus"}
+    ti.update(extra)
+    return {"hook_event_name": "PreToolUse", "tool_name": "Agent",
+            "cwd": "/tmp/x", "tool_input": ti}
+
+
+CFG = SubagentsConfig()
+
+
+def _route(payload, cfg=CFG, has_session=True, codex_ok=True,
+           cwd="/tmp/x", claude_home=Path("/nonexistent")):
+    return route(payload, cfg, cwd, claude_home,
+                 has_session=has_session, codex_ok=codex_ok)
+
+
+class TestRewrite:
+    def test_reroutes_and_rewrites_exactly_three_fields(self):
+        out = _route(_payload(run_in_background=True))
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "allow"
+        ui = hso["updatedInput"]
+        assert ui["subagent_type"] == BRIDGE_AGENT
+        assert ui["model"] == BRIDGE_MODEL          # opus would override haiku
+        assert ui["prompt"] == "find the tests"     # verbatim, built-in type
+        assert ui["description"] == "short label"   # untouched
+        assert ui["run_in_background"] is True      # unknown fields carried
+
+    def test_named_agent_body_is_inlined(self, tmp_path):
+        agents = tmp_path / "proj" / ".claude" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "reviewer.md").write_text(
+            "---\nname: code-reviewer\ndescription: reviews\n---\n"
+            "Always check for X."
+        )
+        out = _route(_payload(subagent_type="code-reviewer"),
+                     cwd=str(tmp_path / "proj"))
+        p = out["hookSpecificOutput"]["updatedInput"]["prompt"]
+        assert "Always check for X." in p
+        assert p.endswith("find the tests")  # original brief last, verbatim
+
+
+class TestPassthrough:
+    def test_fork_passes_through(self):
+        assert _route(_payload(subagent_type="fork")) is None
+
+    def test_bridge_loop_guard(self):
+        assert _route(_payload(subagent_type=BRIDGE_AGENT)) is None
+
+    def test_route_off(self):
+        assert _route(_payload(), cfg=SubagentsConfig(route="off")) is None
+
+    def test_no_session_or_unhealthy_codex(self):
+        assert _route(_payload(), has_session=False) is None
+        assert _route(_payload(), codex_ok=False) is None
+
+    def test_malformed_input(self):
+        assert _route({"tool_input": "not a dict"}) is None
+        assert _route(_payload(prompt="")) is None
+
+
+class TestFindAgentBody:
+    def test_builtin_and_plugin_scoped_have_no_body(self, tmp_path):
+        assert find_agent_body("Explore", str(tmp_path), tmp_path) == ""
+        assert find_agent_body("my-plugin:reviewer", str(tmp_path),
+                               tmp_path) == ""
+
+    def test_walks_up_and_falls_back_to_user_home(self, tmp_path):
+        (tmp_path / ".claude" / "agents").mkdir(parents=True)
+        (tmp_path / ".claude" / "agents" / "helper.md").write_text(
+            "---\nname: helper\n---\nBody from repo root."
+        )
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        body = find_agent_body("helper", str(nested), tmp_path / "nohome")
+        assert body == "Body from repo root."
+
+
+class TestCli:
+    def test_prints_decision_and_exits_zero(self, env_factory, monkeypatch):
+        import click.testing
+        from tandem import cli
+        env = env_factory(active="claude")
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["hook-route"], input=json.dumps(payload))
+        assert r.exit_code == 0
+        out = json.loads(r.output)
+        assert out["hookSpecificOutput"]["updatedInput"]["subagent_type"] \
+            == BRIDGE_AGENT
+
+    def test_any_crash_exits_zero_silent(self, monkeypatch, tmp_path):
+        import click.testing
+        from tandem import cli, hookroute
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        monkeypatch.setattr(hookroute, "route",
+                            lambda *a, **kw: 1 / 0)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["hook-route"], input=json.dumps(_payload()))
+        assert r.exit_code == 0
+        assert r.output == ""
+
+    def test_garbage_stdin_exits_zero_silent(self, tmp_path, monkeypatch):
+        import click.testing
+        from tandem import cli
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["hook-route"], input="not json {{{")
+        assert r.exit_code == 0
+        assert r.output == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_hookroute.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tandem.hookroute'`
+
+- [ ] **Step 3: Write `hookroute.py`**
+
+```python
+# src/tandem/hookroute.py
+"""PreToolUse routing: should this native Agent dispatch run on codex?
+
+Pure decision logic — the CLI wrapper owns process concerns (stdin, exit
+codes). Returning None means 'emit nothing': the dispatch proceeds
+natively. That is the failure mode for everything unexpected."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import SubagentsConfig
+
+BRIDGE_AGENT = "codex-worker"
+BRIDGE_MODEL = "haiku"
+
+
+def route(
+    payload: dict,
+    cfg: SubagentsConfig,
+    cwd: str,
+    claude_home: Path,
+    *,
+    has_session: bool,
+    codex_ok: bool,
+) -> dict | None:
+    if cfg.route != "all" or not has_session or not codex_ok:
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    subagent_type = tool_input.get("subagent_type") or ""
+    # forks keep claude's native full-context contract; bridge = loop guard
+    if subagent_type in ("fork", BRIDGE_AGENT):
+        return None
+    prompt = tool_input.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return None
+    body = find_agent_body(subagent_type, cwd, claude_home)
+    if body:
+        prompt = (
+            "Instructions for this task (from the dispatching session's "
+            f"{subagent_type!r} agent definition):\n\n{body}\n\n---\n\n"
+            + prompt
+        )
+    updated = dict(tool_input)
+    updated["subagent_type"] = BRIDGE_AGENT
+    # per-invocation model overrides agent frontmatter; without this rewrite
+    # the bridge would run on the dispatch's model (observed: opus)
+    updated["model"] = BRIDGE_MODEL
+    updated["prompt"] = prompt
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "tandem: rerouted to codex-worker",
+            "updatedInput": updated,
+        }
+    }
+
+
+def find_agent_body(subagent_type: str, cwd: str, claude_home: Path) -> str:
+    """The definition body a named claude agent would have received as its
+    system prompt: every .claude/agents/ from cwd up to the filesystem
+    root, then <claude_home>/agents/, searched recursively, first `name`
+    match wins. Built-in and plugin-scoped types have no local file."""
+    if not subagent_type or ":" in subagent_type:
+        return ""
+    bases: list[Path] = []
+    d = Path(cwd)
+    while True:
+        bases.append(d / ".claude" / "agents")
+        if d.parent == d:
+            break
+        d = d.parent
+    bases.append(claude_home / "agents")
+    for base in bases:
+        if not base.is_dir():
+            continue
+        for f in sorted(base.rglob("*.md")):
+            name, body = _parse_agent_file(f)
+            if name == subagent_type:
+                return body
+    return ""
+
+
+def _parse_agent_file(path: Path) -> tuple[str, str]:
+    try:
+        text = path.read_text()
+    except OSError:
+        return "", ""
+    name, body = path.stem, text
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            for line in text[3:end].splitlines():
+                if line.strip().startswith("name:"):
+                    name = line.split(":", 1)[1].strip()
+            body = text[end + 4:]
+    return name, body.strip()
+```
+
+- [ ] **Step 4: Add the CLI command**
+
+In `src/tandem/cli.py`, after `sub`:
+
+```python
+@main.command(name="hook-route")
+def hook_route_cmd() -> None:
+    """Claude Code PreToolUse hook: reroute subagent dispatches to codex.
+
+    Reads hook JSON on stdin; prints a decision or nothing. ALWAYS exits 0
+    — exit 2 would block the dispatch, and any failure here must degrade
+    to native behavior."""
+    try:
+        from .config import load_subagents_config
+        from .hookroute import route
+
+        payload = json.loads(sys.stdin.read() or "{}")
+        cwd = payload.get("cwd") or _cwd()
+        cfg = load_subagents_config()
+        with StateStore() as store:
+            session = store.latest_session_for_cwd(cwd)
+        codex_ok = False
+        if session is not None:
+            adapter = get_adapter("codex")
+            v = adapter.detect_version()
+            codex_ok = v is not None and adapter.version_supported(v)
+        decision = route(payload, cfg, cwd, paths.claude_home(),
+                         has_session=session is not None, codex_ok=codex_ok)
+        if decision is not None:
+            click.echo(json.dumps(decision))
+    except Exception:
+        pass
+    sys.exit(0)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_hookroute.py -v && uv run pytest`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tandem/hookroute.py src/tandem/cli.py tests/test_hookroute.py
+git commit -m "feat: tandem hook-route — PreToolUse reroute of Agent dispatches"
+```
+
+---
+
+### Task 5: The plugin — bridge agent, hook registration, manifest
+
+**Files:**
+- Create: `plugin/.claude-plugin/plugin.json`
+- Create: `plugin/hooks/hooks.json`
+- Create: `plugin/agents/codex-worker.md`
+- Test: `tests/test_plugin.py`
+
+**Interfaces:**
+- Consumes: the CLI commands `tandem hook-route` (Task 4) and `tandem sub` (Task 3).
+- Produces: an installable local plugin. Loaded for development/E2E with `claude --plugin-dir /Users/bhavya/git/tandem/plugin` (verify the flag spelling with `claude --help`; the plugins doc also documents marketplace installs for distribution later).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_plugin.py
+"""The plugin is static registration only — validate the three files."""
+
+import json
+import re
+from pathlib import Path
+
+PLUGIN = Path(__file__).parent.parent / "plugin"
+
+
+def test_manifest_parses():
+    m = json.loads((PLUGIN / ".claude-plugin" / "plugin.json").read_text())
+    assert m["name"] == "tandem"
+    assert m["version"]
+
+
+def test_hooks_register_hook_route():
+    h = json.loads((PLUGIN / "hooks" / "hooks.json").read_text())
+    entries = h["hooks"]["PreToolUse"]
+    assert entries[0]["matcher"] == "Agent|Task"
+    cmds = [hk["command"] for hk in entries[0]["hooks"]]
+    assert cmds == ["tandem hook-route"]
+
+
+def test_bridge_agent_definition():
+    text = (PLUGIN / "agents" / "codex-worker.md").read_text()
+    front = text.split("---")[1]
+    assert re.search(r"^name:\s*codex-worker\s*$", front, re.M)
+    assert re.search(r"^model:\s*haiku\s*$", front, re.M)
+    assert re.search(r"^tools:\s*Bash\(tandem sub:\*\)\s*$", front, re.M)
+    body = text.split("---", 2)[2]
+    assert "tandem sub" in body
+    assert "verbatim" in body
+    assert "[tandem-sub failed]" in body
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_plugin.py -v`
+Expected: FAIL with `FileNotFoundError`
+
+- [ ] **Step 3: Create the plugin files**
+
+`plugin/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "tandem",
+  "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
+  "version": "0.1.0",
+  "author": {"name": "tandem"}
+}
+```
+
+`plugin/hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {"type": "command", "command": "tandem hook-route"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+`plugin/agents/codex-worker.md`:
+
+```markdown
+---
+name: codex-worker
+description: Executes delegated tasks on a codex model via tandem. Dispatched automatically by tandem's reroute hook; not meant for manual selection.
+model: haiku
+tools: Bash(tandem sub:*)
+---
+
+You are a relay between this session and a codex worker. Do exactly this:
+
+1. Run ONE command: `tandem sub` with your ENTIRE task message — every
+   line, byte-for-byte, nothing added or removed — on stdin, via heredoc:
+
+   ```
+   tandem sub <<'TANDEM_TASK_EOF'
+   <your entire task message here>
+   TANDEM_TASK_EOF
+   ```
+
+   Set the Bash tool's timeout parameter to 600000 (codex runs are long).
+
+2. If the command exits 0: return its final message as your final message,
+   verbatim — no summary, no commentary, no added headers.
+
+3. If it exits nonzero: return its output prefixed with
+   `[tandem-sub failed]` and stop. Do not attempt the task yourself.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_plugin.py -v`
+Expected: 3 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin tests/test_plugin.py
+git commit -m "feat: tandem claude plugin — reroute hook + codex-worker bridge"
+```
+
+---
+
+### Task 6: Doctor and status surfaces
+
+**Files:**
+- Modify: `src/tandem/doctor.py` (new function + one call in `run_doctor` before the `if live:` line)
+- Modify: `src/tandem/cli.py` (`status` command, after the quarantine block)
+- Test: `tests/test_sub.py` (extend)
+
+**Interfaces:**
+- Consumes: `load_subagents_config` (Task 1); marker/retention layout from Task 3 (`$TANDEM_HOME/subagents/<tandem-id>/running/*.json`, retained `rollout-*.jsonl`); `DoctorReport.warn` (existing).
+- Produces: `_subagent_checks(report: DoctorReport, session) -> None` in `doctor.py`; status output lines starting `  subagent running:` and `  retained forks:`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_sub.py`:
+
+```python
+class TestDoctorAndStatus:
+    def test_doctor_warns_on_api_key_env(self, env_factory, monkeypatch):
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        report = run_doctor(env.store, env.session, live=False)
+        assert any("OPENAI_API_KEY" in c.message for c in report.checks
+                   if c.status == "warn")
+
+    def test_doctor_nudges_shared_block(self, env_factory, monkeypatch):
+        from pathlib import Path
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        Path(env.cwd, "CLAUDE.md").write_text("# rules, no markers\n")
+        report = run_doctor(env.store, env.session, live=False)
+        assert any("tandem:shared" in c.message for c in report.checks)
+
+    def test_status_lists_running_and_retained(self, env_factory, monkeypatch):
+        import click.testing
+        from tandem import cli, paths
+        env = env_factory(active="claude")
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        sub_root = paths.tandem_home() / "subagents" / env.session.tandem_id
+        (sub_root / "running").mkdir(parents=True)
+        (sub_root / "running" / "r1.json").write_text(json.dumps(
+            {"model": "gpt-x-mini", "context": "task",
+             "task_preview": "audit the README", "pid": 1}))
+        (sub_root / "rollout-x-1.jsonl").write_text("{}\n")
+        r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert "subagent running: gpt-x-mini (task) audit the README" in r.output
+        assert "retained forks: 1" in r.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sub.py::TestDoctorAndStatus -v`
+Expected: FAIL (no warn lines / no status lines)
+
+- [ ] **Step 3: Implement the doctor checks**
+
+Append to `src/tandem/doctor.py` (add `import os` to module imports), and call `_subagent_checks(report, session)` in `run_doctor` immediately before the `if live:` line:
+
+```python
+def _subagent_checks(report: DoctorReport, session) -> None:
+    """Subagent routing hygiene: billing follows codex auth, and codex
+    workers only see CLAUDE.md content inside the tandem:shared block."""
+    from . import paths
+    from .config import load_subagents_config
+
+    if load_subagents_config().route == "off":
+        return
+    if os.environ.get("OPENAI_API_KEY"):
+        report.warn(
+            "subagents: OPENAI_API_KEY is set — codex may bill the API "
+            "instead of your ChatGPT subscription"
+        )
+    auth_path = paths.codex_home() / "auth.json"
+    try:
+        auth = json.loads(auth_path.read_text())
+        if auth.get("OPENAI_API_KEY") and not auth.get("tokens"):
+            report.warn(
+                "subagents: codex auth is API-key based — subagent runs "
+                "will bill the API, not the subscription"
+            )
+    except (OSError, ValueError):
+        pass
+    claude_md = Path(session.cwd) / "CLAUDE.md"
+    try:
+        if "tandem:shared:begin" not in claude_md.read_text():
+            report.warn(
+                "subagents: CLAUDE.md has no tandem:shared block — project "
+                "rules will not reach codex workers (move subagent-relevant "
+                "rules into the shared block)"
+            )
+    except OSError:
+        pass
+```
+
+- [ ] **Step 4: Implement the status lines**
+
+In `src/tandem/cli.py` `status()`, after the quarantine block:
+
+```python
+        sub_root = paths.tandem_home() / "subagents" / session.tandem_id
+        run_dir = sub_root / "running"
+        if run_dir.is_dir():
+            import json as _json
+
+            for m in sorted(run_dir.glob("*.json")):
+                try:
+                    d = _json.loads(m.read_text())
+                except (OSError, ValueError):
+                    continue
+                click.echo(
+                    f"  subagent running: {d.get('model') or 'default-model'} "
+                    f"({d.get('context')}) {d.get('task_preview', '')}"
+                )
+        kept = sorted(sub_root.glob("rollout-*.jsonl")) if sub_root.is_dir() else []
+        if kept:
+            click.echo(f"  retained forks: {len(kept)} under {sub_root}")
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest`
+Expected: all pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tandem/doctor.py src/tandem/cli.py tests/test_sub.py
+git commit -m "feat: doctor auth/shared-block checks + status subagent listing"
+```
+
+---
+
+### Task 7: Docs, spikes S1–S4, live E2E
+
+**Files:**
+- Modify: `README.md` (new "Codex subagents" section after "Two model families on one problem"; new cheat-sheet row)
+- Modify: `docs/specs/2026-07-31-codex-subagents-design.md` (record spike results; replace `allow_fanout` with `fanout_feature` in the config block)
+- Test: manual live checklist (this machine has both CLIs + subscriptions)
+
+**Interfaces:**
+- Consumes: everything shipped in Tasks 1–6.
+- Produces: user-facing docs; validated spike facts recorded in the spec's Spikes section (edit each S1–S4 bullet in place, replacing its open question with the observed result).
+
+- [ ] **Step 1: README section + cheat-sheet row**
+
+Add to the cheat-sheet table: `| \`tandem sub "…"\` | Run one delegated task on a codex model (used by the plugin's reroute hook) |`
+
+New section after "Two model families on one problem":
+
+```markdown
+### 🐣 Subagents on the cheap model.
+
+Install the tandem plugin and Claude's subagent dispatches run on a cheap
+codex model instead — automatically, with the task brief forwarded
+verbatim and results returned through Claude's own machinery. Claude
+orchestrates; codex does the legwork; your Claude quota stays for the
+main thread. Routing lives in `~/.tandem/config.toml` (`[subagents]`),
+never in prompts:
+
+    claude --plugin-dir /path/to/tandem/plugin   # try it locally
+
+Forks and specialized flows pass through untouched; remove the plugin and
+Claude is byte-for-byte stock again.
+```
+
+(Verify the `--plugin-dir` flag spelling with `claude --help` and adjust the README line to whatever the installed CLI accepts.)
+
+- [ ] **Step 2: Spike S1 — cheap model ids and `-m` on resume**
+
+Run (in a scratch dir with a tandem session):
+
+```bash
+codex exec --skip-git-repo-check -m gpt-5.6-sol-mini "reply with exactly: ok" ; echo "exit=$?"
+# try candidate mini ids until one succeeds; `codex /model` in the TUI lists them
+tandem sub --context full -m <working-mini-id> "reply with exactly: ok"
+```
+
+Then confirm the fork's rollout (`keep_forks = true` in config for this test) records the requested model in its `turn_context` line, not the account default. Record the working id(s) and the resume-`-m` verdict in the spec's S1 bullet; set the shipped default `model` guidance in README accordingly.
+
+- [ ] **Step 3: Spike S2 — fanout feature name**
+
+Run `codex --help | grep -A2 enable` and `codex features 2>/dev/null || codex config 2>/dev/null` to enumerate feature names; look for the multi-agent/collab feature (spawn_agent tools were observed in rollouts on this machine). Test: `codex exec --enable <name> "spawn a trivial agent that replies ok, then report"`. Record the name in the spec's S2 bullet and document setting `fanout_feature = "<name>"` in the README config example. If no flag exists on codex 0.145, record that and leave `fanout_feature` empty (native default behavior).
+
+- [ ] **Step 4: Spikes S3+S4 — live E2E through the plugin**
+
+```bash
+cd ~/git/tandem && uv tool install . --force   # tandem on PATH for the hook
+cd <scratch project> && tandem                  # pair a session, exit claude
+claude --plugin-dir ~/git/tandem/plugin
+# in claude: "dispatch a subagent to count the .py files here and report"
+```
+
+Verify, in order: (1) the transcript's Agent dispatch carries `subagent_type: "codex-worker"` and `model: "haiku"` (S3: matcher + updatedInput fired on 2.1.220); (2) a codex rollout for the worker exists and did the work; (3) the bridge's final message is codex's output verbatim, unembellished (S4 — if haiku editorializes, tighten `plugin/agents/codex-worker.md` wording and repeat); (4) `tandem status` during the run shows `subagent running:`; (5) after the turn, `tandem switch` + `codex resume` shows the dispatch/result synced into the shadow; (6) `tandem doctor` is green. Record S3/S4 results in the spec.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/specs/2026-07-31-codex-subagents-design.md
+git commit -m "docs: codex subagents — README section, spike results in spec"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** config (T1), fork engine + `sub` + markers (T2/T3), hook + rewrite rules + exit discipline (T4), plugin trio (T5), doctor auth/shared-block + status (T6), docs + S1–S4 + E2E (T7). Deferred spec items (Monitor, matchers, `route_forks`, batch, MCP) are "Later" in the spec and intentionally absent here.
+- **Deviation** (`allow_fanout` → `fanout_feature`) is declared in Global Constraints and reconciled with the spec in Task 7.
+- **Type consistency:** `fork_shadow -> tuple[str, Path]`; `run_sub(..., model="", context="task", fanout_feature="", keep_forks=False) -> int`; `route(payload, cfg, cwd, claude_home, *, has_session, codex_ok) -> dict | None`; `SubagentsConfig(route, model, context, fanout_feature, keep_forks)` — used identically across Tasks 1–6.

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -127,6 +127,8 @@ dispatch in v1 is fresh-type (forks pass through natively).
 Reads the PreToolUse JSON from stdin. Emits nothing (exit 0) — meaning
 "dispatch proceeds natively" — when any of these hold:
 
+- `tool_name` is not `Agent`/`Task` (defense in depth: the hook matcher is
+  config we do not control at call time);
 - no paired tandem session for the cwd, or codex missing/unsupported
   (the plugin is installed globally in Claude; outside tandem sessions the
   hook must be an invisible no-op);
@@ -157,6 +159,15 @@ the dispatch). Any internal failure → exit 0 with no output, i.e. native
 dispatch. The failure mode of this whole feature is "no savings", never
 "broken subagents".
 
+The command body cannot enforce this alone: click's usage-error path exits
+2 *before* the body runs — the realistic case is version skew, where the
+plugin is installed but an older `tandem` on PATH has no `hook-route`
+subcommand, which would then block every dispatch in that session. The hook
+is therefore registered as `tandem hook-route || true`; the shell-level
+guard is what makes exit 2 unreachable. `route()` additionally re-checks
+`tool_name ∈ {Agent, Task}` itself, so a mis-scoped matcher can never make
+it rewrite an unrelated tool's input.
+
 ### The plugin (`plugin/` in this repo)
 
 - `agents/codex-worker.md` — frontmatter: `model: haiku`,
@@ -167,7 +178,10 @@ dispatch. The failure mode of this whole feature is "no savings", never
   output prefixed `[tandem-sub failed]` and stop.
 - `hooks/hooks.json` — PreToolUse, matcher `Agent|Task` (defensive: the
   alias guarantee covers settings/agent definitions, not hook matchers
-  explicitly), command `tandem hook-route`.
+  explicitly), command `tandem hook-route || true`. The `|| true` is
+  load-bearing, not cosmetic: click's usage-error path exits 2 outside the
+  command body (version skew — plugin installed, older tandem on PATH
+  lacking the subcommand), and exit 2 blocks the dispatch.
 - Install: local plugin from the repo for v1 (marketplace later).
   Registration is the plugin's entire job; policy lives in tandem config.
 

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -325,7 +325,12 @@ price of "no forged results" under the documented hook surface.
   "gpt-5.6-luna"` and `thread_settings_applied.model = "gpt-5.6-luna"` in
   the retained rollout, while the account default stayed `gpt-5.6-sol` — no
   per-thread model cache interference. Shipped guidance: `model =
-  "gpt-5.6-luna"` (`gpt-5.4-mini` for the cheapest tier).
+  "gpt-5.6-luna"` (`gpt-5.4-mini` for the cheapest tier). **Setting it is
+  required for the cheap-model promise: without `model`, workers run on
+  your codex account's default model — probably not the cheap one** (here,
+  the frontier `gpt-5.6-sol`). The dataclass default stays `""` on purpose
+  — a baked-in id would 400 on an account that lacks it — so the honesty
+  lives in the docs and in a `tandem doctor` warning instead.
 - **S2** — *fanout feature flag; do spawned workers start cold?* **There is
   no flag to pass on 0.145.** `codex features list` reports `multi_agent`
   as stage `stable`, effective `true` by default; `multi_agent_v2` is

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -1,0 +1,278 @@
+# Codex-model subagents — design
+
+2026-07-31. Status: approved design, pre-implementation.
+
+## Goal
+
+When Claude Code is the active harness in a tandem pair, native subagent
+dispatches transparently execute on a cheap Codex model instead of a Claude
+model. Routing policy lives in tandem configuration, not in prompts or agent
+descriptions. Both harnesses stay stock: uninstall the plugin and Claude is
+byte-for-byte native again.
+
+Non-goals for v1: rerouting fork-type dispatches, tier/matcher routing
+policies, Monitor-based streaming, a batch orchestrator, any MCP surface, and
+the reverse direction (codex-active dispatching Claude minis). See "Later"
+at the end.
+
+## Why this shape
+
+Claude Code's extension surface (verified against docs and live traces,
+claude 2.1.220):
+
+- The `Agent` tool (renamed from `Task` in v2.1.63) dispatches **one tool
+  call per subagent** — parallel fanout is several independent calls, each
+  with its own id, prompt, and result.
+- A PreToolUse hook may return `allow` + `updatedInput`, replacing the
+  entire input object before the subagent spawns. This is the interception
+  seam.
+- **No hook can fabricate a successful tool result.** The architecture is
+  therefore *redirect the dispatch, don't forge the return*: the actual
+  return travels through Claude's native machinery.
+- A named (non-fork) subagent starts cold: its context is the delegation
+  prompt Claude writes, the agent definition's body as system prompt,
+  CLAUDE.md hierarchy (except Explore/Plan), and a git-status snapshot.
+  Claude composes self-contained briefs *because* it knows workers are cold.
+- A `fork`-type subagent (experimental; default-enabled ≥2.1.161) inherits
+  the entire conversation. It is identified by `subagent_type == "fork"` in
+  the dispatch input.
+- Subagents run in the background by default (≥2.1.198): the Agent tool
+  result is launch metadata, and the real result arrives later as a
+  `<task-notification>` user-type transcript entry with the full result
+  text inline.
+
+Codex CLI facts (verified live, codex 0.145): `codex exec -m <model>`
+selects a model per invocation; `codex exec resume <id>` resumes a rollout,
+including rollouts tandem authors from scratch; billing follows the CLI's
+auth (ChatGPT subscription), not interactivity.
+
+## Runtime actors
+
+Only two things act at runtime: the stock harnesses and the tandem binary.
+The plugin is a distribution vehicle — static files registered into Claude,
+never a process.
+
+```
+user ──▶ claude (native UI; native Agent dispatch, one call per subagent)
+             │  PreToolUse (plugin-registered) runs: tandem hook-route
+             │  → allow + updatedInput {subagent_type: codex-worker,
+             │     model: <cheap claude driver>, prompt: brief}
+             ▼
+         codex-worker bridge (haiku driver, Bash-only, plugin-shipped)
+             │  runs: tandem sub -m <mini>   (brief on stdin)
+             ▼
+         tandem: match-mode → cold `codex exec -m <mini>` in cwd
+                 full-mode  → drain, fork shadow rollout, `codex exec resume`
+             ▼
+         codex model works in the stock codex harness (may spawn_agent deeper)
+             ▼
+         final message → bridge returns it verbatim → native return path
+         (foreground: tool result; background: task-notification, result inline)
+             ▼
+         tandem's normal sync mirrors the dispatch + result into the shadow
+```
+
+Management is layered and native at every level: Claude orchestrates the
+fleet (scheduling, background tasks, panel UI, depth budget, aggregation);
+tandem executes exactly one worker per `tandem sub` invocation and holds no
+fleet state; codex manages its own interior fanout.
+
+## Components
+
+### `tandem sub` (new op + CLI command)
+
+`tandem sub [-m MODEL] [--context task|full] [TASK]` — task read from
+stdin when not passed as an argument (Claude briefs are multi-paragraph;
+stdin avoids argv quoting and length limits). With no `--context` flag the
+config policy decides: `match` resolves to `task`, because every rerouted
+dispatch in v1 is fresh-type (forks pass through natively).
+
+- **Invariant: the brief is forwarded verbatim — no truncation, no
+  summarization, at any step.**
+- `--context task` (what match-mode resolves to for non-fork dispatches):
+  no fork, no drain — run `codex exec -m <model> --skip-git-repo-check`
+  with the brief, in the session cwd. Project rules reach the worker the
+  native way: codex reads the AGENTS.md tandem already keeps synced.
+- `--context full`: drain the active source with `flush_dangling` (same
+  machinery as `run_oneoff`), copy the shadow rollout to a fresh uuid7
+  rollout in codex's sessions dir — rewrite `session_meta` id, set
+  `originator: "tandem-sub"`, keep `model_provider: "openai"` — then
+  `codex exec resume <fork-id> -m <model>` with the brief. The fork is
+  **never registered as a sync source**: no cursor, no echo-suppression
+  changes, shadow untouched.
+- Fanout: pass the codex feature flag enabling multi-agent tools when
+  `allow_fanout = true` (flag name pinned by spike S2), so the worker may
+  `spawn_agent` natively at its own discretion.
+- Output: codex exec's streamed activity passes through to stdout as it
+  runs; the final message is printed last. Exit code mirrors codex exec.
+- Cleanup: delete the fork on completion. `keep_forks = true` retains it
+  under `~/.tandem/subagents/<tandem-id>/` for debugging (and as the future
+  resume path for follow-up messages to a finished worker).
+- If codex is missing, unsupported, or the cwd has no paired session:
+  exit nonzero with a one-line reason (the bridge relays it).
+
+### `tandem hook-route` (new CLI command)
+
+Reads the PreToolUse JSON from stdin. Emits nothing (exit 0) — meaning
+"dispatch proceeds natively" — when any of these hold:
+
+- no paired tandem session for the cwd, or codex missing/unsupported
+  (the plugin is installed globally in Claude; outside tandem sessions the
+  hook must be an invisible no-op);
+- `route = "off"` in config;
+- `subagent_type` is `"fork"` (claude forks stay native in v1 — they're
+  prompt-cache-cheap and semantically claude's own full-context worker);
+- `subagent_type` is already `codex-worker` (loop guard).
+
+Otherwise emit `allow` + `updatedInput`. `updatedInput` replaces the whole
+input object, so it carries every original field with three rewrites:
+
+1. `subagent_type` → `codex-worker`.
+2. `model` → the cheap claude driver (`haiku`). **Load-bearing:** real
+   traces show dispatches carry `model: "opus"`, and the per-invocation
+   model param overrides agent frontmatter — without this rewrite the
+   bridge itself would run on opus.
+3. `prompt` → the original brief, prefixed with the named agent's
+   definition body when `subagent_type` matched a file in `.claude/agents/`
+   (walking up from cwd) or `~/.claude/agents/` — that body is the system
+   prompt Claude's own worker would have received. Built-in types
+   (Explore, general-purpose, Plan, …) forward the brief alone, as do
+   plugin-scoped types (ids containing `:`) in v1.
+   `description` is UI chrome Claude's own workers never see; it is left
+   as-is and otherwise ignored.
+
+Exit-code discipline: catch everything; **never exit 2** (exit 2 blocks
+the dispatch). Any internal failure → exit 0 with no output, i.e. native
+dispatch. The failure mode of this whole feature is "no savings", never
+"broken subagents".
+
+### The plugin (`plugin/` in this repo)
+
+- `agents/codex-worker.md` — frontmatter: `model: haiku`,
+  `tools: Bash(tandem sub:*)`. Body: run `tandem sub` with the brief on
+  stdin and a generous Bash timeout (codex runs can be long; background
+  subagents keep Bash, so backgrounding is safe); return the final message
+  verbatim — no summarizing, no commentary; on nonzero exit, return the
+  output prefixed `[tandem-sub failed]` and stop.
+- `hooks/hooks.json` — PreToolUse, matcher `Agent|Task` (defensive: the
+  alias guarantee covers settings/agent definitions, not hook matchers
+  explicitly), command `tandem hook-route`.
+- Install: local plugin from the repo for v1 (marketplace later).
+  Registration is the plugin's entire job; policy lives in tandem config.
+
+### Config (`~/.tandem/config.toml`, new file; `TANDEM_HOME` honored)
+
+```toml
+[subagents]
+route = "all"          # all | off        (later: matchers, route_forks)
+model = "…"            # cheap codex model id; default pinned by spike S1
+context = "match"      # match | task | full
+allow_fanout = true    # codex-native spawn_agent inside workers
+keep_forks = false
+```
+
+`context = "match"` is the core policy: mirror the context decision Claude
+itself made per dispatch. Fresh-type dispatch → task-only (Claude wrote a
+self-contained brief for a cold worker; dumping history on a small model
+distracts it and burns subscription). Fork-type dispatch → full (that's the
+contract a fork asks for — only reachable in v1 by forcing `context =
+"full"`, since forks pass through natively).
+
+## Return path and sync coherence
+
+- Foreground dispatch: the bridge's final message is the Agent tool result.
+- Background dispatch (the default): the tool result is launch metadata;
+  the result text arrives inline in a `<task-notification>` user-type
+  entry. Verified in real traces (full multi-KB results embedded). The
+  notification's `<output-file>` path points into session tmp and may not
+  outlive the session; harmless, the text is inline.
+- Nothing is ever appended to a live Claude's context by tandem: a running
+  claude holds its conversation in memory and does not re-read its
+  transcript. Both return channels above are Claude-native.
+- Shadow sync needs no new machinery: `Agent` call/result pairs are not in
+  toolmap's mapping tables, so they ride the existing Tier-2 passthrough;
+  task-notification entries sync as user messages; subagent internals never
+  appear in the parent transcript (verified: zero sidechain entries in
+  current-format traces); forks are not sync sources.
+
+## Progress visibility
+
+- Claude's native task panel lists every bridge as a running subagent —
+  fleet liveness for free.
+- `codex exec` stdout streams inside the bridge's Bash call and is visible
+  in the TUI task/transcript view today; that rendering is real but
+  contractually unspecified — do not build load-bearing UX on it.
+- `tandem status` (run from a second terminal, or `! tandem status` inside
+  claude, which costs a little context) grows a section listing active
+  workers: model, cold/fork, rollout path, retained forks.
+- The documented streaming channel — a plugin-declared Monitor tailing the
+  fork rollout — is v1.1.
+- The main model sees only the final result, by design.
+
+## Billing and auth
+
+All codex invocations go through the CLI's stored auth: ChatGPT
+subscription, consistent with tandem's zero-API-key stance. `tandem sub`
+must not inject API-key env; `tandem doctor` warns when codex auth is
+key-based or `OPENAI_API_KEY` is set (either could flip billing to API).
+The bridge costs a few hundred haiku-tier relay tokens per dispatch — the
+price of "no forged results" under the documented hook surface.
+
+## Error handling
+
+| Failure | Behavior |
+| --- | --- |
+| hook-route crashes / config unreadable | exit 0, no output → native dispatch |
+| no paired session / codex missing | hook passthrough; if reached anyway, `tandem sub` exits nonzero, bridge relays `[tandem-sub failed]`, main model does the work itself |
+| codex exec nonzero / outage | bridge relays output + `[tandem-sub failed]`; main model retries or does the work natively |
+| shadow missing on `--context full` | seed a fresh rollout from the drained active side (existing `_create_codex_shadow_late` pattern) |
+| parallel dispatches, full mode | file lock serializes drain-then-copy; execs then run concurrently. Match mode touches no shared state — no contention |
+| dangling calls at fork time | `flush_dangling` closes them (both replay APIs reject dangles) |
+
+## Known v1 limitations (stated, accepted)
+
+- CLAUDE.md content **outside** the `tandem:shared` block reaches Claude's
+  own workers but never codex workers (AGENTS.md sync carries only the
+  shared block). `tandem doctor` nudges users to move subagent-relevant
+  rules into the shared block.
+- Named agents' `skills:` preloads are not forwarded (definition body is).
+- Rerouted workers are not resumable via SendMessage the way Claude
+  subagents are; `keep_forks` + `codex exec resume` is the v2 path.
+- Thinking blocks do not cross translation (dropped, as elsewhere in
+  tandem).
+- Fork-type dispatches stay on Claude (`route_forks` is a later option).
+
+## Spikes (before or during implementation)
+
+- **S1**: enumerate cheap codex model ids available under this ChatGPT
+  plan; confirm `codex exec resume <fork> -m <model>` honors the override
+  on a tandem-authored rollout (fresh uuid7 should dodge the per-thread
+  model cache in `state_5.sqlite` — verify).
+- **S2**: codex multi-agent feature flag name for `--enable`; whether
+  spawned workers start cold (expected) — informs `allow_fanout` wiring.
+- **S3**: confirm the `Agent|Task` hook matcher fires on claude 2.1.220,
+  and the exact `updatedInput` echo behavior on an Agent call.
+- **S4**: haiku bridge relays long results verbatim without embellishment
+  (prompt-tune the agent body if not).
+
+## Testing
+
+- Unit: `hook-route` stdin→stdout fixtures (rewrite, all four passthrough
+  cases, model-field rewrite, named-agent body inlining, crash→exit-0);
+  fork op golden tests (session_meta rewrite, fork never in sync cursors);
+  `tandem sub` argv/stdin handling via the existing `_run` seam; config
+  parsing.
+- Integration: golden claude transcript containing background Agent
+  dispatch + task-notification → shadow sync unchanged and complete.
+- Live E2E (manual, this repo): dispatch a real subagent under the plugin,
+  observe reroute, codex execution, result return, `switch`, and both-side
+  resume; `tandem doctor` green throughout.
+
+## Later
+
+Tier/matcher routing (`route` grows match rules on agent type and model
+tier), `route_forks`, Monitor streaming, skill-preload forwarding, worker
+resume via retained forks, batch orchestrator (one codex orchestrator per
+fanout batch — only if S2 shows spawned workers can inherit context),
+MCP front-end, reverse direction (codex-active → claude minis; codex has
+no hook seam today, so model-chooses only).

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -89,28 +89,41 @@ config policy decides: `match` resolves to `task`, because every rerouted
 dispatch in v1 is fresh-type (forks pass through natively).
 
 - **Invariant: the brief is forwarded verbatim — no truncation, no
-  summarization, at any step.**
+  summarization, at any step.** It also never touches argv: the brief is
+  untrusted text, and as a trailing positional codex's own parser reads a
+  leading `-` as a flag (`- review …` dies with `unexpected argument`
+  before the model runs; `-m gpt-9 …` is silently honored, i.e. argv
+  injection). tandem passes codex's documented stdin marker — `resume <id>
+  -` — and writes the brief to the child's stdin, in both quiet and
+  streaming modes. This also removes the argv length ceiling on
+  multi-paragraph briefs.
 - `--context task` (what match-mode resolves to for non-fork dispatches):
   no fork, no drain, no lock — seed a minimal rollout (fresh uuid7,
   `originator: "tandem-sub"`, `model_provider: "openai"`, one note line and
   no history) and run `codex exec -m <model> --skip-git-repo-check resume
-  <seed-id>` with the brief, in the session cwd. The worker still starts
-  cold; the seed exists so tandem *authors* the rollout rather than letting
-  codex mint one. A plain `codex exec` would write an ordinary rollout in
-  the session cwd — non-tandem originator, fresh mtime — which is exactly
-  what `await_codex_rollout` treats as "codex just minted a session": a
-  concurrent fresh-codex launch or one-off would bind the pair's
+  <seed-id> -` with the brief on stdin, in the session cwd. The worker
+  still starts cold; the seed exists so tandem *authors* the rollout rather
+  than letting codex mint one. A plain `codex exec` would write an ordinary
+  rollout in the session cwd — non-tandem originator, fresh mtime — which
+  is exactly what `await_codex_rollout` treats as "codex just minted a
+  session": a concurrent fresh-codex launch or one-off would bind the pair's
   `codex_session_id` to a throwaway worker transcript that `tandem sub`
   then deletes. Seeding puts cold runs behind the same originator guard as
-  forks, so no sub rollout is ever adoptable. Project rules reach the worker
-  the native way: codex reads the AGENTS.md tandem already keeps synced.
+  forks, so no sub rollout is ever adoptable. (`codex exec --ephemeral`
+  ["run without persisting session files to disk"] would also keep the cold
+  path out of discovery's way, and was rejected: it leaves nothing on disk,
+  so `keep_forks` has no worker transcript to retain and the debugging trail
+  — the one way to see what a cheap worker actually did — disappears. A
+  seeded rollout costs one small file and keeps both.) Project rules reach
+  the worker the native way: codex reads the AGENTS.md tandem already keeps
+  synced.
 - `--context full`: drain the active source with `flush_dangling` (same
   machinery as `run_oneoff`), copy the shadow rollout to a fresh uuid7
   rollout in codex's sessions dir — rewrite `session_meta` id, set
   `originator: "tandem-sub"`, keep `model_provider: "openai"` — then
-  `codex exec resume <fork-id> -m <model>` with the brief. The fork is
-  **never registered as a sync source**: no cursor, no echo-suppression
-  changes, shadow untouched.
+  `codex exec -m <model> resume <fork-id> -` with the brief on stdin. The
+  fork is **never registered as a sync source**: no cursor, no
+  echo-suppression changes, shadow untouched.
 - Fanout: pass `--enable <fanout_feature>` when configured. On codex 0.145
   nothing needs passing (S2): the `multi_agent` feature is stable and on by
   default, so the worker may `spawn_agent` natively at its own discretion,
@@ -294,7 +307,7 @@ price of "no forged results" under the documented hook surface.
 | no paired session / codex missing | hook passthrough; if reached anyway, `tandem sub` exits nonzero, bridge relays `[tandem-sub failed]`, main model does the work itself |
 | codex exec nonzero / outage | bridge relays output + `[tandem-sub failed]`; main model retries or does the work natively |
 | shadow missing on `--context full` | seed a fresh rollout from the drained active side (existing `_create_codex_shadow_late` pattern) |
-| parallel dispatches, full mode | file lock serializes drain-then-copy; execs then run concurrently. Match mode touches no shared state — no contention |
+| parallel dispatches, full mode | file lock serializes drain-then-copy; execs then run concurrently. The other drainer is the *session's own tail thread*, running continuously against the same cursor in the `tandem run` process; it takes `_sub_lock` around each drain too, so both sides serialize on one flock. (Guarding only the `tandem sub` side left two concurrent drains of one cursor row free to translate the same lines twice — duplicate turns and call ids in the fork.) Match mode touches no shared state — no contention |
 | dangling calls at fork time | `flush_dangling` closes them (both replay APIs reject dangles) |
 
 ## Known v1 limitations (stated, accepted)
@@ -304,6 +317,13 @@ price of "no forged results" under the documented hook surface.
   shared block). `tandem doctor` nudges users to move subagent-relevant
   rules into the shared block.
 - Named agents' `skills:` preloads are not forwarded (definition body is).
+- A named agent's `tools:` restriction is silently dropped on reroute: the
+  definition body is inlined into the brief, but the allow-list is not
+  translated into any codex-side constraint, so a read-only Explore-style
+  agent runs its codex worker under codex's own sandbox config — which may
+  be write-capable. v2 direction: map a read-only `tools:` list to `codex
+  exec -s read-only` (and refuse to reroute restrictions that have no codex
+  equivalent).
 - Rerouted workers are not resumable via SendMessage the way Claude
   subagents are; `keep_forks` + `codex exec resume` is the v2 path.
 - Thinking blocks do not cross translation (dropped, as elsewhere in
@@ -377,7 +397,7 @@ price of "no forged results" under the documented hook surface.
 
 ## Testing
 
-- Unit: `hook-route` stdin→stdout fixtures (rewrite, all four passthrough
+- Unit: `hook-route` stdin→stdout fixtures (rewrite, all passthrough
   cases, model-field rewrite, named-agent body inlining, crash→exit-0);
   fork op golden tests (session_meta rewrite, fork never in sync cursors);
   `tandem sub` argv/stdin handling via the existing `_run` seam; config

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -81,7 +81,7 @@ fleet state; codex manages its own interior fanout.
 
 ### `tandem sub` (new op + CLI command)
 
-`tandem sub [-m MODEL] [--context task|full] [TASK]` — task read from
+`tandem sub [-m MODEL] [--context task|full] [-q] [TASK]` — task read from
 stdin when not passed as an argument (Claude briefs are multi-paragraph;
 stdin avoids argv quoting and length limits). With no `--context` flag the
 config policy decides: `match` resolves to `task`, because every rerouted
@@ -115,6 +115,18 @@ dispatch in v1 is fresh-type (forks pass through natively).
   `spawn_agent` natively at its own discretion.
 - Output: codex exec's streamed activity passes through to stdout as it
   runs; the final message is printed last. Exit code mirrors codex exec.
+- `-q/--quiet` (what the bridge agent uses): the raw transcript is
+  redirected to `~/.tandem/subagents/<tandem-id>/logs/<run-id>.log` and the
+  command's **entire stdout is the worker's final message**, captured via
+  codex's own `-o/--output-last-message` into `<run-id>.last`. Without this
+  the bridge's Bash output is the whole exec log — header, actions, token
+  counts — and "return the final message verbatim" is not something a
+  haiku-tier relay can do reliably; quiet mode removes the extraction step
+  rather than trusting it. If the `.last` file is missing or empty (codex
+  died first), the log's tail is printed instead, so a failed relay still
+  carries the error text. Both files are retained as the debugging trail.
+  Non-quiet behavior is unchanged: stdio is inherited and manual runs
+  stream live.
 - Cleanup: delete the worker's rollout (fork or seed) on completion.
   `keep_forks = true` retains it under `~/.tandem/subagents/<tandem-id>/`
   for debugging (and as the future resume path for follow-up messages to a
@@ -171,11 +183,16 @@ it rewrite an unrelated tool's input.
 ### The plugin (`plugin/` in this repo)
 
 - `agents/codex-worker.md` — frontmatter: `model: haiku`,
-  `tools: Bash(tandem sub:*)`. Body: run `tandem sub` with the brief on
+  `tools: Bash(tandem sub:*)`. Body: run `tandem sub -q` with the brief on
   stdin and a generous Bash timeout (codex runs can be long; background
-  subagents keep Bash, so backgrounding is safe); return the final message
-  verbatim — no summarizing, no commentary; on nonzero exit, return the
-  output prefixed `[tandem-sub failed]` and stop.
+  subagents keep Bash, so backgrounding is safe); the command's entire
+  output IS the final message, so return it verbatim — no summarizing, no
+  commentary; on nonzero exit, return the output prefixed
+  `[tandem-sub failed]` and stop. The heredoc delimiter is chosen per
+  dispatch: `TANDEM_TASK_EOF` unless that string occurs in the brief, else
+  the same with random digits appended. A fixed delimiter is a shell
+  injection hazard — a brief containing that line (this repo's own docs do)
+  would end the heredoc early and run the remainder as shell.
 - `hooks/hooks.json` — PreToolUse, matcher `Agent|Task` (defensive: the
   alias guarantee covers settings/agent definitions, not hook matchers
   explicitly), command `tandem hook-route || true`. The `|| true` is
@@ -224,9 +241,12 @@ contract a fork asks for — only reachable in v1 by forcing `context =
 
 - Claude's native task panel lists every bridge as a running subagent —
   fleet liveness for free.
-- `codex exec` stdout streams inside the bridge's Bash call and is visible
-  in the TUI task/transcript view today; that rendering is real but
-  contractually unspecified — do not build load-bearing UX on it.
+- Bridge runs no longer stream into the tool view: the bridge passes `-q`,
+  so codex's activity goes to a log file and only the final message reaches
+  stdout. That is the deliberate trade for a relay that cannot garble the
+  result. Manual `tandem sub` (no `-q`) still streams live in the terminal,
+  and the per-run logs under `~/.tandem/subagents/<tandem-id>/logs/` are the
+  debugging trail for what a worker actually did.
 - `tandem status` (run from a second terminal, or `! tandem status` inside
   claude, which costs a little context) grows a section listing active
   workers: model, cold/fork, rollout path, retained forks.

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -1,6 +1,7 @@
 # Codex-model subagents — design
 
-2026-07-31. Status: approved design, pre-implementation.
+2026-07-31. Status: implemented; spikes S1–S4 and the live E2E run against
+claude 2.1.220 / codex 0.145.0 on 2026-07-31 (results recorded inline).
 
 ## Goal
 
@@ -55,7 +56,7 @@ never a process.
 ```
 user ──▶ claude (native UI; native Agent dispatch, one call per subagent)
              │  PreToolUse (plugin-registered) runs: tandem hook-route
-             │  → allow + updatedInput {subagent_type: codex-worker,
+             │  → allow + updatedInput {subagent_type: tandem:codex-worker,
              │     model: <cheap claude driver>, prompt: brief}
              ▼
          codex-worker bridge (haiku driver, Bash-only, plugin-shipped)
@@ -110,9 +111,10 @@ dispatch in v1 is fresh-type (forks pass through natively).
   `codex exec resume <fork-id> -m <model>` with the brief. The fork is
   **never registered as a sync source**: no cursor, no echo-suppression
   changes, shadow untouched.
-- Fanout: pass the codex feature flag enabling multi-agent tools when
-  `allow_fanout = true` (flag name pinned by spike S2), so the worker may
-  `spawn_agent` natively at its own discretion.
+- Fanout: pass `--enable <fanout_feature>` when configured. On codex 0.145
+  nothing needs passing (S2): the `multi_agent` feature is stable and on by
+  default, so the worker may `spawn_agent` natively at its own discretion,
+  and its children inherit its (cheap) model unless it overrides them.
 - Output: codex exec's streamed activity passes through to stdout as it
   runs; the final message is printed last. Exit code mirrors codex exec.
 - `-q/--quiet` (what the bridge agent uses): the raw transcript is
@@ -147,12 +149,19 @@ Reads the PreToolUse JSON from stdin. Emits nothing (exit 0) — meaning
 - `route = "off"` in config;
 - `subagent_type` is `"fork"` (claude forks stay native in v1 — they're
   prompt-cache-cheap and semantically claude's own full-context worker);
-- `subagent_type` is already `codex-worker` (loop guard).
+- `subagent_type` is already the bridge (loop guard) — matched
+  scope-insensitively (`…:codex-worker` or bare `codex-worker`), because
+  the model asks for it both ways once it sees the name in an error.
 
 Otherwise emit `allow` + `updatedInput`. `updatedInput` replaces the whole
 input object, so it carries every original field with three rewrites:
 
-1. `subagent_type` → `codex-worker`.
+1. `subagent_type` → `tandem:codex-worker`. **Plugin-scoped, load-bearing:**
+   claude registers a plugin's agents as `<plugin-name>:<agent-name>` and
+   rejects the bare name — live E2E (2.1.220, 2026-07-31) failed every
+   dispatch with `Agent type 'codex-worker' not found. Available agents:
+   …, tandem:codex-worker`. A test pins the rewrite target to
+   `plugin.json`'s `name` + the agent file's `name:` so the two cannot drift.
 2. `model` → the cheap claude driver (`haiku`). **Load-bearing:** real
    traces show dispatches carry `model: "opus"`, and the per-invocation
    model param overrides agent frontmatter — without this rewrite the
@@ -192,26 +201,40 @@ it rewrite an unrelated tool's input.
   dispatch: `TANDEM_TASK_EOF` unless that string occurs in the brief, else
   the same with random digits appended. A fixed delimiter is a shell
   injection hazard — a brief containing that line (this repo's own docs do)
-  would end the heredoc early and run the remainder as shell.
+  would end the heredoc early and run the remainder as shell. The body
+  opens with an unconditional **"you never do the task yourself"** rule
+  (S4: without it, haiku answered a one-command task directly instead of
+  delegating — correct answer, zero savings, silent policy failure).
 - `hooks/hooks.json` — PreToolUse, matcher `Agent|Task` (defensive: the
   alias guarantee covers settings/agent definitions, not hook matchers
   explicitly), command `tandem hook-route || true`. The `|| true` is
   load-bearing, not cosmetic: click's usage-error path exits 2 outside the
   command body (version skew — plugin installed, older tandem on PATH
   lacking the subcommand), and exit 2 blocks the dispatch.
-- Install: local plugin from the repo for v1 (marketplace later).
-  Registration is the plugin's entire job; policy lives in tandem config.
+- Install: local plugin from a clone of this repo for v1 —
+  `claude --plugin-dir /path/to/tandem/plugin` (marketplace later). The
+  wheel packages `src/tandem` only, so `pip install tandem-cli` alone never
+  reroutes anything; the README says so explicitly. Registration is the
+  plugin's entire job; policy lives in tandem config.
 
 ### Config (`~/.tandem/config.toml`, new file; `TANDEM_HOME` honored)
 
 ```toml
 [subagents]
-route = "all"          # all | off        (later: matchers, route_forks)
-model = "…"            # cheap codex model id; default pinned by spike S1
-context = "match"      # match | task | full
-allow_fanout = true    # codex-native spawn_agent inside workers
+route = "all"           # all | off        (later: matchers, route_forks)
+model = "gpt-5.6-luna"  # cheap codex model id ("" = codex's own default)
+context = "match"       # match | task | full
+fanout_feature = ""     # codex --enable <name>; "" = don't pass the flag
 keep_forks = false
 ```
+
+`fanout_feature` replaces the planned `allow_fanout` boolean: S2 found no
+flag to toggle on codex 0.145 (multi-agent is on by default), so a boolean
+would have had nothing to switch. The string is the escape hatch for a
+future codex that gates fanout behind a named feature — empty means "pass
+no `--enable`", which is the correct value today. **Do not set it blindly:**
+`codex exec --enable <unknown>` exits 1 with `Error: Unknown feature flag`
+before the model is ever called, which would fail every worker.
 
 `context = "match"` is the core policy: mirror the context decision Claude
 itself made per dispatch. Fresh-type dispatch → task-only (Claude wrote a
@@ -287,18 +310,65 @@ price of "no forged results" under the documented hook surface.
   tandem).
 - Fork-type dispatches stay on Claude (`route_forks` is a later option).
 
-## Spikes (before or during implementation)
+## Spikes — run live 2026-07-31 (claude 2.1.220, codex 0.145.0)
 
-- **S1**: enumerate cheap codex model ids available under this ChatGPT
-  plan; confirm `codex exec resume <fork> -m <model>` honors the override
-  on a tandem-authored rollout (fresh uuid7 should dodge the per-thread
-  model cache in `state_5.sqlite` — verify).
-- **S2**: codex multi-agent feature flag name for `--enable`; whether
-  spawned workers start cold (expected) — informs `allow_fanout` wiring.
-- **S3**: confirm the `Agent|Task` hook matcher fires on claude 2.1.220,
-  and the exact `updatedInput` echo behavior on an Agent call.
-- **S4**: haiku bridge relays long results verbatim without embellishment
-  (prompt-tune the agent body if not).
+- **S1** — *cheap codex model ids, and whether `-m` survives a resume of a
+  tandem-authored rollout.* The plan's slugs come from
+  `~/.codex/models_cache.json`: `gpt-5.6-sol` (account default, frontier),
+  `gpt-5.6-terra`, `gpt-5.6-luna` ("fast and affordable"), `gpt-5.5`,
+  `gpt-5.4`, `gpt-5.4-mini` ("small, fast, cost-efficient"). `codex exec -m
+  gpt-5.6-luna` and `-m gpt-5.4-mini` both answered; an unknown id fails
+  loudly and distinctively — HTTP 400 `The '<id>' model is not supported
+  when using Codex with a ChatGPT account.` **`-m` is honored on resume:**
+  `tandem sub -m gpt-5.6-luna --context task` on a freshly seeded
+  `originator: "tandem-sub"` rollout produced `turn_context.model =
+  "gpt-5.6-luna"` and `thread_settings_applied.model = "gpt-5.6-luna"` in
+  the retained rollout, while the account default stayed `gpt-5.6-sol` — no
+  per-thread model cache interference. Shipped guidance: `model =
+  "gpt-5.6-luna"` (`gpt-5.4-mini` for the cheapest tier).
+- **S2** — *fanout feature flag; do spawned workers start cold?* **There is
+  no flag to pass on 0.145.** `codex features list` reports `multi_agent`
+  as stage `stable`, effective `true` by default; `multi_agent_v2` is
+  stable-but-off; `multi_agent_mode` and `enable_fanout` are stage
+  `removed`. The tandem-seeded worker rollout recorded
+  `turn_context.multi_agent_version = "v1"` with no flag passed, so workers
+  can already `spawn_agent`. `fanout_feature` therefore ships empty and
+  exists only for a future codex that gates this; a wrong value is fatal
+  (`codex exec --enable <unknown>` → `Error: Unknown feature flag`, exit 1,
+  before any model call). Spawned workers **do** start cold: the
+  `multi_agent_v1` tool schema defines `fork_context` as "True forks the
+  current thread history into the new agent; false or omitted starts with
+  only the initial prompt", and children "inherit your current model by
+  default" — so a cheap parent keeps its whole subtree cheap.
+- **S3** — *does the `Agent|Task` matcher fire, and how is `updatedInput`
+  echoed?* Fires on 2.1.220 (`hook_name: "PreToolUse:Agent"`), and the
+  rewrite is applied: `task_started` carries `subagent_type:
+  "tandem:codex-worker"`, the worker's sidechain entries carry
+  `attributionAgent: "tandem:codex-worker"` / `attributionPlugin:
+  "tandem"`, and it ran on `claude-haiku-4-5` — the `model` rewrite does
+  override the dispatch's own model, as the design assumed. Echo behavior:
+  the assistant's `tool_use` block in the transcript keeps the **original**
+  input; the hook's stdout lands beside it as a `hook_success` attachment
+  (and as a `hook_response` event under `--include-hook-events`). So the
+  transcript shows the pre-rewrite dispatch — `task_started` is where the
+  effective input is visible. **Defect found here:** rewriting to the bare
+  `codex-worker` failed every dispatch (`Agent type 'codex-worker' not
+  found. Available agents: …, tandem:codex-worker`); the rewrite target is
+  now the plugin-scoped id (see hook-route above).
+- **S4** — *does the haiku bridge relay verbatim?* Not with the original
+  agent body: on a one-command task it answered directly with `find`
+  instead of delegating. The body **was** in its system prompt (probed via
+  `claude -p --agent tandem:codex-worker`) and `tools: Bash(tandem sub:*)`
+  **did** narrow its toolset to Bash alone — but nothing forbade doing the
+  work, so it did. Fixed by an unconditional "you never do the task
+  yourself … `tandem sub` is the ONLY command you may ever run" rule at the
+  top of the body. After the fix the bridge ran `tandem sub -q` with the
+  brief on a heredoc and returned codex's final message **byte-for-byte
+  identical** to the `-o/--output-last-message` file. Caveat: verified on a
+  short result; the mechanism copies stdout, so long-result risk is model
+  discipline, not extraction. Note `Bash(tandem sub:*)` constrains the
+  *tool list*, not the *command* — a session that broadly allows `Bash`
+  still lets the relay run anything, which is how the deviation happened.
 
 ## Testing
 
@@ -309,9 +379,24 @@ price of "no forged results" under the documented hook surface.
   parsing.
 - Integration: golden claude transcript containing background Agent
   dispatch + task-notification → shadow sync unchanged and complete.
-- Live E2E (manual, this repo): dispatch a real subagent under the plugin,
-  observe reroute, codex execution, result return, `switch`, and both-side
-  resume; `tandem doctor` green throughout.
+- Live E2E — run 2026-07-31 headlessly (`claude -p … --plugin-dir <repo>/plugin
+  --output-format stream-json --include-hook-events`, scratch project with a
+  paired session under a scratch `TANDEM_HOME`). All of it verified in one
+  run: hook fires and rewrites (`task_started.subagent_type =
+  tandem:codex-worker`, worker on `claude-haiku-4-5`); bridge runs `tandem
+  sub -q` with the brief on a heredoc; a `tandem-sub` rollout is created in
+  the session cwd and the codex worker does the work on `gpt-5.6-luna`;
+  `tandem status` shows `subagent running: gpt-5.6-luna (task) …` while it
+  runs and the marker is gone after; the Agent tool result equals codex's
+  final message byte-for-byte, and the parent repeats it verbatim; `tandem
+  sync` lands the dispatch in the shadow as a native `function_call`
+  `Agent` + `function_call_output` pair; after `tandem switch`, a real
+  `codex exec resume <shadow>` answered a question about the subagent's
+  result from synced context; `tandem doctor` green.
+  Not reachable headlessly, left for manual interactive verification: the
+  interactive task-panel view of running workers, and the background
+  (`run_in_background: true`) return path — the foreground path was the one
+  exercised.
 
 ## Later
 

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -61,7 +61,7 @@ user ──▶ claude (native UI; native Agent dispatch, one call per subagent)
          codex-worker bridge (haiku driver, Bash-only, plugin-shipped)
              │  runs: tandem sub -m <mini>   (brief on stdin)
              ▼
-         tandem: match-mode → cold `codex exec -m <mini>` in cwd
+         tandem: match-mode → seed empty rollout, `codex exec resume` in cwd
                  full-mode  → drain, fork shadow rollout, `codex exec resume`
              ▼
          codex model works in the stock codex harness (may spawn_agent deeper)
@@ -90,9 +90,19 @@ dispatch in v1 is fresh-type (forks pass through natively).
 - **Invariant: the brief is forwarded verbatim — no truncation, no
   summarization, at any step.**
 - `--context task` (what match-mode resolves to for non-fork dispatches):
-  no fork, no drain — run `codex exec -m <model> --skip-git-repo-check`
-  with the brief, in the session cwd. Project rules reach the worker the
-  native way: codex reads the AGENTS.md tandem already keeps synced.
+  no fork, no drain, no lock — seed a minimal rollout (fresh uuid7,
+  `originator: "tandem-sub"`, `model_provider: "openai"`, one note line and
+  no history) and run `codex exec -m <model> --skip-git-repo-check resume
+  <seed-id>` with the brief, in the session cwd. The worker still starts
+  cold; the seed exists so tandem *authors* the rollout rather than letting
+  codex mint one. A plain `codex exec` would write an ordinary rollout in
+  the session cwd — non-tandem originator, fresh mtime — which is exactly
+  what `await_codex_rollout` treats as "codex just minted a session": a
+  concurrent fresh-codex launch or one-off would bind the pair's
+  `codex_session_id` to a throwaway worker transcript that `tandem sub`
+  then deletes. Seeding puts cold runs behind the same originator guard as
+  forks, so no sub rollout is ever adoptable. Project rules reach the worker
+  the native way: codex reads the AGENTS.md tandem already keeps synced.
 - `--context full`: drain the active source with `flush_dangling` (same
   machinery as `run_oneoff`), copy the shadow rollout to a fresh uuid7
   rollout in codex's sessions dir — rewrite `session_meta` id, set
@@ -105,9 +115,10 @@ dispatch in v1 is fresh-type (forks pass through natively).
   `spawn_agent` natively at its own discretion.
 - Output: codex exec's streamed activity passes through to stdout as it
   runs; the final message is printed last. Exit code mirrors codex exec.
-- Cleanup: delete the fork on completion. `keep_forks = true` retains it
-  under `~/.tandem/subagents/<tandem-id>/` for debugging (and as the future
-  resume path for follow-up messages to a finished worker).
+- Cleanup: delete the worker's rollout (fork or seed) on completion.
+  `keep_forks = true` retains it under `~/.tandem/subagents/<tandem-id>/`
+  for debugging (and as the future resume path for follow-up messages to a
+  finished worker).
 - If codex is missing, unsupported, or the cwd has no paired session:
   exit nonzero with a one-line reason (the bridge relays it).
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "tandem",
+  "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
+  "version": "0.1.0",
+  "author": {"name": "tandem"}
+}

--- a/plugin/agents/codex-worker.md
+++ b/plugin/agents/codex-worker.md
@@ -7,19 +7,27 @@ tools: Bash(tandem sub:*)
 
 You are a relay between this session and a codex worker. Do exactly this:
 
-1. Run ONE command: `tandem sub` with your ENTIRE task message — every
+1. Run ONE command: `tandem sub -q` with your ENTIRE task message — every
    line, byte-for-byte, nothing added or removed — on stdin, via heredoc:
 
    ```
-   tandem sub <<'TANDEM_TASK_EOF'
+   tandem sub -q <<'TANDEM_TASK_EOF'
    <your entire task message here>
    TANDEM_TASK_EOF
    ```
 
+   Choose the delimiter BEFORE writing the command: use `TANDEM_TASK_EOF`
+   unless that string appears anywhere in the task message; in that case
+   append random digits (e.g. `TANDEM_TASK_EOF_84613`) and check again,
+   until the delimiter appears nowhere in the message. A delimiter that
+   collides with a line of the task ends the heredoc early — the brief is
+   truncated and the rest of it runs as shell commands.
+
    Set the Bash tool's timeout parameter to 600000 (codex runs are long).
 
-2. If the command exits 0: return its final message as your final message,
-   verbatim — no summary, no commentary, no added headers.
+2. If the command exits 0: its entire output IS the worker's final message.
+   Return that output as your final message, verbatim — no summary, no
+   commentary, no added headers, nothing trimmed.
 
 3. If it exits nonzero: return its output prefixed with
    `[tandem-sub failed]` and stop. Do not attempt the task yourself.

--- a/plugin/agents/codex-worker.md
+++ b/plugin/agents/codex-worker.md
@@ -5,7 +5,16 @@ model: haiku
 tools: Bash(tandem sub:*)
 ---
 
-You are a relay between this session and a codex worker. Do exactly this:
+You are a relay between this session and a codex worker.
+
+**You never do the task yourself.** Not when it looks trivial, not when one
+command would obviously answer it, not when you already know the answer.
+The whole point of this agent is that the work runs on a codex model
+instead of this one — so `tandem sub` is the ONLY command you may ever run.
+Investigating, searching, reading files, or answering from your own
+knowledge is a failure of this agent, even if the answer is correct.
+
+Do exactly this:
 
 1. Run ONE command: `tandem sub -q` with your ENTIRE task message — every
    line, byte-for-byte, nothing added or removed — on stdin, via heredoc:
@@ -30,4 +39,5 @@ You are a relay between this session and a codex worker. Do exactly this:
    commentary, no added headers, nothing trimmed.
 
 3. If it exits nonzero: return its output prefixed with
-   `[tandem-sub failed]` and stop. Do not attempt the task yourself.
+   `[tandem-sub failed]` and stop. Do not attempt the task yourself — the
+   session that dispatched you decides what happens next.

--- a/plugin/agents/codex-worker.md
+++ b/plugin/agents/codex-worker.md
@@ -1,0 +1,25 @@
+---
+name: codex-worker
+description: Executes delegated tasks on a codex model via tandem. Dispatched automatically by tandem's reroute hook; not meant for manual selection.
+model: haiku
+tools: Bash(tandem sub:*)
+---
+
+You are a relay between this session and a codex worker. Do exactly this:
+
+1. Run ONE command: `tandem sub` with your ENTIRE task message — every
+   line, byte-for-byte, nothing added or removed — on stdin, via heredoc:
+
+   ```
+   tandem sub <<'TANDEM_TASK_EOF'
+   <your entire task message here>
+   TANDEM_TASK_EOF
+   ```
+
+   Set the Bash tool's timeout parameter to 600000 (codex runs are long).
+
+2. If the command exits 0: return its final message as your final message,
+   verbatim — no summary, no commentary, no added headers.
+
+3. If it exits nonzero: return its output prefixed with
+   `[tandem-sub failed]` and stop. Do not attempt the task yourself.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {"type": "command", "command": "tandem hook-route || true"}
+        ]
+      }
+    ]
+  }
+}

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -289,6 +289,40 @@ def run_cmd(target: str, prompt: tuple[str, ...]) -> None:
 
 
 @main.command()
+@click.option("-m", "--model", default=None,
+              help="Codex model for this worker (config default otherwise).")
+@click.option("--context", "context_mode",
+              type=click.Choice(["task", "full"]), default=None,
+              help="Worker context: cold task-only, or a full fork of the "
+                   "paired session (config policy decides by default).")
+@click.argument("task", required=False)
+def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
+    """Run one delegated subagent task on codex (task argument or stdin).
+
+    Used by the tandem plugin's codex-worker bridge; also works manually."""
+    from . import ops
+    from .config import load_subagents_config
+
+    if task is None or task == "-":
+        task = sys.stdin.read()
+    task = task.strip()
+    if not task:
+        click.secho("error: empty task brief.", fg="red", err=True)
+        sys.exit(1)
+    cfg = load_subagents_config()
+    with StateStore() as store:
+        session = _require_session(store)
+        code = ops.run_sub(
+            store, session, task,
+            model=model if model is not None else cfg.model,
+            context=context_mode or ("full" if cfg.context == "full" else "task"),
+            fanout_feature=cfg.fanout_feature,
+            keep_forks=cfg.keep_forks,
+        )
+    sys.exit(code)
+
+
+@main.command()
 @click.option(
     "--live",
     is_flag=True,

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -170,6 +170,21 @@ def status() -> None:
         qdir = paths.quarantine_dir(session.tandem_id)
         if qdir.is_dir() and any(qdir.iterdir()):
             click.echo(f"  quarantine: {qdir} (has entries)")
+        sub_root = paths.tandem_home() / "subagents" / session.tandem_id
+        run_dir = sub_root / "running"
+        if run_dir.is_dir():
+            for m in sorted(run_dir.glob("*.json")):
+                try:
+                    d = json.loads(m.read_text())
+                except (OSError, ValueError):
+                    continue
+                click.echo(
+                    f"  subagent running: {d.get('model') or 'default-model'} "
+                    f"({d.get('context')}) {d.get('task_preview', '')}"
+                )
+        kept = sorted(sub_root.glob("rollout-*.jsonl")) if sub_root.is_dir() else []
+        if kept:
+            click.echo(f"  retained forks: {len(kept)} under {sub_root}")
 
 
 @main.command()

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -320,6 +321,36 @@ def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
             keep_forks=cfg.keep_forks,
         )
     sys.exit(code)
+
+
+@main.command(name="hook-route")
+def hook_route_cmd() -> None:
+    """Claude Code PreToolUse hook: reroute subagent dispatches to codex.
+
+    Reads hook JSON on stdin; prints a decision or nothing. ALWAYS exits 0
+    — exit 2 would block the dispatch, and any failure here must degrade
+    to native behavior."""
+    try:
+        from .config import load_subagents_config
+        from .hookroute import route
+
+        payload = json.loads(sys.stdin.read() or "{}")
+        cwd = payload.get("cwd") or _cwd()
+        cfg = load_subagents_config()
+        with StateStore() as store:
+            session = store.latest_session_for_cwd(cwd)
+        codex_ok = False
+        if session is not None:
+            adapter = get_adapter("codex")
+            v = adapter.detect_version()
+            codex_ok = v is not None and adapter.version_supported(v)
+        decision = route(payload, cfg, cwd, paths.claude_home(),
+                         has_session=session is not None, codex_ok=codex_ok)
+        if decision is not None:
+            click.echo(json.dumps(decision))
+    except Exception:
+        pass
+    sys.exit(0)
 
 
 @main.command()

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -327,9 +327,15 @@ def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
 def hook_route_cmd() -> None:
     """Claude Code PreToolUse hook: reroute subagent dispatches to codex.
 
-    Reads hook JSON on stdin; prints a decision or nothing. ALWAYS exits 0
-    — exit 2 would block the dispatch, and any failure here must degrade
-    to native behavior."""
+    Reads hook JSON on stdin; prints a decision or nothing. This function
+    ALWAYS exits 0 — exit 2 would block the dispatch, and any failure here
+    must degrade to native behavior.
+
+    The function body is not the whole story: click's usage-error path exits
+    2 before this ever runs (version skew — plugin installed, an older
+    tandem on PATH without this subcommand — or a stray argument). So the
+    hook MUST be registered as `tandem hook-route || true`; that shell guard
+    is what makes exit 2 unreachable in practice."""
     try:
         from .config import load_subagents_config
         from .hookroute import route

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -178,6 +178,8 @@ def status() -> None:
                     d = json.loads(m.read_text())
                 except (OSError, ValueError):
                     continue
+                if not isinstance(d, dict):
+                    continue  # non-object marker: skip it, never traceback
                 click.echo(
                     f"  subagent running: {d.get('model') or 'default-model'} "
                     f"({d.get('context')}) {d.get('task_preview', '')}"

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -296,8 +296,13 @@ def run_cmd(target: str, prompt: tuple[str, ...]) -> None:
               type=click.Choice(["task", "full"]), default=None,
               help="Worker context: cold task-only, or a full fork of the "
                    "paired session (config policy decides by default).")
+@click.option("-q", "--quiet", is_flag=True,
+              help="Print only the worker's final message (raw codex output "
+                   "goes to a log under ~/.tandem/subagents/<id>/logs). Used "
+                   "by the bridge agent, which relays stdout verbatim.")
 @click.argument("task", required=False)
-def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
+def sub(model: str | None, context_mode: str | None, quiet: bool,
+        task: str | None) -> None:
     """Run one delegated subagent task on codex (task argument or stdin).
 
     Used by the tandem plugin's codex-worker bridge; also works manually."""
@@ -319,6 +324,7 @@ def sub(model: str | None, context_mode: str | None, task: str | None) -> None:
             context=context_mode or ("full" if cfg.context == "full" else "task"),
             fanout_feature=cfg.fanout_feature,
             keep_forks=cfg.keep_forks,
+            quiet=quiet,
         )
     sys.exit(code)
 

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -29,7 +29,9 @@ def load_subagents_config() -> SubagentsConfig:
     try:
         with open(paths.tandem_home() / "config.toml", "rb") as f:
             data = tomllib.load(f)
-    except (OSError, tomllib.TOMLDecodeError):
+    # ValueError covers TOMLDecodeError (a subclass), the UnicodeDecodeError
+    # tomllib raises when the file is not UTF-8, and open()'s embedded-NUL path.
+    except (OSError, ValueError):
         return SubagentsConfig()
     raw = data.get("subagents")
     if not isinstance(raw, dict):

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -1,0 +1,51 @@
+"""User configuration: $TANDEM_HOME/config.toml, [subagents] table only.
+
+Unknown keys are ignored and every error yields defaults — configuration
+must never be the reason subagent routing breaks (the hook's failure mode
+is 'dispatch natively', and this module upholds it)."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+
+from . import paths
+
+
+@dataclass(frozen=True)
+class SubagentsConfig:
+    route: str = "all"          # "all" | "off"
+    model: str = ""             # "" -> omit -m; codex's configured default
+    context: str = "match"      # "match" | "task" | "full"
+    fanout_feature: str = ""    # --enable <name>; "" -> flag not passed
+    keep_forks: bool = False
+
+
+_ROUTES = ("all", "off")
+_CONTEXTS = ("match", "task", "full")
+
+
+def load_subagents_config() -> SubagentsConfig:
+    try:
+        with open(paths.tandem_home() / "config.toml", "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return SubagentsConfig()
+    raw = data.get("subagents")
+    if not isinstance(raw, dict):
+        return SubagentsConfig()
+    d = SubagentsConfig()
+
+    def pick(key: str, kind: type, default, allowed=None):
+        v = raw.get(key, default)
+        if not isinstance(v, kind) or (allowed and v not in allowed):
+            return default
+        return v
+
+    return SubagentsConfig(
+        route=pick("route", str, d.route, _ROUTES),
+        model=pick("model", str, d.model),
+        context=pick("context", str, d.context, _CONTEXTS),
+        fanout_feature=pick("fanout_feature", str, d.fanout_feature),
+        keep_forks=pick("keep_forks", bool, d.keep_forks),
+    )

--- a/src/tandem/constants.py
+++ b/src/tandem/constants.py
@@ -16,6 +16,12 @@ SEED_NOTE = (
     "this session's own tool vocabulary."
 )
 
+# Seed line of the minimal rollout a cold `tandem sub` worker resumes. Cold
+# workers get no shared history; the note exists so the rollout has model
+# context at all (codex resume and tandem's own validate_transcript both
+# reject a rollout with no response_item).
+SUB_SEED_NOTE = "[tandem] Delegated subagent worker session (no shared history)."
+
 # Untranslatable-entry placeholder (decision for the spec's open question).
 PLACEHOLDER = (
     "[tandem: turn {turn} could not be translated from {source} — {reason}; "

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -234,13 +234,26 @@ def run_doctor(store, session, live: bool = False) -> DoctorReport:
 
 
 def _subagent_checks(report: DoctorReport, session) -> None:
-    """Subagent routing hygiene: billing follows codex auth, and codex
-    workers only see CLAUDE.md content inside the tandem:shared block."""
+    """Subagent routing hygiene: routing is on by default but the model is
+    not chosen for you, billing follows codex auth, and codex workers only
+    see CLAUDE.md content inside the tandem:shared block."""
     from . import paths
     from .config import load_subagents_config
 
-    if load_subagents_config().route == "off":
+    cfg = load_subagents_config()
+    if cfg.route == "off":
         return
+    # model="" means no `-m`, i.e. the codex account default — the frontier
+    # tier on every plan seen so far. Combined with the route="all" default
+    # that silently sends every dispatch to the most expensive model, so it
+    # is a warning, not a note. The dataclass default stays empty on
+    # purpose: a baked-in id would 400 on accounts that lack it.
+    if not cfg.model:
+        report.warn(
+            "subagents: no model configured — workers will use your codex "
+            "account's default (set [subagents] model in "
+            "~/.tandem/config.toml to a cheap tier)"
+        )
     if os.environ.get("OPENAI_API_KEY"):
         report.warn(
             "subagents: OPENAI_API_KEY is set — codex may bill the API "

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -249,13 +249,16 @@ def _subagent_checks(report: DoctorReport, session) -> None:
     auth_path = paths.codex_home() / "auth.json"
     try:
         auth = json.loads(auth_path.read_text())
-        if auth.get("OPENAI_API_KEY") and not auth.get("tokens"):
-            report.warn(
-                "subagents: codex auth is API-key based — subagent runs "
-                "will bill the API, not the subscription"
-            )
     except (OSError, ValueError):
-        pass
+        auth = None
+    # valid JSON that is not an object would make .get raise AttributeError,
+    # which no doctor check may do: an unreadable auth.json is a skipped
+    # check, never a traceback.
+    if isinstance(auth, dict) and auth.get("OPENAI_API_KEY") and not auth.get("tokens"):
+        report.warn(
+            "subagents: codex auth is API-key based — subagent runs "
+            "will bill the API, not the subscription"
+        )
     claude_md = Path(session.cwd) / "CLAUDE.md"
     try:
         if "tandem:shared:begin" not in claude_md.read_text():

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -10,6 +10,7 @@ calls) on top.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -225,9 +226,46 @@ def run_doctor(store, session, live: bool = False) -> DoctorReport:
             f"{len(qfiles)} quarantined raw entr(y/ies) under {qdir}"
         )
 
+    _subagent_checks(report, session)
+
     if live:
         _live_resume_checks(report, session, transcripts)
     return report
+
+
+def _subagent_checks(report: DoctorReport, session) -> None:
+    """Subagent routing hygiene: billing follows codex auth, and codex
+    workers only see CLAUDE.md content inside the tandem:shared block."""
+    from . import paths
+    from .config import load_subagents_config
+
+    if load_subagents_config().route == "off":
+        return
+    if os.environ.get("OPENAI_API_KEY"):
+        report.warn(
+            "subagents: OPENAI_API_KEY is set — codex may bill the API "
+            "instead of your ChatGPT subscription"
+        )
+    auth_path = paths.codex_home() / "auth.json"
+    try:
+        auth = json.loads(auth_path.read_text())
+        if auth.get("OPENAI_API_KEY") and not auth.get("tokens"):
+            report.warn(
+                "subagents: codex auth is API-key based — subagent runs "
+                "will bill the API, not the subscription"
+            )
+    except (OSError, ValueError):
+        pass
+    claude_md = Path(session.cwd) / "CLAUDE.md"
+    try:
+        if "tandem:shared:begin" not in claude_md.read_text():
+            report.warn(
+                "subagents: CLAUDE.md has no tandem:shared block — project "
+                "rules will not reach codex workers (move subagent-relevant "
+                "rules into the shared block)"
+            )
+    except OSError:
+        pass
 
 
 def _live_resume_checks(report: DoctorReport, session, transcripts) -> None:

--- a/src/tandem/harness/codex.py
+++ b/src/tandem/harness/codex.py
@@ -50,15 +50,14 @@ class CodexAdapter(HarnessAdapter):
     def mint_session_id(self) -> str:
         return uuid7()
 
-    def create_shadow_transcript(
-        self, cwd: str, session_id: str, ctx: SessionContext, note: str
-    ) -> Path:
-        """Create a rollout file shaped like codex's own, headed by a
-        session_meta whose originator marks it as tandem-created."""
-        now = datetime.now(timezone.utc)
-        day_dir = paths.codex_sessions_dir() / now.strftime("%Y/%m/%d")
-        fname = f"rollout-{now.strftime('%Y-%m-%dT%H-%M-%S')}-{session_id}.jsonl"
-        path = day_dir / fname
+    def session_meta(
+        self, cwd: str, session_id: str, originator: str = "tandem"
+    ) -> dict[str, Any]:
+        """The session_meta first line codex expects for a rollout tandem
+        authored. `originator` must stay one of runner._TANDEM_ORIGINATORS:
+        rollout discovery skips exactly those, which is what keeps a
+        tandem-written rollout from being adopted as a freshly minted codex
+        session ("tandem-sub" marks throwaway subagent rollouts)."""
         version = "0.0.0"
         raw = self.detect_version()
         if raw:
@@ -66,7 +65,7 @@ class CodexAdapter(HarnessAdapter):
             if parsed:
                 version = ".".join(str(x) for x in parsed)
         ts = iso_now_ms()
-        meta = {
+        return {
             "timestamp": ts,
             "type": "session_meta",
             "payload": {
@@ -74,7 +73,7 @@ class CodexAdapter(HarnessAdapter):
                 "id": session_id,
                 "timestamp": ts,
                 "cwd": cwd,
-                "originator": "tandem",
+                "originator": originator,
                 "cli_version": version,
                 "source": "exec",
                 "thread_source": "user",
@@ -84,7 +83,21 @@ class CodexAdapter(HarnessAdapter):
                 "history_mode": "legacy",
             },
         }
-        entries = [meta] + self.render_note(note)
+
+    def rollout_path(self, session_id: str) -> Path:
+        """Where a rollout tandem writes for `session_id` lives — codex's own
+        naming (day directory + timestamped filename embedding the id)."""
+        now = datetime.now(timezone.utc)
+        day_dir = paths.codex_sessions_dir() / now.strftime("%Y/%m/%d")
+        return day_dir / f"rollout-{now.strftime('%Y-%m-%dT%H-%M-%S')}-{session_id}.jsonl"
+
+    def create_shadow_transcript(
+        self, cwd: str, session_id: str, ctx: SessionContext, note: str
+    ) -> Path:
+        """Create a rollout file shaped like codex's own, headed by a
+        session_meta whose originator marks it as tandem-created."""
+        path = self.rollout_path(session_id)
+        entries = [self.session_meta(cwd, session_id)] + self.render_note(note)
         append_jsonl_fsync(path, entries)
         return path
 

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -10,7 +10,13 @@ from pathlib import Path
 
 from .config import SubagentsConfig
 
-BRIDGE_AGENT = "codex-worker"
+# Claude registers a plugin's agents under `<plugin-name>:<agent-name>`, and
+# the bare name does NOT resolve. Live E2E on claude 2.1.220 (2026-07-31):
+# rewriting to "codex-worker" made every dispatch fail with
+#   Agent type 'codex-worker' not found. Available agents: …, tandem:codex-worker
+# so the rewrite must carry the plugin scope.
+BRIDGE_NAME = "codex-worker"
+BRIDGE_AGENT = f"tandem:{BRIDGE_NAME}"
 BRIDGE_MODEL = "haiku"
 
 
@@ -33,8 +39,11 @@ def route(
     if not isinstance(tool_input, dict):
         return None
     subagent_type = tool_input.get("subagent_type") or ""
-    # forks keep claude's native full-context contract; bridge = loop guard
-    if subagent_type in ("fork", BRIDGE_AGENT):
+    # forks keep claude's native full-context contract; bridge = loop guard.
+    # The guard is scope-insensitive: the model can (and in live traces does)
+    # ask for the bridge by either the plugin-scoped id or the bare name, and
+    # rewriting either one again would re-enter this hook forever.
+    if subagent_type == "fork" or subagent_type.rsplit(":", 1)[-1] == BRIDGE_NAME:
         return None
     prompt = tool_input.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -23,6 +23,10 @@ def route(
     has_session: bool,
     codex_ok: bool,
 ) -> dict | None:
+    # defense in depth: the plugin's matcher is `Agent|Task`, but a matcher is
+    # config we do not control at call time — never rewrite another tool's input
+    if payload.get("tool_name") not in ("Agent", "Task"):
+        return None
     if cfg.route != "all" or not has_session or not codex_ok:
         return None
     tool_input = payload.get("tool_input")

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -1,0 +1,99 @@
+"""PreToolUse routing: should this native Agent dispatch run on codex?
+
+Pure decision logic — the CLI wrapper owns process concerns (stdin, exit
+codes). Returning None means 'emit nothing': the dispatch proceeds
+natively. That is the failure mode for everything unexpected."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import SubagentsConfig
+
+BRIDGE_AGENT = "codex-worker"
+BRIDGE_MODEL = "haiku"
+
+
+def route(
+    payload: dict,
+    cfg: SubagentsConfig,
+    cwd: str,
+    claude_home: Path,
+    *,
+    has_session: bool,
+    codex_ok: bool,
+) -> dict | None:
+    if cfg.route != "all" or not has_session or not codex_ok:
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    subagent_type = tool_input.get("subagent_type") or ""
+    # forks keep claude's native full-context contract; bridge = loop guard
+    if subagent_type in ("fork", BRIDGE_AGENT):
+        return None
+    prompt = tool_input.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return None
+    body = find_agent_body(subagent_type, cwd, claude_home)
+    if body:
+        prompt = (
+            "Instructions for this task (from the dispatching session's "
+            f"{subagent_type!r} agent definition):\n\n{body}\n\n---\n\n"
+            + prompt
+        )
+    updated = dict(tool_input)
+    updated["subagent_type"] = BRIDGE_AGENT
+    # per-invocation model overrides agent frontmatter; without this rewrite
+    # the bridge would run on the dispatch's model (observed: opus)
+    updated["model"] = BRIDGE_MODEL
+    updated["prompt"] = prompt
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "tandem: rerouted to codex-worker",
+            "updatedInput": updated,
+        }
+    }
+
+
+def find_agent_body(subagent_type: str, cwd: str, claude_home: Path) -> str:
+    """The definition body a named claude agent would have received as its
+    system prompt: every .claude/agents/ from cwd up to the filesystem
+    root, then <claude_home>/agents/, searched recursively, first `name`
+    match wins. Built-in and plugin-scoped types have no local file."""
+    if not subagent_type or ":" in subagent_type:
+        return ""
+    bases: list[Path] = []
+    d = Path(cwd)
+    while True:
+        bases.append(d / ".claude" / "agents")
+        if d.parent == d:
+            break
+        d = d.parent
+    bases.append(claude_home / "agents")
+    for base in bases:
+        if not base.is_dir():
+            continue
+        for f in sorted(base.rglob("*.md")):
+            name, body = _parse_agent_file(f)
+            if name == subagent_type:
+                return body
+    return ""
+
+
+def _parse_agent_file(path: Path) -> tuple[str, str]:
+    try:
+        text = path.read_text()
+    except OSError:
+        return "", ""
+    name, body = path.stem, text
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            for line in text[3:end].splitlines():
+                if line.strip().startswith("name:"):
+                    name = line.split(":", 1)[1].strip()
+            body = text[end + 4:]
+    return name, body.strip()

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import os
 import subprocess
 import time
 from contextlib import contextmanager
@@ -254,3 +255,51 @@ def fork_shadow(store: StateStore, session: PairedSession) -> tuple[str, Path]:
     fork_path = day_dir / fname
     append_jsonl_fsync(fork_path, [meta] + entries[1:])
     return fork_id, fork_path
+
+
+def run_sub(
+    store: StateStore,
+    session: PairedSession,
+    task: str,
+    *,
+    model: str = "",
+    context: str = "task",
+    fanout_feature: str = "",
+    keep_forks: bool = False,
+) -> int:
+    """Execute one delegated subagent task on codex. context='task' is a
+    cold `codex exec` in the session cwd (claude wrote a self-contained
+    brief for a cold worker); context='full' forks the shadow and resumes
+    it. The brief is passed through verbatim. Exit code mirrors codex."""
+    adapter = get_adapter("codex")
+    argv = [adapter.binary, "exec", "--skip-git-repo-check"]
+    if model:
+        argv += ["-m", model]
+    if fanout_feature:
+        argv += ["--enable", fanout_feature]
+    fork_path: Path | None = None
+    fork_id = ""
+    if context == "full":
+        with _sub_lock():
+            fork_id, fork_path = fork_shadow(store, session)
+        argv += ["resume", fork_id]
+    argv.append(task)
+
+    sub_root = paths.tandem_home() / "subagents" / session.tandem_id
+    marker = sub_root / "running" / f"{fork_id or uuid7()}.json"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps({
+        "model": model, "context": context, "pid": os.getpid(),
+        "task_preview": task[:120],
+    }))
+    try:
+        code = _run(argv, cwd=session.cwd).returncode
+    finally:
+        marker.unlink(missing_ok=True)
+        if fork_path is not None:
+            if keep_forks:
+                sub_root.mkdir(parents=True, exist_ok=True)
+                fork_path.rename(sub_root / fork_path.name)
+            else:
+                fork_path.unlink(missing_ok=True)
+    return code

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -297,7 +298,8 @@ def run_sub(
     and resumes that instead. Either way the worker runs in a tandem-authored
     'tandem-sub' rollout that is never a sync source and never adoptable as
     the pair's own codex session, and is disposed of on exit. The brief is
-    passed through verbatim. Exit code mirrors codex.
+    passed through verbatim, on codex's stdin (`resume <id> -`), never as
+    argv. Exit code mirrors codex.
 
     quiet=True is the bridge-agent mode: codex's raw transcript goes to a log
     file and this command's ENTIRE stdout becomes the worker's final message
@@ -326,30 +328,43 @@ def run_sub(
         last_path, log_path = logs / f"{sub_id}.last", logs / f"{sub_id}.log"
         # exec-level flag: must precede the `resume` subcommand, like -m
         argv += ["-o", str(last_path)]
-    argv += ["resume", sub_id, task]
+    # `-` is codex's documented "read the prompt from stdin" marker. The brief
+    # must never be a trailing positional: it is untrusted text, so codex's own
+    # parser reads a leading `-` as a flag — "- review …" dies with `unexpected
+    # argument` before the model runs, and "-m gpt-9 …" is silently honored as
+    # a flag. stdin keeps it opaque, and drops the argv length limit too.
+    argv += ["resume", sub_id, "-"]
 
     marker = sub_root / "running" / f"{sub_id}.json"
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps({
         "model": model, "context": context, "pid": os.getpid(),
-        "task_preview": task[:120],
+        # collapsed: `tandem status` prints this on one line, and briefs are
+        # multi-paragraph
+        "task_preview": " ".join(task.split())[:120],
     }))
+    brief = task.encode()
     try:
         if quiet:
             with open(log_path, "wb") as fh:
-                code = _run(argv, cwd=session.cwd, stdout=fh,
+                code = _run(argv, cwd=session.cwd, input=brief, stdout=fh,
                             stderr=subprocess.STDOUT).returncode
         else:
-            code = _run(argv, cwd=session.cwd).returncode
+            code = _run(argv, cwd=session.cwd, input=brief).returncode
     finally:
+        # The worker's answer is what this run exists to produce; disposal is
+        # bookkeeping. Relay first so a raising cleanup cannot swallow a result
+        # codex already produced and billed for.
+        if quiet:
+            _relay_last_message(last_path, log_path)
         marker.unlink(missing_ok=True)
         if keep_forks:
             sub_root.mkdir(parents=True, exist_ok=True)
-            sub_path.rename(sub_root / sub_path.name)
+            # move, not rename: codex's sessions dir and TANDEM_HOME can sit on
+            # different filesystems, and rename() across devices raises
+            shutil.move(sub_path, sub_root / sub_path.name)
         else:
             sub_path.unlink(missing_ok=True)
-        if quiet:
-            _relay_last_message(last_path, log_path)
     return code
 
 

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -17,7 +17,6 @@ import os
 import subprocess
 import time
 from contextlib import contextmanager
-from datetime import datetime, timezone
 from pathlib import Path
 
 from . import paths
@@ -216,7 +215,8 @@ def _file_size(path: Path | None) -> int | None:
 @contextmanager
 def _sub_lock():
     """Serializes drain-then-fork across parallel `tandem sub` processes.
-    The cold task path never takes this lock — it touches no shared state."""
+    The cold task path never takes this lock — seeding its own empty rollout
+    touches no cursor and no shadow."""
     lock_path = paths.tandem_home() / "sub.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as f:
@@ -249,12 +249,34 @@ def fork_shadow(store: StateStore, session: PairedSession) -> tuple[str, Path]:
     meta["payload"]["id"] = fork_id
     meta["payload"]["session_id"] = fork_id
     meta["payload"]["originator"] = "tandem-sub"
-    now = datetime.now(timezone.utc)
-    day_dir = paths.codex_sessions_dir() / now.strftime("%Y/%m/%d")
-    fname = f"rollout-{now.strftime('%Y-%m-%dT%H-%M-%S')}-{fork_id}.jsonl"
-    fork_path = day_dir / fname
+    fork_path = get_adapter("codex").rollout_path(fork_id)
     append_jsonl_fsync(fork_path, [meta] + entries[1:])
     return fork_id, fork_path
+
+
+def seed_sub_rollout(session: PairedSession) -> tuple[str, Path]:
+    """Author the minimal rollout a cold (`context='task'`) worker resumes:
+    fresh uuid7 identity, originator 'tandem-sub', one seed note and no
+    shared history.
+
+    Cold runs resume this instead of `codex exec`-ing fresh because a plain
+    exec writes an ordinary rollout — non-tandem originator, session cwd,
+    fresh mtime — which `await_codex_rollout` would hand to the next
+    codex-id capture, binding the pair's codex_session_id to a throwaway
+    worker transcript tandem then deletes. Seeding keeps every sub rollout
+    behind the same discovery guard as forks.
+
+    Touches no cursor and no shadow: no drain, no `_sub_lock` needed.
+    Returns (seed_session_id, seed_path)."""
+    from .constants import SUB_SEED_NOTE
+
+    adapter = get_adapter("codex")
+    seed_id = adapter.mint_session_id()
+    seed_path = adapter.rollout_path(seed_id)
+    entries = [adapter.session_meta(session.cwd, seed_id, originator="tandem-sub")]
+    entries += adapter.render_note(SUB_SEED_NOTE)
+    append_jsonl_fsync(seed_path, entries)
+    return seed_id, seed_path
 
 
 def run_sub(
@@ -267,26 +289,28 @@ def run_sub(
     fanout_feature: str = "",
     keep_forks: bool = False,
 ) -> int:
-    """Execute one delegated subagent task on codex. context='task' is a
-    cold `codex exec` in the session cwd (claude wrote a self-contained
-    brief for a cold worker); context='full' forks the shadow and resumes
-    it. The brief is passed through verbatim. Exit code mirrors codex."""
+    """Execute one delegated subagent task on codex. context='task' resumes
+    a freshly seeded empty rollout in the session cwd (claude wrote a
+    self-contained brief for a cold worker); context='full' forks the shadow
+    and resumes that instead. Either way the worker runs in a tandem-authored
+    'tandem-sub' rollout that is never a sync source and never adoptable as
+    the pair's own codex session, and is disposed of on exit. The brief is
+    passed through verbatim. Exit code mirrors codex."""
     adapter = get_adapter("codex")
     argv = [adapter.binary, "exec", "--skip-git-repo-check"]
     if model:
         argv += ["-m", model]
     if fanout_feature:
         argv += ["--enable", fanout_feature]
-    fork_path: Path | None = None
-    fork_id = ""
     if context == "full":
         with _sub_lock():
-            fork_id, fork_path = fork_shadow(store, session)
-        argv += ["resume", fork_id]
-    argv.append(task)
+            sub_id, sub_path = fork_shadow(store, session)
+    else:
+        sub_id, sub_path = seed_sub_rollout(session)
+    argv += ["resume", sub_id, task]
 
     sub_root = paths.tandem_home() / "subagents" / session.tandem_id
-    marker = sub_root / "running" / f"{fork_id or uuid7()}.json"
+    marker = sub_root / "running" / f"{sub_id}.json"
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps({
         "model": model, "context": context, "pid": os.getpid(),
@@ -296,10 +320,9 @@ def run_sub(
         code = _run(argv, cwd=session.cwd).returncode
     finally:
         marker.unlink(missing_ok=True)
-        if fork_path is not None:
-            if keep_forks:
-                sub_root.mkdir(parents=True, exist_ok=True)
-                fork_path.rename(sub_root / fork_path.name)
-            else:
-                fork_path.unlink(missing_ok=True)
+        if keep_forks:
+            sub_root.mkdir(parents=True, exist_ok=True)
+            sub_path.rename(sub_root / sub_path.name)
+        else:
+            sub_path.unlink(missing_ok=True)
     return code

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -229,8 +229,10 @@ def _sub_lock():
 def fork_shadow(store: StateStore, session: PairedSession) -> tuple[str, Path]:
     """Copy the codex shadow rollout into a fresh ephemeral rollout for one
     subagent worker: same history, new uuid7 identity, originator
-    'tandem-sub'. The fork is NEVER registered as a sync source. Returns
-    (fork_session_id, fork_path)."""
+    'tandem-sub'. The fork is NEVER registered as a sync source. Callers MUST
+    hold `_sub_lock()` across this call: it drains the active source first,
+    and concurrent drains against the same cursor row corrupt sync state.
+    Returns (fork_session_id, fork_path)."""
     if not session.codex_session_id:
         _create_codex_shadow_late(store, session)
         session = store.get_session(session.tandem_id) or session

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -11,8 +11,12 @@ nothing synced ever bounces back.
 
 from __future__ import annotations
 
+import fcntl
+import json
 import subprocess
 import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 from . import paths
@@ -20,6 +24,7 @@ from .harness import get_adapter, other
 from .runner import TailLoop, await_codex_rollout
 from .state import PairedSession, StateStore
 from .sync import SyncEngine, SyncSetupError
+from .util import append_jsonl_fsync, read_jsonl, uuid7
 
 # seam for tests (patching subprocess.run itself would also intercept the
 # CLI version probes)
@@ -205,3 +210,45 @@ def _file_size(path: Path | None) -> int | None:
         return path.stat().st_size
     except OSError:
         return None
+
+
+@contextmanager
+def _sub_lock():
+    """Serializes drain-then-fork across parallel `tandem sub` processes.
+    The cold task path never takes this lock — it touches no shared state."""
+    lock_path = paths.tandem_home() / "sub.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def fork_shadow(store: StateStore, session: PairedSession) -> tuple[str, Path]:
+    """Copy the codex shadow rollout into a fresh ephemeral rollout for one
+    subagent worker: same history, new uuid7 identity, originator
+    'tandem-sub'. The fork is NEVER registered as a sync source. Returns
+    (fork_session_id, fork_path)."""
+    if not session.codex_session_id:
+        _create_codex_shadow_late(store, session)
+        session = store.get_session(session.tandem_id) or session
+    drain_source(store, session, session.active, flush_dangling=True)
+    src = source_transcript(session, "codex")
+    if src is None:
+        raise SyncSetupError("codex shadow rollout not found")
+    entries = read_jsonl(src)
+    if not entries or entries[0].get("type") != "session_meta":
+        raise SyncSetupError("shadow rollout has no session_meta first line")
+    fork_id = uuid7()
+    meta = json.loads(json.dumps(entries[0]))  # deep copy
+    meta["payload"]["id"] = fork_id
+    meta["payload"]["session_id"] = fork_id
+    meta["payload"]["originator"] = "tandem-sub"
+    now = datetime.now(timezone.utc)
+    day_dir = paths.codex_sessions_dir() / now.strftime("%Y/%m/%d")
+    fname = f"rollout-{now.strftime('%Y-%m-%dT%H-%M-%S')}-{fork_id}.jsonl"
+    fork_path = day_dir / fname
+    append_jsonl_fsync(fork_path, [meta] + entries[1:])
+    return fork_id, fork_path

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -15,6 +15,7 @@ import fcntl
 import json
 import os
 import subprocess
+import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -288,6 +289,7 @@ def run_sub(
     context: str = "task",
     fanout_feature: str = "",
     keep_forks: bool = False,
+    quiet: bool = False,
 ) -> int:
     """Execute one delegated subagent task on codex. context='task' resumes
     a freshly seeded empty rollout in the session cwd (claude wrote a
@@ -295,7 +297,15 @@ def run_sub(
     and resumes that instead. Either way the worker runs in a tandem-authored
     'tandem-sub' rollout that is never a sync source and never adoptable as
     the pair's own codex session, and is disposed of on exit. The brief is
-    passed through verbatim. Exit code mirrors codex."""
+    passed through verbatim. Exit code mirrors codex.
+
+    quiet=True is the bridge-agent mode: codex's raw transcript goes to a log
+    file and this command's ENTIRE stdout becomes the worker's final message
+    (via codex's own `-o/--output-last-message`). With inherited stdio the
+    caller would instead get the whole exec log — header, actions, token
+    counts — and asking a cheap relay model to extract "the final message"
+    from that is unreliable. quiet=False is byte-for-byte unchanged: stdio is
+    inherited so manual runs still stream live."""
     adapter = get_adapter("codex")
     argv = [adapter.binary, "exec", "--skip-git-repo-check"]
     if model:
@@ -307,9 +317,17 @@ def run_sub(
             sub_id, sub_path = fork_shadow(store, session)
     else:
         sub_id, sub_path = seed_sub_rollout(session)
-    argv += ["resume", sub_id, task]
 
     sub_root = paths.tandem_home() / "subagents" / session.tandem_id
+    last_path = log_path = None
+    if quiet:
+        logs = sub_root / "logs"
+        logs.mkdir(parents=True, exist_ok=True)
+        last_path, log_path = logs / f"{sub_id}.last", logs / f"{sub_id}.log"
+        # exec-level flag: must precede the `resume` subcommand, like -m
+        argv += ["-o", str(last_path)]
+    argv += ["resume", sub_id, task]
+
     marker = sub_root / "running" / f"{sub_id}.json"
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps({
@@ -317,7 +335,12 @@ def run_sub(
         "task_preview": task[:120],
     }))
     try:
-        code = _run(argv, cwd=session.cwd).returncode
+        if quiet:
+            with open(log_path, "wb") as fh:
+                code = _run(argv, cwd=session.cwd, stdout=fh,
+                            stderr=subprocess.STDOUT).returncode
+        else:
+            code = _run(argv, cwd=session.cwd).returncode
     finally:
         marker.unlink(missing_ok=True)
         if keep_forks:
@@ -325,4 +348,29 @@ def run_sub(
             sub_path.rename(sub_root / sub_path.name)
         else:
             sub_path.unlink(missing_ok=True)
+        if quiet:
+            _relay_last_message(last_path, log_path)
     return code
+
+
+def _relay_last_message(last_path: Path, log_path: Path, tail: int = 50) -> None:
+    """Print exactly what the bridge should return as its final message: the
+    worker's last message, or — when codex died before writing one — the tail
+    of its log, so a failed relay still carries the error text instead of
+    reporting an empty failure. Never prefixes or wraps: the caller's whole
+    stdout is the payload. Both files are retained as the debugging trail."""
+    text = ""
+    try:
+        text = last_path.read_text(errors="replace")
+    except OSError:
+        pass
+    if not text.strip():
+        try:
+            lines = log_path.read_text(errors="replace").splitlines()
+        except OSError:
+            lines = []
+        text = "\n".join(lines[-tail:])
+    if not text:
+        return
+    sys.stdout.write(text if text.endswith("\n") else text + "\n")
+    sys.stdout.flush()

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -126,10 +126,11 @@ class TailLoop:
 
 
 # Rollouts tandem wrote itself: "tandem" heads a seeded shadow (codex
-# adapter), "tandem-sub" heads a subagent fork (ops.fork_shadow). Both live
-# in codex's sessions dir with a fresh mtime and the session cwd, so
-# discovery must skip them or a live fork gets adopted as the pair's real
-# codex session.
+# adapter), "tandem-sub" heads a subagent rollout (ops.fork_shadow for
+# --context full, ops.seed_sub_rollout for the cold path). Both live in
+# codex's sessions dir with a fresh mtime and the session cwd, so discovery
+# must skip them or a live worker gets adopted as the pair's real codex
+# session.
 _TANDEM_ORIGINATORS = ("tandem", "tandem-sub")
 
 
@@ -223,12 +224,23 @@ class InteractiveRunner:
                 watcher.watch(sentinel)
                 watcher.start()
                 loop = TailLoop(store, current, active, path, sink)
+                # `tandem sub --context full` drains this same cursor row from
+                # a separate process, holding `ops._sub_lock()` across its
+                # drain-then-fork. Two concurrent drains of one cursor
+                # translate the same lines twice — duplicate turns and call ids
+                # in the shadow and in the fork — so the tail thread takes the
+                # same flock. Kept tight around the drain itself: the wait
+                # between iterations must not hold it. (Imported here: `ops`
+                # imports this module.)
+                from . import ops
                 try:
                     while not stop.is_set():
-                        loop.drain()
+                        with ops._sub_lock():
+                            loop.drain()
                         watcher.wait()
                     # final drain after the CLI exits
-                    loop.drain()
+                    with ops._sub_lock():
+                        loop.drain()
                     errors.extend(loop.errors)
                 finally:
                     watcher.stop()

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -125,9 +125,18 @@ class TailLoop:
         return len(lines)
 
 
+# Rollouts tandem wrote itself: "tandem" heads a seeded shadow (codex
+# adapter), "tandem-sub" heads a subagent fork (ops.fork_shadow). Both live
+# in codex's sessions dir with a fresh mtime and the session cwd, so
+# discovery must skip them or a live fork gets adopted as the pair's real
+# codex session.
+_TANDEM_ORIGINATORS = ("tandem", "tandem-sub")
+
+
 def await_codex_rollout(cwd: str, after: float, timeout: float | None = None) -> Path | None:
     """Find the rollout file codex just created for this cwd (codex mints its
-    own session id; tandem discovers it from the filesystem)."""
+    own session id; tandem discovers it from the filesystem). Rollouts tandem
+    authored are never candidates."""
     deadline = None if timeout is None else time.time() + timeout
     while True:
         for p in paths.iter_codex_rollouts_newest_first():
@@ -140,7 +149,8 @@ def await_codex_rollout(cwd: str, after: float, timeout: float | None = None) ->
                 if (
                     meta.get("type") == "session_meta"
                     and meta.get("payload", {}).get("cwd") == cwd
-                    and meta.get("payload", {}).get("originator") != "tandem"
+                    and meta.get("payload", {}).get("originator")
+                    not in _TANDEM_ORIGINATORS
                 ):
                     return p
             except (OSError, json.JSONDecodeError):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,3 +44,11 @@ def test_broken_toml_falls_back(tmp_path, monkeypatch):
     (home / "config.toml").write_text("[subagents\nnot toml")
     monkeypatch.setenv("TANDEM_HOME", str(home))
     assert load_subagents_config() == SubagentsConfig()
+
+
+def test_non_utf8_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_bytes(b'[subagents]\nmodel = "caf\xe9"\n')
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    assert load_subagents_config() == SubagentsConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+"""[subagents] config: defaults on missing/broken file, validated values."""
+
+from tandem.config import SubagentsConfig, load_subagents_config
+
+
+def test_defaults_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+    cfg = load_subagents_config()
+    assert cfg == SubagentsConfig()
+    assert (cfg.route, cfg.model, cfg.context) == ("all", "", "match")
+    assert (cfg.fanout_feature, cfg.keep_forks) == ("", False)
+
+
+def test_reads_values(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text(
+        '[subagents]\nroute = "off"\nmodel = "gpt-x-mini"\n'
+        'context = "full"\nfanout_feature = "collab"\nkeep_forks = true\n'
+    )
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    cfg = load_subagents_config()
+    assert cfg.route == "off"
+    assert cfg.model == "gpt-x-mini"
+    assert cfg.context == "full"
+    assert cfg.fanout_feature == "collab"
+    assert cfg.keep_forks is True
+
+
+def test_invalid_values_fall_back(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text(
+        '[subagents]\nroute = "sometimes"\ncontext = 7\nkeep_forks = "yes"\n'
+    )
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    cfg = load_subagents_config()
+    assert cfg == SubagentsConfig()  # every bad value -> default
+
+
+def test_broken_toml_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text("[subagents\nnot toml")
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    assert load_subagents_config() == SubagentsConfig()

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -38,6 +38,12 @@ class TestRewrite:
         assert ui["description"] == "short label"   # untouched
         assert ui["run_in_background"] is True      # unknown fields carried
 
+    def test_task_alias_is_rerouted(self):
+        payload = _payload()
+        payload["tool_name"] = "Task"  # the documented alias of Agent
+        ui = _route(payload)["hookSpecificOutput"]["updatedInput"]
+        assert ui["subagent_type"] == BRIDGE_AGENT
+
     def test_named_agent_body_is_inlined(self, tmp_path):
         agents = tmp_path / "proj" / ".claude" / "agents"
         agents.mkdir(parents=True)
@@ -66,8 +72,17 @@ class TestPassthrough:
         assert _route(_payload(), has_session=False) is None
         assert _route(_payload(), codex_ok=False) is None
 
+    def test_other_tool_names_pass_through(self):
+        # the plugin matcher should never send these here; if it ever does,
+        # rewriting an unrelated tool's input would corrupt the call
+        payload = _payload()          # otherwise fully rewritable
+        payload["tool_name"] = "Bash"
+        assert _route(payload) is None
+        del payload["tool_name"]
+        assert _route(payload) is None
+
     def test_malformed_input(self):
-        assert _route({"tool_input": "not a dict"}) is None
+        assert _route({"tool_name": "Agent", "tool_input": "not a dict"}) is None
         assert _route(_payload(prompt="")) is None
 
 

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -1,0 +1,123 @@
+"""hook-route: reroute native Agent dispatches to the codex-worker bridge.
+Failure discipline: any problem -> None (native dispatch), CLI always exit 0."""
+
+import json
+from pathlib import Path
+
+from tandem.config import SubagentsConfig
+from tandem.hookroute import BRIDGE_AGENT, BRIDGE_MODEL, find_agent_body, route
+
+
+def _payload(subagent_type="Explore", prompt="find the tests", **extra):
+    ti = {"subagent_type": subagent_type, "prompt": prompt,
+          "description": "short label", "model": "opus"}
+    ti.update(extra)
+    return {"hook_event_name": "PreToolUse", "tool_name": "Agent",
+            "cwd": "/tmp/x", "tool_input": ti}
+
+
+CFG = SubagentsConfig()
+
+
+def _route(payload, cfg=CFG, has_session=True, codex_ok=True,
+           cwd="/tmp/x", claude_home=Path("/nonexistent")):
+    return route(payload, cfg, cwd, claude_home,
+                 has_session=has_session, codex_ok=codex_ok)
+
+
+class TestRewrite:
+    def test_reroutes_and_rewrites_exactly_three_fields(self):
+        out = _route(_payload(run_in_background=True))
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "allow"
+        ui = hso["updatedInput"]
+        assert ui["subagent_type"] == BRIDGE_AGENT
+        assert ui["model"] == BRIDGE_MODEL          # opus would override haiku
+        assert ui["prompt"] == "find the tests"     # verbatim, built-in type
+        assert ui["description"] == "short label"   # untouched
+        assert ui["run_in_background"] is True      # unknown fields carried
+
+    def test_named_agent_body_is_inlined(self, tmp_path):
+        agents = tmp_path / "proj" / ".claude" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "reviewer.md").write_text(
+            "---\nname: code-reviewer\ndescription: reviews\n---\n"
+            "Always check for X."
+        )
+        out = _route(_payload(subagent_type="code-reviewer"),
+                     cwd=str(tmp_path / "proj"))
+        p = out["hookSpecificOutput"]["updatedInput"]["prompt"]
+        assert "Always check for X." in p
+        assert p.endswith("find the tests")  # original brief last, verbatim
+
+
+class TestPassthrough:
+    def test_fork_passes_through(self):
+        assert _route(_payload(subagent_type="fork")) is None
+
+    def test_bridge_loop_guard(self):
+        assert _route(_payload(subagent_type=BRIDGE_AGENT)) is None
+
+    def test_route_off(self):
+        assert _route(_payload(), cfg=SubagentsConfig(route="off")) is None
+
+    def test_no_session_or_unhealthy_codex(self):
+        assert _route(_payload(), has_session=False) is None
+        assert _route(_payload(), codex_ok=False) is None
+
+    def test_malformed_input(self):
+        assert _route({"tool_input": "not a dict"}) is None
+        assert _route(_payload(prompt="")) is None
+
+
+class TestFindAgentBody:
+    def test_builtin_and_plugin_scoped_have_no_body(self, tmp_path):
+        assert find_agent_body("Explore", str(tmp_path), tmp_path) == ""
+        assert find_agent_body("my-plugin:reviewer", str(tmp_path),
+                               tmp_path) == ""
+
+    def test_walks_up_and_falls_back_to_user_home(self, tmp_path):
+        (tmp_path / ".claude" / "agents").mkdir(parents=True)
+        (tmp_path / ".claude" / "agents" / "helper.md").write_text(
+            "---\nname: helper\n---\nBody from repo root."
+        )
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        body = find_agent_body("helper", str(nested), tmp_path / "nohome")
+        assert body == "Body from repo root."
+
+
+class TestCli:
+    def test_prints_decision_and_exits_zero(self, env_factory, monkeypatch):
+        import click.testing
+        from tandem import cli
+        env = env_factory(active="claude")
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["hook-route"], input=json.dumps(payload))
+        assert r.exit_code == 0
+        out = json.loads(r.output)
+        assert out["hookSpecificOutput"]["updatedInput"]["subagent_type"] \
+            == BRIDGE_AGENT
+
+    def test_any_crash_exits_zero_silent(self, monkeypatch, tmp_path):
+        import click.testing
+        from tandem import cli, hookroute
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        monkeypatch.setattr(hookroute, "route",
+                            lambda *a, **kw: 1 / 0)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["hook-route"], input=json.dumps(_payload()))
+        assert r.exit_code == 0
+        assert r.output == ""
+
+    def test_garbage_stdin_exits_zero_silent(self, tmp_path, monkeypatch):
+        import click.testing
+        from tandem import cli
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["hook-route"], input="not json {{{")
+        assert r.exit_code == 0
+        assert r.output == ""

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -5,7 +5,13 @@ import json
 from pathlib import Path
 
 from tandem.config import SubagentsConfig
-from tandem.hookroute import BRIDGE_AGENT, BRIDGE_MODEL, find_agent_body, route
+from tandem.hookroute import (
+    BRIDGE_AGENT,
+    BRIDGE_MODEL,
+    BRIDGE_NAME,
+    find_agent_body,
+    route,
+)
 
 
 def _payload(subagent_type="Explore", prompt="find the tests", **extra):
@@ -64,6 +70,12 @@ class TestPassthrough:
 
     def test_bridge_loop_guard(self):
         assert _route(_payload(subagent_type=BRIDGE_AGENT)) is None
+
+    def test_bridge_loop_guard_is_scope_insensitive(self):
+        # the model asks for the bridge by either id (both observed live);
+        # rewriting the bare name would re-enter this hook forever
+        assert _route(_payload(subagent_type=BRIDGE_NAME)) is None
+        assert _route(_payload(subagent_type=f"other:{BRIDGE_NAME}")) is None
 
     def test_route_off(self):
         assert _route(_payload(), cfg=SubagentsConfig(route="off")) is None

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -33,3 +33,11 @@ def test_bridge_agent_definition():
     assert "tandem sub" in body
     assert "verbatim" in body
     assert "[tandem-sub failed]" in body
+    # quiet mode: the command's whole output IS the final message, so the
+    # relay has nothing to extract (inherited stdio would hand it codex's
+    # entire exec log instead)
+    assert "tandem sub -q" in body
+    # a fixed heredoc delimiter is a shell-injection hazard: a task message
+    # containing that line truncates the brief and runs the rest as shell
+    assert "TANDEM_TASK_EOF_" in body
+    assert re.search(r"unless .*appears|appears .*in the task", body)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -23,6 +23,21 @@ def test_hooks_register_hook_route():
     assert cmds == ["tandem hook-route || true"]
 
 
+def test_hook_rewrite_target_matches_the_plugin_scoped_agent_id():
+    """Claude resolves a plugin's agents as `<plugin-name>:<agent-name>` and
+    rejects the bare name (live, 2.1.220: "Agent type 'codex-worker' not
+    found. Available agents: …, tandem:codex-worker"). If the manifest name
+    or the agent's `name:` ever moves, the hook's rewrite target must move
+    with it — otherwise every rerouted dispatch fails."""
+    from tandem.hookroute import BRIDGE_AGENT
+
+    plugin_name = json.loads(
+        (PLUGIN / ".claude-plugin" / "plugin.json").read_text())["name"]
+    front = (PLUGIN / "agents" / "codex-worker.md").read_text().split("---")[1]
+    agent_name = re.search(r"^name:\s*(\S+)\s*$", front, re.M).group(1)
+    assert BRIDGE_AGENT == f"{plugin_name}:{agent_name}"
+
+
 def test_bridge_agent_definition():
     text = (PLUGIN / "agents" / "codex-worker.md").read_text()
     front = text.split("---")[1]
@@ -33,6 +48,10 @@ def test_bridge_agent_definition():
     assert "tandem sub" in body
     assert "verbatim" in body
     assert "[tandem-sub failed]" in body
+    # live E2E (haiku 4.5, 2026-07-31): given a one-command task and a Bash
+    # tool, the relay answered it itself with `find` instead of delegating.
+    # The unconditional "never do the task yourself" rule is the fix.
+    assert re.search(r"never do the task yourself", body, re.I)
     # quiet mode: the command's whole output IS the final message, so the
     # relay has nothing to extract (inherited stdio would hand it codex's
     # entire exec log instead)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,35 @@
+"""The plugin is static registration only — validate the three files."""
+
+import json
+import re
+from pathlib import Path
+
+PLUGIN = Path(__file__).parent.parent / "plugin"
+
+
+def test_manifest_parses():
+    m = json.loads((PLUGIN / ".claude-plugin" / "plugin.json").read_text())
+    assert m["name"] == "tandem"
+    assert m["version"]
+
+
+def test_hooks_register_hook_route():
+    h = json.loads((PLUGIN / "hooks" / "hooks.json").read_text())
+    entries = h["hooks"]["PreToolUse"]
+    assert entries[0]["matcher"] == "Agent|Task"
+    cmds = [hk["command"] for hk in entries[0]["hooks"]]
+    # `|| true` is load-bearing: click exits 2 on a usage error (older
+    # tandem on PATH without the subcommand), and exit 2 blocks dispatches
+    assert cmds == ["tandem hook-route || true"]
+
+
+def test_bridge_agent_definition():
+    text = (PLUGIN / "agents" / "codex-worker.md").read_text()
+    front = text.split("---")[1]
+    assert re.search(r"^name:\s*codex-worker\s*$", front, re.M)
+    assert re.search(r"^model:\s*haiku\s*$", front, re.M)
+    assert re.search(r"^tools:\s*Bash\(tandem sub:\*\)\s*$", front, re.M)
+    body = text.split("---", 2)[2]
+    assert "tandem sub" in body
+    assert "verbatim" in body
+    assert "[tandem-sub failed]" in body

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -370,6 +370,26 @@ class TestDoctorAndStatus:
         assert any("OPENAI_API_KEY" in c.message for c in report.checks
                    if c.status == "warn")
 
+    def test_doctor_warns_when_no_model_is_configured(self, env_factory,
+                                                      monkeypatch):
+        """The shipped defaults are route="all" + model="" — everything is
+        rerouted, but with no `-m` the worker runs on the codex account's
+        default, which is the frontier tier (S1: gpt-5.6-sol). Silently
+        spending frontier money is the one surprise doctor must call out."""
+        from tandem import paths
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        report = run_doctor(env.store, env.session, live=False)
+        assert any("no model configured" in c.message for c in report.checks
+                   if c.status == "warn")
+        # configuring one silences it
+        (paths.tandem_home() / "config.toml").write_text(
+            '[subagents]\nmodel = "gpt-5.6-luna"\n')
+        report = run_doctor(env.store, env.session, live=False)
+        assert not any("no model configured" in c.message
+                       for c in report.checks)
+
     def test_doctor_nudges_shared_block(self, env_factory, monkeypatch):
         from pathlib import Path
         from tandem.doctor import run_doctor

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -359,3 +359,41 @@ class TestSubCli:
         r = click.testing.CliRunner().invoke(cli.main, ["sub"], input="  \n")
         assert r.exit_code == 1
         assert "empty task" in r.output
+
+
+class TestDoctorAndStatus:
+    def test_doctor_warns_on_api_key_env(self, env_factory, monkeypatch):
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        report = run_doctor(env.store, env.session, live=False)
+        assert any("OPENAI_API_KEY" in c.message for c in report.checks
+                   if c.status == "warn")
+
+    def test_doctor_nudges_shared_block(self, env_factory, monkeypatch):
+        from pathlib import Path
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        Path(env.cwd, "CLAUDE.md").write_text("# rules, no markers\n")
+        report = run_doctor(env.store, env.session, live=False)
+        assert any("tandem:shared" in c.message for c in report.checks)
+
+    def test_status_lists_running_and_retained(self, env_factory, monkeypatch):
+        import click.testing
+        from tandem import cli, paths
+        env = env_factory(active="claude")
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        sub_root = paths.tandem_home() / "subagents" / env.session.tandem_id
+        (sub_root / "running").mkdir(parents=True)
+        (sub_root / "running" / "r1.json").write_text(json.dumps(
+            {"model": "gpt-x-mini", "context": "task",
+             "task_preview": "audit the README", "pid": 1}))
+        (sub_root / "rollout-x-1.jsonl").write_text("{}\n")
+        r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert "subagent running: gpt-x-mini (task) audit the README" in r.output
+        assert "retained forks: 1" in r.output

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -1,8 +1,10 @@
 """tandem sub: shadow forking and the subagent execution op."""
 
 import json
+import time
 
 from tandem import ops
+from tandem.runner import await_codex_rollout
 from tandem.util import read_jsonl
 
 from conftest import claude_user, write_line
@@ -49,3 +51,24 @@ class TestForkShadow:
         after = env.store.get_cursor(env.session.tandem_id, "codex")
         assert after.byte_offset == before_cursor.byte_offset
         assert after.line_index == before_cursor.line_index
+
+    def test_fork_is_not_adopted_as_a_freshly_minted_codex_session(self, env_factory):
+        """A live fork sits in codex's sessions dir with the session cwd and a
+        fresh mtime. If rollout discovery returned it, a concurrent fresh-codex
+        launch would bind the pair's codex id to the subagent's throwaway."""
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        started = time.time()
+        _, fork_path = ops.fork_shadow(env.store, env.session)
+
+        assert await_codex_rollout(env.cwd, started, timeout=0) is None
+
+        # control: a rollout codex itself wrote, same dir, is still discovered
+        real_sid = "019faca1-0000-7000-8000-0000000000ff"
+        real = fork_path.with_name(f"rollout-2026-07-31T00-00-00-{real_sid}.jsonl")
+        write_line(real, {
+            "timestamp": "t", "type": "session_meta",
+            "payload": {"id": real_sid, "session_id": real_sid,
+                        "cwd": env.cwd, "originator": "codex_cli"},
+        })
+        assert await_codex_rollout(env.cwd, started, timeout=0) == real

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -1,7 +1,9 @@
 """tandem sub: shadow forking and the subagent execution op."""
 
 import json
+import subprocess
 import time
+from pathlib import Path
 
 from tandem import ops, paths
 from tandem.runner import await_codex_rollout
@@ -226,6 +228,75 @@ class TestRunSub:
         assert seen["during"][0].exists() is False  # removed on completion
 
 
+class TestQuietRelay:
+    """Quiet mode exists for the bridge agent: with inherited stdio the Bash
+    output is codex's ENTIRE exec log (header, actions, token counts), and
+    "return the final message verbatim" is not something a haiku relay can do
+    reliably. Quiet mode makes the command's whole output BE the final
+    message, via codex's own `-o/--output-last-message`."""
+
+    def test_quiet_relays_only_the_last_message(self, env_factory, monkeypatch,
+                                                capsys):
+        env = env_factory(active="claude")
+        calls = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            calls["argv"], calls["kw"] = argv, kw
+            i = argv.index("-o")
+            calls["o_before_resume"] = i < argv.index("resume")
+            calls["last"] = Path(argv[i + 1])
+            calls["last"].write_text("FINAL ANSWER")
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+
+        assert code == 0
+        # -o is an exec-level flag: it must precede the `resume` subcommand
+        assert calls["o_before_resume"]
+        # stdout carries the worker's answer and nothing else
+        assert capsys.readouterr().out == "FINAL ANSWER\n"
+        # the raw transcript is redirected to a retained log for debugging
+        logs = (paths.tandem_home() / "subagents" / env.session.tandem_id
+                / "logs")
+        assert calls["last"].parent == logs
+        assert calls["kw"]["stderr"] == subprocess.STDOUT
+        assert list(logs.glob("*.log")) != []
+
+    def test_quiet_falls_back_to_the_log_tail(self, env_factory, monkeypatch,
+                                              capsys):
+        """A codex run that dies before writing a last message must still
+        relay something — otherwise the bridge reports an empty failure."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, stdout=None, **kw):
+            stdout.write(b"boom: auth failed\nstack line\n")
+            stdout.flush()
+            return _R(1)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "boom: auth failed" in out
+        assert "stack line" in out
+
+    def test_non_quiet_streams_with_inherited_stdio(self, env_factory,
+                                                    monkeypatch, capsys):
+        """Manual `tandem sub` keeps streaming: no -o, no redirection."""
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv, kw=kw) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t")
+        assert "-o" not in calls["argv"]
+        assert calls["kw"] == {}
+        assert capsys.readouterr().out == ""
+
+
 class TestSubCli:
     def _cli_env(self, env, monkeypatch):
         from tandem import cli
@@ -266,6 +337,20 @@ class TestSubCli:
         assert r.exit_code == 0
         assert calls["kw"]["model"] == "gpt-x-mini"
         assert calls["kw"]["context"] == "full"
+        assert calls["kw"]["quiet"] is False
+
+    def test_sub_quiet_flag_forwards(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(cli.main, ["sub", "-q", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["quiet"] is True
 
     def test_sub_empty_task_errors(self, env_factory, monkeypatch):
         import click.testing

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -1,0 +1,51 @@
+"""tandem sub: shadow forking and the subagent execution op."""
+
+import json
+
+from tandem import ops
+from tandem.util import read_jsonl
+
+from conftest import claude_user, write_line
+
+
+class TestForkShadow:
+    def test_fork_copies_shadow_with_new_identity(self, env_factory):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        write_line(env.claude_shadow, claude_user("context before fork"))
+
+        fork_id, fork_path = ops.fork_shadow(env.store, env.session)
+
+        assert fork_id != env.session.codex_session_id
+        assert fork_path.name.endswith(f"-{fork_id}.jsonl")
+        entries = read_jsonl(fork_path)
+        meta = entries[0]
+        assert meta["type"] == "session_meta"
+        assert meta["payload"]["id"] == fork_id
+        assert meta["payload"]["session_id"] == fork_id
+        assert meta["payload"]["originator"] == "tandem-sub"
+        assert meta["payload"]["model_provider"] == "openai"
+        # the pre-fork drain landed the claude turn in the fork's history
+        dump = json.dumps(entries)
+        assert "context before fork" in dump
+
+    def test_fork_is_structurally_resumable(self, env_factory):
+        from tandem.doctor import validate_transcript
+
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        fork_id, fork_path = ops.fork_shadow(env.store, env.session)
+        assert validate_transcript("codex", fork_path, fork_id) == []
+
+    def test_fork_leaves_shadow_and_cursors_alone(self, env_factory):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        before_bytes = env.codex_shadow.read_bytes()
+        before_cursor = env.store.get_cursor(env.session.tandem_id, "codex")
+
+        ops.fork_shadow(env.store, env.session)
+
+        assert env.codex_shadow.read_bytes() == before_bytes
+        after = env.store.get_cursor(env.session.tandem_id, "codex")
+        assert after.byte_offset == before_cursor.byte_offset
+        assert after.line_index == before_cursor.line_index

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -1,11 +1,14 @@
 """tandem sub: shadow forking and the subagent execution op."""
 
+import contextlib
 import json
 import subprocess
 import time
 from pathlib import Path
 
-from tandem import ops, paths
+import pytest
+
+from tandem import ops, paths, runner
 from tandem.runner import await_codex_rollout
 from tandem.util import read_jsonl
 
@@ -131,7 +134,7 @@ class TestRunSub:
         started = time.time()
 
         def fake_run(argv, cwd=None, **kw):
-            calls["argv"], calls["cwd"] = argv, cwd
+            calls["argv"], calls["cwd"], calls["kw"] = argv, cwd, kw
             seed = paths.find_codex_rollout(argv[argv.index("resume") + 1])
             calls["meta"] = read_jsonl(seed)[0]
             # while the worker runs, the seed must not look like a fresh codex
@@ -148,12 +151,47 @@ class TestRunSub:
         assert argv[5] == "resume"
         seed_id = argv[6]
         assert seed_id != env.session.codex_session_id
-        assert argv[7:] == ["audit the README"]
+        # the brief travels on stdin; argv ends at codex's `-` stdin marker
+        assert argv[7:] == ["-"]
+        assert calls["kw"]["input"] == b"audit the README"
         assert calls["cwd"] == env.cwd
         assert calls["meta"]["payload"]["originator"] == "tandem-sub"
         assert calls["meta"]["payload"]["cwd"] == env.cwd
         assert calls["adopted"] is None
         assert paths.find_codex_rollout(seed_id) is None  # cleaned up after
+
+    def test_brief_never_reaches_argv(self, env_factory, monkeypatch):
+        """A brief is untrusted text, not argv. As a trailing positional,
+        anything starting with `-` is parsed by codex's own CLI: `- review …`
+        dies with `unexpected argument '- ' found` before the model runs, and
+        `-m gpt-9 …` is silently accepted as a flag — argv injection. codex
+        documents `-` as "read the prompt from stdin"; that is the transport."""
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv, kw=kw) or _R(0),
+        )
+        task = "- review the diff\n-m gpt-9 --dangerously-bypass\n"
+        ops.run_sub(env.store, env.session, task)
+        argv = calls["argv"]
+        assert argv[-3:-2] == ["resume"] and argv[-1] == "-"
+        # not one fragment of the brief is on the command line
+        assert not any(a.startswith("- ") or a == "-m gpt-9" for a in argv[:-1])
+        assert calls["kw"]["input"] == task.encode()
+
+    def test_full_context_brief_also_goes_over_stdin(self, env_factory,
+                                                     monkeypatch):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv, kw=kw) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "-m sneaky", context="full")
+        assert calls["argv"][-1] == "-"
+        assert calls["kw"]["input"] == b"-m sneaky"
 
     def test_task_context_keep_forks_retains_seed(self, env_factory, monkeypatch):
         env = env_factory(active="claude")
@@ -227,6 +265,40 @@ class TestRunSub:
         assert seen["payload"][0]["task_preview"] == "watch me"
         assert seen["during"][0].exists() is False  # removed on completion
 
+    def test_marker_preview_is_single_line(self, env_factory, monkeypatch):
+        """`tandem status` prints the preview on its own line. A raw slice of a
+        multi-paragraph Claude brief drags newlines into that line and the
+        listing becomes multi-line garbage."""
+        env = env_factory(active="claude")
+        seen = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            run_dir = (paths.tandem_home() / "subagents"
+                       / env.session.tandem_id / "running")
+            seen["payload"] = json.loads(next(run_dir.glob("*.json")).read_text())
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session,
+                    "Audit the README.\n\n  Then\treport back.\n")
+        preview = seen["payload"]["task_preview"]
+        assert preview == "Audit the README. Then report back."
+        assert len(preview.splitlines()) == 1
+
+    def test_marker_preview_is_capped(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        seen = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            run_dir = (paths.tandem_home() / "subagents"
+                       / env.session.tandem_id / "running")
+            seen["payload"] = json.loads(next(run_dir.glob("*.json")).read_text())
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "word " * 200)
+        assert len(seen["payload"]["task_preview"]) == 120
+
 
 class TestQuietRelay:
     """Quiet mode exists for the bridge agent: with inherited stdio the Bash
@@ -282,6 +354,27 @@ class TestQuietRelay:
         assert "boom: auth failed" in out
         assert "stack line" in out
 
+    def test_relay_precedes_fork_disposal(self, env_factory, monkeypatch,
+                                          capsys):
+        """The worker's answer is the whole point of the run; cleanup is
+        bookkeeping. With the relay last in `finally`, a raising disposal
+        (cross-device rename, unwritable home) destroys a result codex already
+        produced and paid for. Relay first, then clean up."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("FINAL ANSWER")
+            return _R(0)
+
+        def boom(*a, **kw):
+            raise OSError("cross-device link")
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        monkeypatch.setattr(ops.shutil, "move", boom)
+        with pytest.raises(OSError):
+            ops.run_sub(env.store, env.session, "t", quiet=True, keep_forks=True)
+        assert capsys.readouterr().out == "FINAL ANSWER\n"
+
     def test_non_quiet_streams_with_inherited_stdio(self, env_factory,
                                                     monkeypatch, capsys):
         """Manual `tandem sub` keeps streaming: no -o, no redirection."""
@@ -293,8 +386,54 @@ class TestQuietRelay:
         )
         ops.run_sub(env.store, env.session, "t")
         assert "-o" not in calls["argv"]
-        assert calls["kw"] == {}
+        # stdin carries the brief; stdout/stderr stay inherited
+        assert set(calls["kw"]) == {"input"}
         assert capsys.readouterr().out == ""
+
+
+class TestSubLockCoverage:
+    """`--context full` drains the active source from a *second* process while
+    the session's own tail thread is draining the same cursor row in the
+    first. `fork_shadow` holds `_sub_lock`; until the tail thread took it too,
+    the lock guarded only one side of the race and two concurrent drains could
+    translate the same lines twice (duplicate turns and call ids in the fork).
+    Both sides now serialize on the same flock."""
+
+    def test_tail_thread_drains_under_the_sub_lock(self, env_factory,
+                                                   monkeypatch):
+        env = env_factory(active="claude")
+        depth = [0]
+        seen: list[int] = []
+
+        @contextlib.contextmanager
+        def recording_lock():
+            depth[0] += 1
+            try:
+                yield
+            finally:
+                depth[0] -= 1
+
+        real_drain = runner.TailLoop.drain
+
+        def drain(self):
+            seen.append(depth[0])
+            return real_drain(self)
+
+        monkeypatch.setattr(ops, "_sub_lock", recording_lock)
+        monkeypatch.setattr(runner.TailLoop, "drain", drain)
+        monkeypatch.setattr(runner, "run_in_pty", lambda argv, cwd=None: 0)
+
+        class _Sink:
+            def handle(self, line, ctx, cursor): ...
+            def close(self): ...
+
+        code = runner.InteractiveRunner(
+            env.session, lambda store, session, source: _Sink()).run()
+
+        assert code == 0
+        assert seen, "the tail thread never drained"
+        assert all(d == 1 for d in seen), f"drain ran outside the lock: {seen}"
+        assert depth[0] == 0  # released every time
 
 
 class TestSubCli:

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -395,5 +395,43 @@ class TestDoctorAndStatus:
              "task_preview": "audit the README", "pid": 1}))
         (sub_root / "rollout-x-1.jsonl").write_text("{}\n")
         r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert r.exit_code == 0
         assert "subagent running: gpt-x-mini (task) audit the README" in r.output
         assert "retained forks: 1" in r.output
+
+    def test_doctor_survives_non_object_auth_json(self, env_factory, monkeypatch):
+        """auth.json that is valid JSON but not an object must not crash
+        doctor: `.get` on a list raises AttributeError, not ValueError."""
+        from tandem import paths
+        from tandem.doctor import run_doctor
+        env = env_factory(active="claude")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        auth = paths.codex_home() / "auth.json"
+        auth.parent.mkdir(parents=True, exist_ok=True)
+        auth.write_text("[]")
+        report = run_doctor(env.store, env.session, live=False)
+        assert not any("API-key" in c.message for c in report.checks)
+        assert not any("OPENAI_API_KEY" in c.message for c in report.checks)
+
+    def test_status_skips_non_object_marker(self, env_factory, monkeypatch):
+        """A marker holding valid-but-non-object JSON is skipped, not fatal."""
+        import click.testing
+        from tandem import cli, paths
+        env = env_factory(active="claude")
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        run_dir = (paths.tandem_home() / "subagents" / env.session.tandem_id
+                   / "running")
+        run_dir.mkdir(parents=True)
+        # sorts first, so it would crash before the good marker is reached
+        (run_dir / "bad.json").write_text('"3"')
+        (run_dir / "good.json").write_text(json.dumps(
+            {"model": "gpt-x-mini", "context": "task",
+             "task_preview": "audit the README", "pid": 1}))
+        r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert r.exit_code == 0
+        assert "subagent running: gpt-x-mini (task) audit the README" in r.output
+        assert r.output.count("subagent running:") == 1

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -3,7 +3,7 @@
 import json
 import time
 
-from tandem import ops
+from tandem import ops, paths
 from tandem.runner import await_codex_rollout
 from tandem.util import read_jsonl
 
@@ -74,29 +74,92 @@ class TestForkShadow:
         assert await_codex_rollout(env.cwd, started, timeout=0) == real
 
 
+class TestSeedSubRollout:
+    def test_seed_is_a_resumable_tandem_sub_rollout(self, env_factory):
+        from tandem.doctor import validate_transcript
+
+        env = env_factory(active="claude")
+        seed_id, seed_path = ops.seed_sub_rollout(env.session)
+
+        assert validate_transcript("codex", seed_path, seed_id) == []
+        entries = read_jsonl(seed_path)
+        meta = entries[0]
+        assert meta["payload"]["id"] == seed_id
+        assert meta["payload"]["session_id"] == seed_id
+        assert meta["payload"]["cwd"] == env.cwd
+        assert meta["payload"]["originator"] == "tandem-sub"
+        assert meta["payload"]["model_provider"] == "openai"
+        # minimal: the meta plus one note (response_item + event_msg)
+        assert len(entries) == 3
+
+    def test_seed_carries_no_history_and_drains_nothing(self, env_factory):
+        env = env_factory(active="claude")
+        write_line(env.claude_shadow, claude_user("pair-only context"))
+        before_bytes = env.codex_shadow.read_bytes()
+        before = env.store.get_cursor(env.session.tandem_id, "claude")
+
+        _, seed_path = ops.seed_sub_rollout(env.session)
+
+        assert "pair-only context" not in seed_path.read_text()
+        assert env.codex_shadow.read_bytes() == before_bytes
+        after = env.store.get_cursor(env.session.tandem_id, "claude")
+        assert after.byte_offset == before.byte_offset
+        assert after.line_index == before.line_index
+
+    def test_seed_is_not_adopted_as_a_freshly_minted_codex_session(self, env_factory):
+        env = env_factory(active="claude")
+        started = time.time()
+        ops.seed_sub_rollout(env.session)
+        assert await_codex_rollout(env.cwd, started, timeout=0) is None
+
+
 class _R:
     def __init__(self, code=0):
         self.returncode = code
 
 
 class TestRunSub:
-    def test_task_context_is_cold_exec(self, env_factory, monkeypatch):
+    def test_task_context_resumes_a_tandem_sub_seed(self, env_factory, monkeypatch):
+        """A cold worker resumes its own seeded rollout rather than exec-ing
+        fresh: a plain `codex exec` writes an ordinary rollout in the session
+        cwd, and rollout discovery would then bind the pair's codex id to that
+        throwaway (which run_sub deletes on the way out)."""
         env = env_factory(active="claude")
         calls = {}
+        started = time.time()
 
         def fake_run(argv, cwd=None, **kw):
             calls["argv"], calls["cwd"] = argv, cwd
+            seed = paths.find_codex_rollout(argv[argv.index("resume") + 1])
+            calls["meta"] = read_jsonl(seed)[0]
+            # while the worker runs, the seed must not look like a fresh codex
+            calls["adopted"] = await_codex_rollout(env.cwd, started, timeout=0)
             return _R(0)
 
         monkeypatch.setattr(ops, "_run", fake_run)
         code = ops.run_sub(env.store, env.session, "audit the README",
                            model="gpt-x-mini", context="task")
         assert code == 0
-        assert calls["argv"] == [
-            "codex", "exec", "--skip-git-repo-check",
-            "-m", "gpt-x-mini", "audit the README",
-        ]
+        argv = calls["argv"]
+        assert argv[:5] == ["codex", "exec", "--skip-git-repo-check",
+                            "-m", "gpt-x-mini"]
+        assert argv[5] == "resume"
+        seed_id = argv[6]
+        assert seed_id != env.session.codex_session_id
+        assert argv[7:] == ["audit the README"]
         assert calls["cwd"] == env.cwd
+        assert calls["meta"]["payload"]["originator"] == "tandem-sub"
+        assert calls["meta"]["payload"]["cwd"] == env.cwd
+        assert calls["adopted"] is None
+        assert paths.find_codex_rollout(seed_id) is None  # cleaned up after
+
+    def test_task_context_keep_forks_retains_seed(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(0))
+        ops.run_sub(env.store, env.session, "t", keep_forks=True)
+        kept = list((paths.tandem_home() / "subagents"
+                     / env.session.tandem_id).glob("rollout-*.jsonl"))
+        assert len(kept) == 1
 
     def test_no_model_omits_flag_and_fanout_adds_enable(self, env_factory,
                                                         monkeypatch):
@@ -125,7 +188,6 @@ class TestRunSub:
         fork_id = argv[argv.index("resume") + 1]
         assert fork_id != env.session.codex_session_id
         # the fork was cleaned up (keep_forks=False)
-        from tandem import paths
         assert paths.find_codex_rollout(fork_id) is None
         kept = list((paths.tandem_home() / "subagents").rglob("*.jsonl"))
         assert kept == []
@@ -136,7 +198,6 @@ class TestRunSub:
         monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(0))
         ops.run_sub(env.store, env.session, "deep task", context="full",
                     keep_forks=True)
-        from tandem import paths
         kept = list((paths.tandem_home() / "subagents"
                      / env.session.tandem_id).glob("rollout-*.jsonl"))
         assert len(kept) == 1
@@ -147,7 +208,6 @@ class TestRunSub:
         assert ops.run_sub(env.store, env.session, "t") == 3
 
     def test_running_marker_lifecycle(self, env_factory, monkeypatch):
-        from tandem import paths
         env = env_factory(active="claude")
         seen = {}
 

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -72,3 +72,145 @@ class TestForkShadow:
                         "cwd": env.cwd, "originator": "codex_cli"},
         })
         assert await_codex_rollout(env.cwd, started, timeout=0) == real
+
+
+class _R:
+    def __init__(self, code=0):
+        self.returncode = code
+
+
+class TestRunSub:
+    def test_task_context_is_cold_exec(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            calls["argv"], calls["cwd"] = argv, cwd
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "audit the README",
+                           model="gpt-x-mini", context="task")
+        assert code == 0
+        assert calls["argv"] == [
+            "codex", "exec", "--skip-git-repo-check",
+            "-m", "gpt-x-mini", "audit the README",
+        ]
+        assert calls["cwd"] == env.cwd
+
+    def test_no_model_omits_flag_and_fanout_adds_enable(self, env_factory,
+                                                        monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t", fanout_feature="collab")
+        assert "-m" not in calls["argv"]
+        assert ["--enable", "collab"] == calls["argv"][3:5]
+
+    def test_full_context_forks_resumes_and_deletes(self, env_factory,
+                                                    monkeypatch):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "deep task", context="full")
+        argv = calls["argv"]
+        assert "resume" in argv
+        fork_id = argv[argv.index("resume") + 1]
+        assert fork_id != env.session.codex_session_id
+        # the fork was cleaned up (keep_forks=False)
+        from tandem import paths
+        assert paths.find_codex_rollout(fork_id) is None
+        kept = list((paths.tandem_home() / "subagents").rglob("*.jsonl"))
+        assert kept == []
+
+    def test_full_context_keep_forks_retains(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(0))
+        ops.run_sub(env.store, env.session, "deep task", context="full",
+                    keep_forks=True)
+        from tandem import paths
+        kept = list((paths.tandem_home() / "subagents"
+                     / env.session.tandem_id).glob("rollout-*.jsonl"))
+        assert len(kept) == 1
+
+    def test_exit_code_mirrors_codex(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", lambda *a, **kw: _R(3))
+        assert ops.run_sub(env.store, env.session, "t") == 3
+
+    def test_running_marker_lifecycle(self, env_factory, monkeypatch):
+        from tandem import paths
+        env = env_factory(active="claude")
+        seen = {}
+
+        def fake_run(argv, cwd=None, **kw):
+            run_dir = (paths.tandem_home() / "subagents"
+                       / env.session.tandem_id / "running")
+            seen["during"] = list(run_dir.glob("*.json"))
+            # read the marker while the run is in flight; it is gone after
+            seen["payload"] = [json.loads(p.read_text()) for p in seen["during"]]
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "watch me")
+        assert len(seen["during"]) == 1
+        assert seen["payload"][0]["task_preview"] == "watch me"
+        assert seen["during"][0].exists() is False  # removed on completion
+
+
+class TestSubCli:
+    def _cli_env(self, env, monkeypatch):
+        from tandem import cli
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        return cli
+
+    def test_sub_reads_task_from_stdin(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(
+                task=task, kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="line one\nline two\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "line one\nline two"
+        assert calls["kw"]["context"] == "task"   # config default: match->task
+
+    def test_sub_flags_override_config(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-m", "gpt-x-mini", "--context", "full", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "gpt-x-mini"
+        assert calls["kw"]["context"] == "full"
+
+    def test_sub_empty_task_errors(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        r = click.testing.CliRunner().invoke(cli.main, ["sub"], input="  \n")
+        assert r.exit_code == 1
+        assert "empty task" in r.output


### PR DESCRIPTION
## Summary

Native Claude Code subagent dispatches transparently execute on a cheap codex model. A Claude plugin (`plugin/`) registers a PreToolUse hook (`tandem hook-route || true`) that rewrites `Agent` dispatches to a `tandem:codex-worker` bridge (haiku, Bash-only), which runs `tandem sub -q` — executing the task on codex via a tandem-authored seed rollout (cold default) or a full shadow-fork (`--context full`), with the result relayed byte-verbatim through codex's `-o/--output-last-message`. Routing policy lives in `~/.tandem/config.toml` (`[subagents]`); uninstall the plugin and claude is stock again.

Design: `docs/specs/2026-07-31-codex-subagents-design.md` · Plan: `docs/plans/2026-07-31-codex-subagents.md`

## Key properties

- **Redirect the dispatch, don't forge the return** — results travel through claude's native tool-result / task-notification machinery; tandem never fabricates.
- **Match-mode context**: fresh-type dispatches get the self-contained brief claude wrote (cold seed rollout); `--context full` forks the shadow for full-history workers. Forks/seeds are never sync sources; discovery refuses to adopt tandem-authored rollouts.
- **Failure ladder**: every failure (hook crash, version skew, codex outage, missing session) degrades to a native claude dispatch or a relayed `[tandem-sub failed]` — never a blocked subagent.
- **Brief travels verbatim**: claude→tandem over stdin, tandem→codex over stdin (`resume <id> -`), no truncation, no argv injection surface.
- Doctor gains auth/billing + no-model + shared-block warnings; status lists running workers and retained forks.

## Live validation (2026-07-31, claude 2.1.220 / codex 0.145.0)

- Headless E2E of the full loop: hook rewrite observed (`subagent_type → tandem:codex-worker`, `model → haiku`), codex worker ran on `gpt-5.6-luna` via `-m` on a resumed tandem-authored rollout, relay byte-verbatim, dispatch+result synced into the shadow and answered from a real `codex exec resume`, doctor green.
- Spikes S1–S4 recorded in the spec with dated results (model ids per plan, no fanout flag on 0.145, hook fires headless, `-o` relay).
- Remaining manual checks (spec Testing section): interactive task-panel view; background-dispatch return path.

## Testing

`uv run pytest` — **194 passed** (was 137). Each of the 7 plan tasks passed an independent spec+quality review plus a scoped re-review of its fix round; final whole-branch review + fix wave clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)