### PR TITLE
feat: marketplace install for the plugin + one-time missed-reroute notice

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "tandem",
+  "owner": {
+    "name": "Bhavya Agarwal",
+    "url": "https://github.com/Bhavya6187"
+  },
+  "plugins": [
+    {
+      "name": "tandem",
+      "source": "./plugin",
+      "description": "Route Claude Code subagent dispatches to cheap codex models via tandem."
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "tandem",
+  "description": "tandem's plugin marketplace: run Claude Code subagents on cheap codex models.",
   "owner": {
     "name": "Bhavya Agarwal",
     "url": "https://github.com/Bhavya6187"

--- a/README.md
+++ b/README.md
@@ -65,13 +65,19 @@ Load tandem's Claude Code plugin and Claude's subagent dispatches run on
 the codex model you choose instead — automatically, with the task brief
 forwarded verbatim and the result returned through Claude's own machinery.
 Claude orchestrates; codex does the legwork; your Claude quota stays on the
-main thread. The plugin lives in this repo (not in the wheel), so point
-Claude at a clone:
+main thread. Two pieces: the `tandem` binary the hook shells out to, and
+the plugin that registers the hook — the plugin lives in this repo, not in
+the wheel, and without the binary on PATH it is inert.
 
 ```bash
-git clone https://github.com/Bhavya6187/tandem
-claude --plugin-dir /path/to/tandem/plugin
+uv tool install tandem-cli                        # the binary the hook drives
+claude plugin marketplace add Bhavya6187/tandem   # this repo, as a marketplace
+claude plugin install tandem@tandem
 ```
+
+The marketplace tracks this repo's default branch, but nothing updates
+behind your back: you pull new versions when you run `claude plugin
+marketplace update` (or `/plugin marketplace update` inside Claude).
 
 Then create `~/.tandem/config.toml` and pick your plan's cheap model (ids
 are listed in `~/.codex/models_cache.json`):
@@ -91,7 +97,13 @@ that one is not, and routing is on as soon as the plugin loads, so
 
 Fork dispatches stay on Claude, each worker's full codex log is kept under
 `~/.tandem/subagents/`, and `tandem status` lists the workers running right
-now. Drop the `--plugin-dir` flag and Claude is byte-for-byte stock again.
+now. The plugin is installed for every Claude session, so in a directory
+with no paired tandem session dispatches simply run natively — the first
+one says so once, then the session stays quiet. `claude plugin uninstall
+tandem@tandem` and Claude is byte-for-byte stock again.
+
+Hacking on the plugin itself? Skip the marketplace and point Claude at your
+clone: `claude --plugin-dir /path/to/tandem/plugin`.
 
 ### 🏠 Every model in its native harness.
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ that one is not, and routing is on as soon as the plugin loads, so
 Fork dispatches stay on Claude, each worker's full codex log is kept under
 `~/.tandem/subagents/`, and `tandem status` lists the workers running right
 now. The plugin is installed for every Claude session, so in a directory
-with no paired tandem session dispatches simply run natively — the first
+with no paired tandem session, dispatches simply run natively — the first
 one says so once, then the session stays quiet. `claude plugin uninstall
-tandem@tandem` and Claude is byte-for-byte stock again.
+tandem@tandem` and Claude is stock again — add `claude plugin marketplace
+remove tandem` to also unregister the marketplace.
 
 Hacking on the plugin itself? Skip the marketplace and point Claude at your
 clone: `claude --plugin-dir /path/to/tandem/plugin`.

--- a/docs/plans/2026-08-01-plugin-marketplace-install.md
+++ b/docs/plans/2026-08-01-plugin-marketplace-install.md
@@ -1,0 +1,141 @@
+# Plugin marketplace install + missed-reroute notice
+
+Make the tandem Claude Code plugin installable directly from GitHub (no clone),
+and surface a one-time, user-visible notice when the plugin is active but no
+tandem session backs it. Design is agreed — do not re-explore alternatives.
+
+## Context
+
+All prior plugin work merged via PR #16 (commit 070e87d):
+
+- The plugin lives at `plugin/` — manifest `plugin/.claude-plugin/plugin.json`,
+  `plugin/hooks/hooks.json` (whose command `tandem hook-route || true` is
+  load-bearing — never simplify it), `plugin/agents/codex-worker.md`. Today it
+  installs only via `claude --plugin-dir <clone>/plugin`.
+- `tandem hook-route` (`src/tandem/cli.py:349` wrapper + `src/tandem/hookroute.py`
+  decision logic) deliberately emits nothing and exits 0 when the cwd has no
+  paired tandem session — invisible no-op, dispatch proceeds natively.
+- `src/tandem/hookroute.py` is pure decision logic; the CLI wrapper owns process
+  concerns (stdin, stdout, exit codes, filesystem side effects).
+- Config: `src/tandem/config.py` — `SubagentsConfig.route` is `"all" | "off"`,
+  loaded from `$TANDEM_HOME/config.toml`; `paths.tandem_home()` resolves
+  `$TANDEM_HOME` (default `~/.tandem`).
+- Structural plugin tests: `tests/test_plugin.py` (4 tests). Hook tests:
+  `tests/test_hookroute.py` (15 tests). Suite baseline: 194 passed.
+- README has a "Subagents on the cheap model" section documenting clone +
+  `--plugin-dir`. Design spec: `docs/specs/2026-07-31-codex-subagents-design.md`.
+- Local claude CLI is 2.1.220.
+
+## Global Constraints
+
+- **Exit discipline (invariant):** `tandem hook-route` must NEVER block a
+  dispatch and NEVER exit nonzero — every failure (stamp I/O, config, missing
+  dirs, bad payload) degrades to native dispatch, silently or with the notice.
+  No permission `deny` anywhere. The `|| true` in hooks.json stays.
+- **TDD red-first:** write the failing test, watch it fail, then implement.
+- **Full suite green:** `uv run pytest` — 194 baseline tests keep passing plus
+  the new ones.
+- **Purity split:** decision logic in `hookroute.py` stays pure (no I/O);
+  stamp-file reads/writes and stdout live in the CLI wrapper layer.
+- Never commit on main; work stays on this branch; one squash-merged PR.
+
+## Task 1: Marketplace manifest, version alignment, structural tests
+
+1. Tests first, in `tests/test_plugin.py` (same style as the existing
+   hook-rewrite-target drift guard):
+   - repo-root `.claude-plugin/marketplace.json` exists and parses as JSON;
+   - its plugin entry's `source` resolves to the `plugin/` directory
+     (relative to repo root);
+   - its plugin entry's `name` matches `plugin/.claude-plugin/plugin.json`'s
+     `name` (drift guard);
+   - `plugin/.claude-plugin/plugin.json` `version` matches `pyproject.toml`'s
+     `version` (drift guard for item 2).
+2. Add repo-root `.claude-plugin/marketplace.json` declaring the plugin:
+   marketplace name `"tandem"`, owner, `plugins: [{name: "tandem",
+   source: "./plugin", description: …}]`. The exact schema MUST follow the
+   verified findings in the workspace file `docs-verification.md` (checked
+   against code.claude.com/docs/en/plugins-reference and the marketplace docs)
+   — not this plan's field list.
+3. Align `plugin/.claude-plugin/plugin.json` `"version"` from `0.1.0` to
+   `0.1.5` (pyproject.toml's current version). Note in the commit message that
+   this is a hand-maintained version string; single-sourcing is out of scope.
+
+## Task 2: Missed-reroute notice
+
+When the hook fires (plugin installed) but the cwd has NO paired tandem
+session, surface a user-visible notice instead of pure silence — once per
+claude session, not once per dispatch.
+
+- **Mechanism:** emit hook JSON with a top-level `"systemMessage"` field and NO
+  permission decision, so the dispatch still proceeds natively. The verified
+  behavior of `systemMessage` for PreToolUse on claude 2.1.220 is recorded in
+  the workspace file `docs-verification.md` — follow it. If it says
+  systemMessage is NOT honored for PreToolUse, do NOT substitute a deny;
+  document the limitation in the spec and skip the feature (report this back).
+- **Scope of the notice:** only for `Agent`/`Task` payloads (same tool_name
+  guard as routing). Warn when `cfg.route == "all"` and either (a) no paired
+  session for cwd, or (b) a session IS paired but codex is missing or its
+  version unsupported — text names the actual cause. NEVER warn when
+  `cfg.route == "off"` (explicit user choice). No notice when a rewrite is
+  emitted, and none for fork/bridge dispatches when a session is paired and
+  codex is fine.
+- **Suggested no-session text:** "tandem: subagent plugin is active but this
+  directory has no paired tandem session — dispatches stay on claude. Run
+  `tandem` here to enable codex subagents." Codex-missing text: same style,
+  naming that cause instead.
+- **Once per session:** the hook's stdin payload carries `session_id`; keep a
+  stamp under `$TANDEM_HOME` (e.g. `warned/<session_id>`) and skip the message
+  when stamped. Prune old stamps opportunistically (mtime-based is fine).
+  Stamp I/O failures degrade to warn-anyway or stay-silent — never a nonzero
+  exit. Stamp writes happen in the CLI wrapper (purity split); the pure layer
+  decides "would warn" from inputs (route, has_session, codex_ok, tool_name,
+  already-warned flag).
+- **Tests** (in `tests/test_hookroute.py`, red-first):
+  - notice emitted with NO permission decision on first dispatch (no
+    `hookSpecificOutput`, no `decision` key);
+  - suppressed on second dispatch with the same `session_id`;
+  - suppressed when `route == "off"`;
+  - codex-missing-with-paired-session variant emits the cause-naming notice;
+  - rewrite path unchanged when a session exists and codex is fine;
+  - exit code 0 everywhere, including stamp-dir failures (e.g. `TANDEM_HOME`
+    pointing at an unwritable/occupied path).
+- **Spec update** (`docs/specs/2026-07-31-codex-subagents-design.md`): the
+  no-session row of the failure ladder / passthrough list becomes "native
+  dispatch + one-time notice", and the exit-discipline section gains the
+  systemMessage mechanism.
+
+## Task 3: README + spec install story
+
+1. README "Subagents on the cheap model": replace the `--plugin-dir`
+   instructions with the two-step story:
+   (a) `uv tool install tandem-cli` — the hook/bridge need the `tandem` binary
+   on PATH; the plugin alone is inert without it;
+   (b) `claude plugin marketplace add Bhavya6187/tandem` then
+   `claude plugin install tandem@tandem`.
+   Keep `--plugin-dir` documented as the local-development path. Mention that
+   marketplace installs track the repo's default branch on update.
+2. Update the spec's plugin/install bullet
+   (`docs/specs/2026-07-31-codex-subagents-design.md`) to match the new
+   install story.
+
+## Task 4: Live verification
+
+Before the PR (adapt commands to the verified CLI syntax in
+`docs-verification.md` if it differs):
+
+1. `claude plugin marketplace add <this repo's worktree path>` +
+   `claude plugin install tandem@tandem`; `claude plugin list` shows it.
+2. In a directory WITHOUT a tandem session, one subagent dispatch surfaces the
+   notice exactly once and runs natively (headless `claude -p` is fine).
+3. In a paired session, dispatches still reroute — or at minimum a
+   `tandem hook-route` smoke test via stdin both ways (no-session → notice
+   JSON; paired-session shape → rewrite JSON).
+4. Clean up: remove the locally-added marketplace afterwards so the user's
+   claude config is left as found.
+
+Record the exact commands and observed output in the workspace report file.
+
+## Ship
+
+Branch + PR to main following repo conventions (squash merge, PR body
+convention from prior PRs).

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -151,14 +151,15 @@ dispatch in v1 is fresh-type (forks pass through natively).
 
 ### `tandem hook-route` (new CLI command)
 
-Reads the PreToolUse JSON from stdin. Emits nothing (exit 0) — meaning
-"dispatch proceeds natively" — when any of these hold:
+Reads the PreToolUse JSON from stdin. Emits no permission decision (exit 0)
+— meaning "dispatch proceeds natively" — when any of these hold:
 
 - `tool_name` is not `Agent`/`Task` (defense in depth: the hook matcher is
   config we do not control at call time);
 - no paired tandem session for the cwd, or codex missing/unsupported
   (the plugin is installed globally in Claude; outside tandem sessions the
-  hook must be an invisible no-op);
+  hook must not touch the dispatch) — the one case that is not silent: it
+  carries the one-time notice described under exit discipline below;
 - `route = "off"` in config;
 - `subagent_type` is `"fork"` (claude forks stay native in v1 — they're
   prompt-cache-cheap and semantically claude's own full-context worker);
@@ -201,6 +202,31 @@ is therefore registered as `tandem hook-route || true`; the shell-level
 guard is what makes exit 2 unreachable. `route()` additionally re-checks
 `tool_name ∈ {Agent, Task}` itself, so a mis-scoped matcher can never make
 it rewrite an unrelated tool's input.
+
+**The one silence that gets a voice.** The plugin is installed globally, so
+a dispatch in a directory with no paired session — or one where codex is
+missing/unsupported — is indistinguishable from a dispatch on a machine
+without tandem at all: nothing reroutes, nothing says why. When `route =
+"all"` and an `Agent`/`Task` dispatch cannot be rerouted for either of
+those reasons, hook-route therefore prints a bare top-level
+`{"systemMessage": "…"}` naming the actual cause. `systemMessage` is the
+documented universal hook-output field ("warning message shown to the
+user", claude 2.1.220), and carrying it *without* a permission decision
+leaves the call in claude's normal permission flow — the dispatch still
+runs natively, exactly as if the hook had said nothing. Not a `deny`:
+blocking a dispatch to explain a missing optimization would be worse than
+the optimization's absence. It never accompanies a rewrite, and `route =
+"off"` stays silent — that silence is what the user asked for.
+
+Once per claude session, not per dispatch: the PreToolUse payload's
+top-level `session_id` names a stamp file under `$TANDEM_HOME/warned/`,
+written only after a notice was actually printed, pruned opportunistically
+at ~7 days. The stamp is the CLI wrapper's business (the decision layer
+stays pure: it is told `already_warned` and answers whether and what to
+warn). Every bookkeeping failure — unwritable or occupied `$TANDEM_HOME`,
+a payload with no `session_id` — degrades to warn-anyway rather than
+stay-silent: a repeated line is a smaller loss than the one message that
+explains otherwise-invisible behavior. Exit 0 on every path.
 
 ### The plugin (`plugin/` in this repo)
 
@@ -304,7 +330,8 @@ price of "no forged results" under the documented hook surface.
 | Failure | Behavior |
 | --- | --- |
 | hook-route crashes / config unreadable | exit 0, no output → native dispatch |
-| no paired session / codex missing | hook passthrough; if reached anyway, `tandem sub` exits nonzero, bridge relays `[tandem-sub failed]`, main model does the work itself |
+| no paired session / codex missing | native dispatch + a one-time `systemMessage` notice naming the cause (no permission decision, once per claude session); if the bridge is reached anyway, `tandem sub` exits nonzero, bridge relays `[tandem-sub failed]`, main model does the work itself |
+| notice stamp unwritable / payload has no `session_id` | notice repeats instead of being suppressed; exit 0, dispatch untouched |
 | codex exec nonzero / outage | bridge relays output + `[tandem-sub failed]`; main model retries or does the work natively |
 | shadow missing on `--context full` | seed a fresh rollout from the drained active side (existing `_create_codex_shadow_late` pattern) |
 | parallel dispatches, full mode | file lock serializes drain-then-copy; execs then run concurrently. The other drainer is the *session's own tail thread*, running continuously against the same cursor in the `tandem run` process; it takes `_sub_lock` around each drain too, so both sides serialize on one flock. (Guarding only the `tandem sub` side left two concurrent drains of one cursor row free to translate the same lines twice — duplicate turns and call ids in the fork.) Match mode touches no shared state — no contention |
@@ -398,7 +425,10 @@ price of "no forged results" under the documented hook surface.
 ## Testing
 
 - Unit: `hook-route` stdin→stdout fixtures (rewrite, all passthrough
-  cases, model-field rewrite, named-agent body inlining, crash→exit-0);
+  cases, model-field rewrite, named-agent body inlining, crash→exit-0;
+  notice emitted with no decision, suppressed on the second dispatch of a
+  session, silent under `route = "off"`, codex-cause variant, warn-anyway
+  on stamp failure — all exit 0);
   fork op golden tests (session_meta rewrite, fork never in sync cursors);
   `tandem sub` argv/stdin handling via the existing `_run` seam; config
   parsing.

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -250,11 +250,21 @@ explains otherwise-invisible behavior. Exit 0 on every path.
   load-bearing, not cosmetic: click's usage-error path exits 2 outside the
   command body (version skew — plugin installed, older tandem on PATH
   lacking the subcommand), and exit 2 blocks the dispatch.
-- Install: local plugin from a clone of this repo for v1 —
-  `claude --plugin-dir /path/to/tandem/plugin` (marketplace later). The
-  wheel packages `src/tandem` only, so `pip install tandem-cli` alone never
-  reroutes anything; the README says so explicitly. Registration is the
-  plugin's entire job; policy lives in tandem config.
+- Install: this repo doubles as its own plugin marketplace
+  (`.claude-plugin/marketplace.json` at the root, marketplace name
+  `tandem`, source `./plugin`), so the user story is two steps —
+  `uv tool install tandem-cli` for the binary, then
+  `claude plugin marketplace add Bhavya6187/tandem` +
+  `claude plugin install tandem@tandem`. The marketplace tracks the repo's
+  default branch, but third-party marketplaces do not auto-update: new
+  versions land only when the user runs `claude plugin marketplace update`
+  (and only if `plugin.json`'s `version` moved — a matching resolved
+  version skips the update). `claude --plugin-dir /path/to/tandem/plugin`
+  from a clone remains the local-development path. The wheel packages
+  `src/tandem` only, so `pip install tandem-cli` alone never reroutes
+  anything, and the plugin without `tandem` on PATH is inert; the README
+  says both explicitly. Registration is the plugin's entire job; policy
+  lives in tandem config.
 
 ### Config (`~/.tandem/config.toml`, new file; `TANDEM_HOME` honored)
 

--- a/docs/specs/2026-07-31-codex-subagents-design.md
+++ b/docs/specs/2026-07-31-codex-subagents-design.md
@@ -462,6 +462,12 @@ price of "no forged results" under the documented hook surface.
   interactive task-panel view of running workers, and the background
   (`run_in_background: true`) return path — the foreground path was the one
   exercised.
+- Where a hook's user-visible line actually surfaces, verified live on
+  claude 2.1.220 (2026-08-01): a decision-free `systemMessage` from a
+  PreToolUse hook appears nowhere in `claude -p --output-format stream-json`
+  output (no stream event at all), because claude classifies it into a
+  `hook_system_message` attachment record in the session transcript JSONL —
+  that record, not stdout, is what the TUI renders.
 
 ## Later
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "author": {"name": "tandem"}
 }

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -390,13 +390,16 @@ def _mark_warned(stamp: Path | None) -> None:
         stamp.parent.mkdir(parents=True, exist_ok=True)
         stamp.touch()
         cutoff = time.time() - _WARN_STAMP_TTL
-        stale = [p for p in stamp.parent.iterdir()
-                 if p.stat().st_mtime < cutoff]
+        entries = list(stamp.parent.iterdir())
     except OSError:
         return
-    for p in stale:
+    for p in entries:
+        # per entry: one unreadable stamp (dangling symlink, vanished
+        # mid-pass) must not abort the prune and strand every other one.
+        # lstat, since a dangling link has no stat to follow.
         try:
-            p.unlink()
+            if p.lstat().st_mtime < cutoff:
+                p.unlink()
         except OSError:
             pass
 
@@ -447,6 +450,10 @@ def hook_route_cmd() -> None:
                 payload, cfg,
                 has_session=session is not None, codex_ok=codex_ok,
                 already_warned=_already_warned(stamp))
+            # Accepted race: check and stamp are not atomic, so concurrent
+            # first dispatches in one session can each print. Claiming the
+            # stamp first (O_EXCL) would instead spend the session's single
+            # notice on a caller that never got to print it.
             if notice is not None:
                 click.echo(json.dumps(notice))
                 _mark_warned(stamp)     # only ever stamp what we printed

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
+import time
 from pathlib import Path
 
 import click
@@ -346,6 +348,59 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
     sys.exit(code)
 
 
+# Stamps are per claude session id and worthless once that session is gone;
+# a week is long enough that a resumed session stays quiet.
+_WARN_STAMP_TTL = 7 * 24 * 3600
+_SESSION_ID_RE = re.compile(r"[A-Za-z0-9._-]{1,128}")
+
+
+def _warn_stamp(payload: dict) -> Path | None:
+    """Where this claude session's 'already warned' stamp lives, or None when
+    the payload carries no usable `session_id`. The id is untrusted text, so
+    anything that is not a plain filename component (traversal, separators)
+    counts as absent — the notice then repeats rather than tandem writing
+    outside TANDEM_HOME."""
+    sid = payload.get("session_id")
+    if not isinstance(sid, str) or not _SESSION_ID_RE.fullmatch(sid):
+        return None
+    if not sid.strip("."):        # "." and ".." match the pattern
+        return None
+    return paths.tandem_home() / "warned" / sid
+
+
+def _already_warned(stamp: Path | None) -> bool:
+    """True only when a notice is *provably* already out for this session.
+    Every doubt resolves to False — repeating the one message that explains
+    the silence is cheaper than swallowing it."""
+    if stamp is None:
+        return False
+    try:
+        return stamp.exists()
+    except OSError:
+        return False
+
+
+def _mark_warned(stamp: Path | None) -> None:
+    """Record the notice and opportunistically prune week-old stamps. All
+    best-effort: the message is already printed, and no bookkeeping failure
+    may reach the dispatch."""
+    if stamp is None:
+        return
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.touch()
+        cutoff = time.time() - _WARN_STAMP_TTL
+        stale = [p for p in stamp.parent.iterdir()
+                 if p.stat().st_mtime < cutoff]
+    except OSError:
+        return
+    for p in stale:
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+
 @main.command(name="hook-route")
 def hook_route_cmd() -> None:
     """Claude Code PreToolUse hook: reroute subagent dispatches to codex.
@@ -354,6 +409,15 @@ def hook_route_cmd() -> None:
     ALWAYS exits 0 — exit 2 would block the dispatch, and any failure here
     must degrade to native behavior.
 
+    When nothing is rerouted because tandem is not usable here — no paired
+    session for the cwd, or codex missing/unsupported — it prints a bare
+    top-level `{"systemMessage": …}` instead: a user-visible line with NO
+    permission decision, so claude still runs the dispatch natively. That
+    fires once per claude session, stamped under `$TANDEM_HOME/warned/`.
+    Stamp I/O is best-effort and failures warn again rather than go silent,
+    since the notice exists precisely to explain otherwise-invisible
+    behavior.
+
     The function body is not the whole story: click's usage-error path exits
     2 before this ever runs (version skew — plugin installed, an older
     tandem on PATH without this subcommand — or a stray argument). So the
@@ -361,7 +425,7 @@ def hook_route_cmd() -> None:
     is what makes exit 2 unreachable in practice."""
     try:
         from .config import load_subagents_config
-        from .hookroute import route
+        from .hookroute import missed_reroute_notice, route
 
         payload = json.loads(sys.stdin.read() or "{}")
         cwd = payload.get("cwd") or _cwd()
@@ -377,6 +441,15 @@ def hook_route_cmd() -> None:
                          has_session=session is not None, codex_ok=codex_ok)
         if decision is not None:
             click.echo(json.dumps(decision))
+        else:
+            stamp = _warn_stamp(payload)
+            notice = missed_reroute_notice(
+                payload, cfg,
+                has_session=session is not None, codex_ok=codex_ok,
+                already_warned=_already_warned(stamp))
+            if notice is not None:
+                click.echo(json.dumps(notice))
+                _mark_warned(stamp)     # only ever stamp what we printed
     except Exception:
         pass
     sys.exit(0)

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -1,8 +1,10 @@
 """PreToolUse routing: should this native Agent dispatch run on codex?
 
 Pure decision logic — the CLI wrapper owns process concerns (stdin, exit
-codes). Returning None means 'emit nothing': the dispatch proceeds
-natively. That is the failure mode for everything unexpected."""
+codes, the once-per-session stamp file). Returning None means 'emit
+nothing': the dispatch proceeds natively. That is the failure mode for
+everything unexpected. The second decision here — missed_reroute_notice —
+is what keeps two of those silences explainable instead of merely quiet."""
 
 from __future__ import annotations
 
@@ -18,6 +20,21 @@ from .config import SubagentsConfig
 BRIDGE_NAME = "codex-worker"
 BRIDGE_AGENT = f"tandem:{BRIDGE_NAME}"
 BRIDGE_MODEL = "haiku"
+
+# The plugin is installed globally in claude, so its silence is ambiguous:
+# "no tandem session here" and "tandem is broken" look identical from the
+# UI. These two lines are the only thing that distinguishes them, and each
+# names the one command that fixes its own cause.
+NOTICE_NO_SESSION = (
+    "tandem: subagent plugin is active but this directory has no paired "
+    "tandem session — dispatches stay on claude. Run `tandem` here to "
+    "enable codex subagents."
+)
+NOTICE_CODEX = (
+    "tandem: subagent plugin is active but codex is missing or its version "
+    "is unsupported — dispatches stay on claude. Run `tandem doctor` to see "
+    "what is wrong."
+)
 
 
 def route(
@@ -69,6 +86,36 @@ def route(
             "updatedInput": updated,
         }
     }
+
+
+def missed_reroute_notice(
+    payload: dict,
+    cfg: SubagentsConfig,
+    *,
+    has_session: bool,
+    codex_ok: bool,
+    already_warned: bool,
+) -> dict | None:
+    """The 'plugin fired, nothing was rerouted' notice, or None for silence.
+
+    A bare top-level `systemMessage` — no permission decision, so the
+    dispatch still falls through claude's normal permission flow and runs
+    natively. Mutually exclusive with route()'s rewrite by construction: a
+    rewrite requires has_session and codex_ok, and those two silence this.
+    `route = "off"` is an explicit user choice, so it stays silent even
+    though nothing reroutes. Whether this session was warned already is the
+    caller's business (it owns the stamp file), as is printing the result."""
+    if payload.get("tool_name") not in ("Agent", "Task"):
+        return None
+    if cfg.route != "all" or already_warned:
+        return None
+    if has_session and codex_ok:
+        return None
+    # deliberately not narrowed to reroutable dispatches: with no session or
+    # no codex, a fork/bridge/malformed dispatch is just as unrerouted, and
+    # the notice explains the environment rather than the call
+    return {"systemMessage": NOTICE_NO_SESSION if not has_session
+            else NOTICE_CODEX}
 
 
 def find_agent_body(subagent_type: str, cwd: str, claude_home: Path) -> str:

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -4,12 +4,16 @@ Failure discipline: any problem -> None (native dispatch), CLI always exit 0."""
 import json
 from pathlib import Path
 
+from tandem import paths
 from tandem.config import SubagentsConfig
 from tandem.hookroute import (
     BRIDGE_AGENT,
     BRIDGE_MODEL,
     BRIDGE_NAME,
+    NOTICE_CODEX,
+    NOTICE_NO_SESSION,
     find_agent_body,
+    missed_reroute_notice,
     route,
 )
 
@@ -29,6 +33,21 @@ def _route(payload, cfg=CFG, has_session=True, codex_ok=True,
            cwd="/tmp/x", claude_home=Path("/nonexistent")):
     return route(payload, cfg, cwd, claude_home,
                  has_session=has_session, codex_ok=codex_ok)
+
+
+def _notice(payload, cfg=CFG, has_session=False, codex_ok=True,
+            already_warned=False):
+    return missed_reroute_notice(payload, cfg, has_session=has_session,
+                                 codex_ok=codex_ok,
+                                 already_warned=already_warned)
+
+
+def _run_hook(payload):
+    import click.testing
+
+    from tandem import cli
+    return click.testing.CliRunner().invoke(
+        cli.main, ["hook-route"], input=json.dumps(payload))
 
 
 class TestRewrite:
@@ -98,6 +117,51 @@ class TestPassthrough:
         assert _route(_payload(prompt="")) is None
 
 
+class TestNotice:
+    def test_no_session_notice_carries_no_permission_decision(self):
+        out = _notice(_payload())
+        assert out == {"systemMessage": NOTICE_NO_SESSION}
+        assert "hookSpecificOutput" not in out and "decision" not in out
+        assert "Run `tandem` here" in NOTICE_NO_SESSION
+
+    def test_codex_variant_names_its_own_cause(self):
+        out = _notice(_payload(), has_session=True, codex_ok=False)
+        assert out == {"systemMessage": NOTICE_CODEX}
+        assert NOTICE_CODEX != NOTICE_NO_SESSION
+        assert "codex" in NOTICE_CODEX
+
+    def test_silent_when_the_reroute_works(self):
+        # a rewrite is emitted here; a notice must never accompany one
+        assert _notice(_payload(), has_session=True, codex_ok=True) is None
+
+    def test_route_off_never_warns(self):
+        # explicit user choice — silence is the requested behavior
+        assert _notice(_payload(), cfg=SubagentsConfig(route="off")) is None
+        assert _notice(_payload(), cfg=SubagentsConfig(route="off"),
+                       has_session=True, codex_ok=False) is None
+
+    def test_already_warned_suppresses(self):
+        assert _notice(_payload(), already_warned=True) is None
+
+    def test_only_agent_dispatches_warn(self):
+        payload = _payload()
+        payload["tool_name"] = "Bash"
+        assert _notice(payload) is None
+        del payload["tool_name"]
+        assert _notice(payload) is None
+
+    def test_fork_and_bridge_still_warn_without_a_session(self):
+        # deliberately not special-cased: with no paired session nothing can
+        # reroute, so the explanation is due whatever the dispatch asked for
+        assert _notice(_payload(subagent_type="fork")) is not None
+        assert _notice(_payload(subagent_type=BRIDGE_AGENT)) is not None
+
+    def test_malformed_input_still_warns(self):
+        # the notice explains the environment, not the dispatch's shape
+        assert _notice({"tool_name": "Agent"}) == {
+            "systemMessage": NOTICE_NO_SESSION}
+
+
 class TestFindAgentBody:
     def test_builtin_and_plugin_scoped_have_no_body(self, tmp_path):
         assert find_agent_body("Explore", str(tmp_path), tmp_path) == ""
@@ -128,6 +192,9 @@ class TestCli:
         out = json.loads(r.output)
         assert out["hookSpecificOutput"]["updatedInput"]["subagent_type"] \
             == BRIDGE_AGENT
+        # the working path is untouched by the notice: no extra key, no stamp
+        assert "systemMessage" not in out
+        assert not (paths.tandem_home() / "warned").exists()
 
     def test_any_crash_exits_zero_silent(self, monkeypatch, tmp_path):
         import click.testing
@@ -148,3 +215,89 @@ class TestCli:
             cli.main, ["hook-route"], input="not json {{{")
         assert r.exit_code == 0
         assert r.output == ""
+
+
+class TestCliNotice:
+    """The wrapper half: stamp bookkeeping and what reaches stdout."""
+
+    def _unpaired(self, tmp_path, monkeypatch, session_id="s-1"):
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        payload = _payload()
+        payload["cwd"] = str(tmp_path)      # no paired session here
+        if session_id is not None:
+            payload["session_id"] = session_id
+        return payload
+
+    def test_first_dispatch_warns_without_deciding_and_stamps(
+            self, tmp_path, monkeypatch):
+        payload = self._unpaired(tmp_path, monkeypatch)
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        out = json.loads(r.output)
+        assert out == {"systemMessage": NOTICE_NO_SESSION}
+        assert "hookSpecificOutput" not in out and "decision" not in out
+        assert (tmp_path / ".tandem" / "warned" / "s-1").exists()
+
+    def test_second_dispatch_same_session_is_silent(
+            self, tmp_path, monkeypatch):
+        payload = self._unpaired(tmp_path, monkeypatch)
+        assert _run_hook(payload).output != ""
+        again = _run_hook(payload)
+        assert again.exit_code == 0
+        assert again.output == ""
+        # a different claude session warns again
+        payload["session_id"] = "s-2"
+        assert json.loads(_run_hook(payload).output) == {
+            "systemMessage": NOTICE_NO_SESSION}
+
+    def test_route_off_is_silent(self, tmp_path, monkeypatch):
+        payload = self._unpaired(tmp_path, monkeypatch)
+        (tmp_path / ".tandem").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".tandem" / "config.toml").write_text(
+            '[subagents]\nroute = "off"\n')
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        assert r.output == ""
+        assert not (tmp_path / ".tandem" / "warned").exists()
+
+    def test_paired_session_with_broken_codex_names_codex(
+            self, env_factory, monkeypatch):
+        from tandem.harness.codex import CodexAdapter
+        env = env_factory(active="claude")
+        monkeypatch.setattr(CodexAdapter, "detect_version", lambda self: None)
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        payload["session_id"] = "s-codex"
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        assert json.loads(r.output) == {"systemMessage": NOTICE_CODEX}
+
+    def test_unusable_stamp_dir_warns_anyway_and_exits_zero(
+            self, tmp_path, monkeypatch):
+        payload = self._unpaired(tmp_path, monkeypatch)
+        (tmp_path / ".tandem").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".tandem" / "warned").write_text("not a directory")
+        for _ in range(2):  # unstampable => warns every time, never blocks
+            r = _run_hook(payload)
+            assert r.exit_code == 0
+            assert json.loads(r.output) == {"systemMessage": NOTICE_NO_SESSION}
+
+    def test_missing_session_id_warns_anyway(self, tmp_path, monkeypatch):
+        payload = self._unpaired(tmp_path, monkeypatch, session_id=None)
+        for _ in range(2):  # nothing to stamp => no suppression, still exit 0
+            r = _run_hook(payload)
+            assert r.exit_code == 0
+            assert json.loads(r.output) == {"systemMessage": NOTICE_NO_SESSION}
+        assert not (tmp_path / ".tandem" / "warned").exists()
+
+    def test_stamps_are_pruned_after_a_week(self, tmp_path, monkeypatch):
+        import os
+        payload = self._unpaired(tmp_path, monkeypatch)
+        warned = tmp_path / ".tandem" / "warned"
+        warned.mkdir(parents=True)
+        stale = warned / "s-old"
+        stale.touch()
+        os.utime(stale, (0, 0))
+        _run_hook(payload)
+        assert not stale.exists()
+        assert (warned / "s-1").exists()

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -4,6 +4,8 @@ Failure discipline: any problem -> None (native dispatch), CLI always exit 0."""
 import json
 from pathlib import Path
 
+import pytest
+
 from tandem import paths
 from tandem.config import SubagentsConfig
 from tandem.hookroute import (
@@ -290,6 +292,29 @@ class TestCliNotice:
             assert json.loads(r.output) == {"systemMessage": NOTICE_NO_SESSION}
         assert not (tmp_path / ".tandem" / "warned").exists()
 
+    @pytest.mark.parametrize("bad_id", ["../../evil", "..", "a/b"])
+    def test_hostile_session_id_never_becomes_a_path(
+            self, tmp_path, monkeypatch, bad_id):
+        """`session_id` is untrusted payload text that names a file, so the
+        id filter is the whole security boundary here. A rejected id must
+        degrade like a missing one: warn (every time — nothing suppresses
+        it), exit 0, and write nothing inside or outside TANDEM_HOME."""
+        home = tmp_path / "home"            # `warned/../../x` escapes to here
+        monkeypatch.setenv("TANDEM_HOME", str(home / ".tandem"))
+        payload = _payload()
+        payload["cwd"] = str(tmp_path)      # no paired session here
+        payload["session_id"] = bad_id
+        for _ in range(2):  # unstampable => no suppression, warns again
+            r = _run_hook(payload)
+            assert r.exit_code == 0
+            assert json.loads(r.output) == {"systemMessage": NOTICE_NO_SESSION}
+        warned = home / ".tandem" / "warned"
+        assert not warned.exists() or not list(warned.iterdir())
+        # nothing was created at the traversal target, or anywhere else
+        # outside the tandem home the stamp path was supposed to stay in
+        assert not (home / "evil").exists()
+        assert [p.name for p in home.iterdir()] == [".tandem"]
+
     def test_stamps_are_pruned_after_a_week(self, tmp_path, monkeypatch):
         import os
         payload = self._unpaired(tmp_path, monkeypatch)
@@ -301,3 +326,19 @@ class TestCliNotice:
         _run_hook(payload)
         assert not stale.exists()
         assert (warned / "s-1").exists()
+
+    def test_one_broken_stamp_does_not_stop_the_prune(
+            self, tmp_path, monkeypatch):
+        # a dangling symlink has no stat() to follow; pruning it must stay a
+        # per-entry failure rather than stranding every other stale stamp
+        import os
+        payload = self._unpaired(tmp_path, monkeypatch)
+        warned = tmp_path / ".tandem" / "warned"
+        warned.mkdir(parents=True)
+        (warned / "dangling").symlink_to(tmp_path / "does-not-exist")
+        stale = warned / "s-old"
+        stale.touch()
+        os.utime(stale, (0, 0))
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        assert not stale.exists()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,15 +2,71 @@
 
 import json
 import re
+import tomllib
 from pathlib import Path
 
-PLUGIN = Path(__file__).parent.parent / "plugin"
+ROOT = Path(__file__).parent.parent
+PLUGIN = ROOT / "plugin"
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
 
 
 def test_manifest_parses():
     m = json.loads((PLUGIN / ".claude-plugin" / "plugin.json").read_text())
     assert m["name"] == "tandem"
     assert m["version"]
+
+
+def test_marketplace_manifest_declares_the_tandem_marketplace():
+    """The top-level `name` is the `@<marketplace>` half of
+    `claude plugin install tandem@tandem` — it is NOT derived from the
+    GitHub owner/repo the user passes to `marketplace add`, so it has to be
+    exactly "tandem" for the documented install command to work."""
+    m = json.loads(MARKETPLACE.read_text())
+    assert m["name"] == "tandem"
+    assert m["owner"] == {
+        "name": "Bhavya Agarwal",
+        "url": "https://github.com/Bhavya6187",
+    }
+    assert len(m["plugins"]) == 1
+
+
+def test_marketplace_entry_source_resolves_to_the_plugin_directory():
+    """A relative source is resolved against the marketplace root (the dir
+    holding `.claude-plugin/`), i.e. the repo root."""
+    entry = json.loads(MARKETPLACE.read_text())["plugins"][0]
+    assert entry["source"] == "./plugin"
+    assert (ROOT / entry["source"]).resolve() == PLUGIN.resolve()
+    assert (PLUGIN / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_marketplace_entry_name_matches_the_plugin_manifest():
+    """Claude installs the plugin under the entry's `name`, and every
+    plugin-scoped reference (`tandem:codex-worker`, hook rewrite target)
+    is built from it — the two manifests must not drift apart."""
+    entry = json.loads(MARKETPLACE.read_text())["plugins"][0]
+    plugin = json.loads((PLUGIN / ".claude-plugin" / "plugin.json").read_text())
+    assert entry["name"] == plugin["name"]
+    assert entry["description"] == plugin["description"]
+
+
+def test_marketplace_entry_leaves_version_and_strict_to_plugin_json():
+    """Version resolution is plugin.json → entry → git SHA, so an entry
+    `version` is silently shadowed by plugin.json and only invites drift.
+    `strict` defaults to true (plugin.json authoritative); `strict: false`
+    against a component-declaring plugin.json is a documented load failure,
+    so it stays unset too."""
+    entry = json.loads(MARKETPLACE.read_text())["plugins"][0]
+    assert set(entry) == {"name", "source", "description"}
+
+
+def test_plugin_version_matches_pyproject_version():
+    """Hand-maintained twin of pyproject's version. It gates update
+    delivery: `plugin marketplace update` skips a plugin whose resolved
+    version already matches the installed one, so a stale plugin.json
+    version means shipped fixes never reach users."""
+    plugin = json.loads((PLUGIN / ".claude-plugin" / "plugin.json").read_text())
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    assert plugin["version"] == pyproject["project"]["version"]
 
 
 def test_hooks_register_hook_route():


### PR DESCRIPTION
Make the tandem Claude Code plugin installable straight from GitHub — no clone — and give the hook a voice for the one confusion a marketplace install creates: "I installed it, nothing happened."

## What's here

**Marketplace install** (`9a8d342`)
- Repo-root `.claude-plugin/marketplace.json` (marketplace name `tandem`, plugin entry `name`/`source`/`description` only), so installation becomes:
  ```
  claude plugin marketplace add Bhavya6187/tandem
  claude plugin install tandem@tandem
  ```
- Schema verified against the current plugin-marketplaces/plugins-reference docs, not assumed: the entry deliberately omits `version` (plugin.json's silently wins; dual-setting invites drift) and `strict` (defaults to true; `strict: false` against a component-declaring plugin.json is a documented load failure).
- `plugin/.claude-plugin/plugin.json` version aligned `0.1.0` → `0.1.5`. This is a **hand-maintained version string** — single-sourcing from package metadata is out of scope here. A drift-guard test now fails if it ever disagrees with pyproject again; the value matters because marketplace updates are skipped when the resolved version matches the installed one.

**Missed-reroute notice** (`2e5bd51`)
- When the hook fires but can't reroute (no paired tandem session for the cwd, or codex missing/unsupported), it now emits `{"systemMessage": …}` — top-level, **no permission decision** — so the user learns why dispatches stay on claude while the dispatch proceeds natively, untouched.
- Once per claude session, not per dispatch: stamp files under `$TANDEM_HOME/warned/<session_id>`, 7-day opportunistic pruning. `session_id` is treated as untrusted input (allowlist regex; traversal is unrepresentable, with a regression test pinning the guard).
- Silent when `route = "off"` (explicit user choice), and every failure — stamp I/O, bad payload, unwritable dirs — degrades to warn-anyway or native dispatch with exit 0. The never-block invariant (`no exit 2, no deny`) survives unchanged, and the rewrite path is byte-for-byte identical.

**Docs** (`4cb6774`, `3b3aeaf`)
- README install story is now two steps: `uv tool install tandem-cli` (the plugin is inert without the binary) + marketplace add/install; `--plugin-dir` stays as the local-dev path. Update wording matches verified behavior: installs track the default branch, but nothing updates behind your back — `claude plugin marketplace update` pulls.
- Design spec updated: the no-session passthrough row is now "native dispatch + one-time notice," the exit-discipline section documents the systemMessage mechanism, and the testing section preserves a live-verified fact future debuggers will want: a decision-free `systemMessage` never appears in `stream-json` output — it renders via a `hook_system_message` transcript attachment record.

## Verification

- `uv run pytest`: **218 passed** (194 baseline + 24 new), TDD red-first throughout.
- `claude plugin validate .`: clean, no advisories.
- Live end-to-end on claude 2.1.220: marketplace add (local path) → install → `plugin list` shows tandem v0.1.5; in an unpaired directory, 4 dispatches across 2 sessions produced exactly 1 notice each and all ran natively; the rewrite path was exercised live (against a copy of state.db) and still produces `allow` + `tandem:codex-worker`; `claude plugin uninstall tandem@tandem` + `marketplace remove tandem` restored the plugin config byte-identical.

## Out of scope, noticed along the way

Pre-existing on main: `tandem --version` crashes in editable/dev installs because `cli.py` passes `version_option(package_name="tandem")` while the dist is `tandem-cli` (traced to `5891025`). Worth its own small PR.

Plan: `docs/plans/2026-08-01-plugin-marketplace-install.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
