### PR TITLE
fix: tandem --version crashed without a 'tandem' dist

### DIFF
--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import click
 
-from . import compat, paths
+from . import __version__, compat, paths
 from .constants import SEED_NOTE
 from .events import SessionContext
 from .harness import get_adapter, other
@@ -72,7 +72,7 @@ def _check_versions(warn_only: bool = False) -> dict[str, str | None]:
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(package_name="tandem")
+@click.version_option(version=__version__, prog_name="tandem")
 @click.option(
     "--active",
     type=click.Choice(["claude", "codex"]),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ tmp homes (same env vars as conftest.Env)."""
 import click.testing
 import pytest
 
+import tandem
 from tandem import cli, compat
 from tandem.state import StateStore
 
@@ -33,6 +34,14 @@ def entered(monkeypatch):
     calls = []
     monkeypatch.setattr(cli, "_enter_session", lambda s: (calls.append(s), 0)[1])
     return calls
+
+
+def test_version_reports_installed_dist():
+    # The dist is named tandem-cli, not tandem; --version must come from
+    # tandem.__version__ or it crashes in venvs without a "tandem" dist.
+    r = click.testing.CliRunner().invoke(cli.main, ["--version"])
+    assert r.exit_code == 0
+    assert tandem.__version__ in r.output
 
 
 def test_bare_tandem_pairs_fresh_each_launch(homes, ok_versions, entered):


### PR DESCRIPTION
Follow-up to the review note on #16: `tandem --version` passes `version_option(package_name="tandem")`, but the dist was renamed to `tandem-cli` in 5891025.

**Verified failure modes:**
- Fresh dev venv: click raises `RuntimeError: 'tandem' is not installed`.
- Venv with a stale `tandem-0.1.0.dist-info` (pre-rename leftover): silently reports 0.1.0 instead of the installed 0.1.5.

**Fix:** point `version_option` at `tandem.__version__` — the metadata-derived version established in #15 — so there's a single source of truth and a source tree without an installed dist falls back to `0.0.0.dev0` instead of crashing. Regression test invokes `--version` and asserts it matches `tandem.__version__`.

Full suite: 219 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)