### PR TITLE
feat: sandbox consent, blocked-write trailer, tandem:gpt alias, route=manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ are listed in `~/.codex/models_cache.json`):
 ```toml
 [subagents]
 model = "gpt-5.6-luna"  # ← the whole point: set this
-route = "all"           # all | off
+route = "all"           # all | manual | off
 context = "match"       # match | task | full
 keep_forks = false      # keep each worker's rollout for debugging
 ```
@@ -94,6 +94,24 @@ keep_forks = false      # keep each worker's rollout for debugging
 probably not the cheap one.** Every other key above is already the default;
 that one is not, and routing is on as soon as the plugin loads, so
 `tandem doctor` warns until you set it.
+
+- `route = "manual"` turns off automatic rerouting: dispatches stay on
+  Claude until you explicitly ask for the `tandem:gpt` agent — "use gpt
+  subagents for this". (`route = "off"` is the same silence, but `manual`
+  keeps `tandem doctor`'s subagent checks on, since you still send work to
+  codex.) Explicit `tandem:gpt` dispatches work under `route = "all"` too;
+  there they're just not the only way in.
+- Write access follows your Claude permission mode. Dispatch while you're in
+  `acceptEdits` or `bypassPermissions` and the codex worker runs with
+  `--sandbox workspace-write`; in any other mode tandem passes no sandbox
+  flag at all, so the worker gets codex's own default — read-only, unless
+  you configured codex otherwise. A read-only worker that tried to edit
+  files comes back with a `[tandem-sub blocked: write]` trailer naming the
+  rejected paths; then it's your call — have it rerun with `tandem sub -q
+  --sandbox workspace-write`, or apply what it returned yourself.
+- Your own agents named `gpt` or `codex-worker` are never rerouted — the
+  loop guard matches on the last segment of the agent name in any scope — so
+  a local `.claude/agents/gpt.md` of yours keeps dispatching natively.
 
 Fork dispatches stay on Claude, each worker's full codex log is kept under
 `~/.tandem/subagents/`, and `tandem status` lists the workers running right
@@ -161,7 +179,7 @@ tandem resume a1b2c3d4e5f6   # a specific one (id from the exit hint)
 | `switch` | Flip active/shadow and enter the other agent — at the tandem prompt, or one-shot from your shell (one-shot only flips, it doesn't enter) |
 | `tandem resume [id]` | Continue the most recent (or a specific) session |
 | `tandem run --on codex "…"` | One-off prompt to the *other* agent, with full context |
-| `tandem sub "…"` | Run one delegated task on a codex model (used by the plugin's reroute hook) |
+| `tandem sub "…"` | Run one delegated task on a codex model (used by the plugin's reroute hook; `--sandbox read-only\|workspace-write` overrides the dispatching session's write consent) |
 | `tandem status` | Show pairing, roles, and sync position |
 
 There are also three maintenance commands — `tandem doctor` (health

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ that one is not, and routing is on as soon as the plugin loads, so
   files comes back with a `[tandem-sub blocked: write]` trailer naming the
   rejected paths; then it's your call — have it rerun with `tandem sub -q
   --sandbox workspace-write`, or apply what it returned yourself.
+- Know the trust boundary: `--sandbox` on `tandem sub` overrides whatever
+  consent your permission mode stamped, and the only thing stopping a task
+  brief from talking the relay into adding that flag is the relay's own
+  instructions — so dispatching a task brief you don't trust is handing that
+  text the relay's privileges.
 - Your own agents named `gpt` or `codex-worker` are never rerouted — the
   loop guard matches on the last segment of the agent name in any scope — so
   a local `.claude/agents/gpt.md` of yours keeps dispatching natively.

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -81,8 +81,11 @@ home), `TANDEM_HOME` (tandem state).
       is written when a patch applies, and every observed one carried
       `success: true`). The rejection survives only in the `response_item`
       pair — the `custom_tool_call` that ran the patch tool plus its
-      call_id-matched `custom_tool_call_output`, whose output text contains
-      `patch rejected`. That pair is what `ops.blocked_write_paths` matches.
+      call_id-matched `custom_tool_call_output`, whose output text carries
+      `patch rejected` at the start of a line (`Script error:\npatch
+      rejected: …`). That pair is what `ops.blocked_write_paths` matches, and
+      it matches the marker line-anchored — mid-line hits are what a worker
+      grepping for these literals gets back, not a rejection.
   - `turn_context` — per turn: cwd, approval_policy, sandbox_policy, model.
   - `world_state` — environment snapshot.
 - Resume: `codex resume <session-id>` (interactive) and

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -76,6 +76,13 @@ home), `TANDEM_HOME` (tandem state).
     (`turn_id`), `user_message`, `agent_message` (`phase`), `token_count`,
     `patch_apply_end` (`{stdout, success, changes: {path: {type, content}}}`),
     `task_complete` (`last_agent_message`).
+    - A patch the sandbox **rejects** emits no `patch_apply_end` at all
+      (live probe, 2026-08-01, `codex exec --sandbox read-only`: the event
+      is written when a patch applies, and every observed one carried
+      `success: true`). The rejection survives only in the `response_item`
+      pair — the `custom_tool_call` that ran the patch tool plus its
+      call_id-matched `custom_tool_call_output`, whose output text contains
+      `patch rejected`. That pair is what `ops.blocked_write_paths` matches.
   - `turn_context` — per turn: cwd, approval_policy, sandbox_policy, model.
   - `world_state` — environment snapshot.
 - Resume: `codex resume <session-id>` (interactive) and

--- a/docs/plans/2026-08-01-sandbox-consent-and-manual-routing.md
+++ b/docs/plans/2026-08-01-sandbox-consent-and-manual-routing.md
@@ -1,0 +1,873 @@
+# Sandbox Consent & Manual Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Codex subagent dispatches inherit write-consent from the dispatching Claude session's permission mode, report sandbox-blocked writes in a structured way, and become explicitly selectable via a user-facing `tandem:gpt` agent and a `route = "manual"` config mode.
+
+**Architecture:** Four additive features on the existing hook→relay→`tandem sub`→`codex exec` pipeline. (A) `tandem hook-route` maps the hook payload's `permission_mode` to a codex sandbox choice and stamps it under `$TANDEM_HOME/sandbox/<tandem_id>`; `tandem sub` reads the stamp (or an explicit `--sandbox` flag) and passes `--sandbox` to `codex exec`. (B) After a quiet run, `run_sub` scans the sub-rollout for `event_msg/patch_apply_end` events with `success: false` and appends a structured `[tandem-sub blocked: write]` footer to stdout so the orchestrating session gets a machine-recognizable signal instead of prose. (C) A `plugin/agents/gpt.md` alias agent makes GPT dispatch user-selectable; the hook's loop guard learns to skip it. (D) `route = "manual"` disables auto-reroute (and the missed-reroute notice) while explicit bridge dispatches keep working.
+
+**Tech Stack:** Python 3.12, click, pytest (run via `uv run pytest`), Claude Code plugin (markdown agents + hooks.json — no hooks.json changes needed).
+
+## Global Constraints
+
+- Failure discipline (repo-wide, load-bearing): `tandem hook-route` ALWAYS exits 0; any internal error degrades to native dispatch. Config errors yield defaults (`config.py` module docstring). New sandbox plumbing must never be the reason a dispatch or `tandem sub` run fails: all stamp I/O is best-effort `try/except OSError`.
+- The task brief never reaches argv (untrusted text; stdin only). The `--sandbox` value is NEVER taken from the brief.
+- Only `"workspace-write"` and `"read-only"` are ever passed to codex. `danger-full-access` is deliberately unsupported.
+- Permission modes that map to write access: exactly `acceptEdits` and `bypassPermissions`. All other modes (`default`, `plan`, unknown/missing) map to no flag (codex's configured default, read-only in practice). Unknown modes MUST degrade to no-write.
+- `plugin/.claude-plugin/plugin.json` version must equal `pyproject.toml` version (`test_plugin_version_matches_pyproject_version`); both bump 0.1.5 → 0.1.6 in the final task.
+- Comment style: comments state constraints the code can't show (see existing `hookroute.py`/`ops.py`); match it.
+- Commit style: `feat:`/`fix:`/`docs:` prefixes, imperative mood (see `git log`).
+
+## File Structure
+
+- `src/tandem/hookroute.py` — add `sandbox_for_mode()` (pure mapping), `WRITE_MODES`, `ALIAS_NAME`/`RELAY_NAMES` loop-guard set.
+- `src/tandem/cli.py` — `hook_route_cmd` stamps the sandbox; `sub` grows `--sandbox` and stamp-read fallback; new `_sandbox_stamp_path`/`_stamp_sandbox`/`_read_sandbox_stamp` helpers next to the warn-stamp helpers.
+- `src/tandem/ops.py` — `run_sub(sandbox=...)` argv plumbing; `blocked_write_paths()` detector; `blocked_footer()` + quiet-mode footer printing.
+- `src/tandem/config.py` — `_ROUTES` grows `"manual"`.
+- `plugin/agents/codex-worker.md` — blocked-footer relay rule + sanctioned `--sandbox workspace-write` retry form.
+- `plugin/agents/gpt.md` — new user-facing alias agent (same relay protocol).
+- `tests/test_hookroute.py`, `tests/test_sub.py`, `tests/test_config.py`, `tests/test_plugin.py` — extended.
+- `README.md`, `pyproject.toml`, `plugin/.claude-plugin/plugin.json` — docs + version bump.
+
+---
+
+### Task 1: `sandbox_for_mode()` — pure permission-mode → sandbox mapping
+
+**Files:**
+- Modify: `src/tandem/hookroute.py` (add after `BRIDGE_MODEL` constant, line ~22)
+- Test: `tests/test_hookroute.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `WRITE_MODES: frozenset[str]`, `sandbox_for_mode(permission_mode) -> str` returning `"workspace-write"` or `""`. Task 2 calls `sandbox_for_mode(payload.get("permission_mode"))`.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_hookroute.py`:
+
+```python
+class TestSandboxForMode:
+    def test_edit_consenting_modes_map_to_workspace_write(self):
+        from tandem.hookroute import sandbox_for_mode
+        assert sandbox_for_mode("acceptEdits") == "workspace-write"
+        assert sandbox_for_mode("bypassPermissions") == "workspace-write"
+
+    def test_everything_else_maps_to_no_flag(self):
+        # unknown/future modes MUST degrade to no-write: an unrecognized
+        # string is not consent
+        from tandem.hookroute import sandbox_for_mode
+        for mode in ("default", "plan", "dontAsk", "auto", "", None, 7):
+            assert sandbox_for_mode(mode) == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_hookroute.py::TestSandboxForMode -v`
+Expected: FAIL with `ImportError: cannot import name 'sandbox_for_mode'`
+
+- [ ] **Step 3: Implement** — in `src/tandem/hookroute.py`, after `BRIDGE_MODEL = "haiku"`:
+
+```python
+# Write-consent propagation: these are the two claude permission modes in
+# which the user has already said "apply edits without asking". Every other
+# value — default, plan, and any mode added after this list was written —
+# maps to "" (codex keeps its configured default, read-only in practice):
+# an unrecognized mode is not consent.
+WRITE_MODES = frozenset({"acceptEdits", "bypassPermissions"})
+
+
+def sandbox_for_mode(permission_mode) -> str:
+    """The codex --sandbox value a dispatch from this claude permission
+    mode has consented to, or "" for 'pass no flag'."""
+    return "workspace-write" if permission_mode in WRITE_MODES else ""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_hookroute.py::TestSandboxForMode -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/hookroute.py tests/test_hookroute.py
+git commit -m "feat: map claude permission modes to a codex sandbox choice"
+```
+
+---
+
+### Task 2: hook-route stamps the sandbox choice per pair
+
+**Files:**
+- Modify: `src/tandem/cli.py` (`hook_route_cmd` body at line ~429, new helpers after `_mark_warned` at line ~404)
+- Test: `tests/test_hookroute.py`
+
+**Interfaces:**
+- Consumes: `sandbox_for_mode` from Task 1; existing `paths.tandem_home()`, `store.latest_session_for_cwd(cwd)`.
+- Produces: stamp file `$TANDEM_HOME/sandbox/<tandem_id>` whose content is `"workspace-write"` or `""`, rewritten on EVERY Agent/Task hook firing (so it always reflects the dispatching session's current mode). Task 3 reads it via `_read_sandbox_stamp(tandem_id)` (also added here so the pair of helpers lands together).
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_hookroute.py` (uses the existing `env_factory` conftest fixture, which sets `TANDEM_HOME` and creates a paired session for `env.cwd`):
+
+```python
+class TestSandboxStamp:
+    def _hook(self, env, mode):
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        payload["session_id"] = "s-1"
+        if mode is not None:
+            payload["permission_mode"] = mode
+        return _run_hook(payload)
+
+    def _stamp(self, env):
+        return (paths.tandem_home() / "sandbox" / env.session.tandem_id)
+
+    def test_accept_edits_stamps_workspace_write(self, env_factory):
+        env = env_factory(active="claude")
+        r = self._hook(env, "acceptEdits")
+        assert r.exit_code == 0
+        assert self._stamp(env).read_text() == "workspace-write"
+        # the rewrite decision itself is unchanged by stamping
+        out = json.loads(r.output)
+        assert out["hookSpecificOutput"]["updatedInput"]["subagent_type"] \
+            == BRIDGE_AGENT
+
+    def test_default_mode_restamps_empty(self, env_factory):
+        # a later default-mode dispatch must revoke an earlier consent
+        env = env_factory(active="claude")
+        self._hook(env, "acceptEdits")
+        self._hook(env, "default")
+        assert self._stamp(env).read_text() == ""
+
+    def test_missing_mode_stamps_empty(self, env_factory):
+        env = env_factory(active="claude")
+        self._hook(env, None)
+        assert self._stamp(env).read_text() == ""
+
+    def test_no_session_writes_no_stamp(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        payload = _payload()
+        payload["cwd"] = str(tmp_path)          # no paired session here
+        payload["permission_mode"] = "acceptEdits"
+        assert _run_hook(payload).exit_code == 0
+        assert not (tmp_path / ".tandem" / "sandbox").exists()
+
+    def test_unwritable_stamp_dir_does_not_break_the_dispatch(
+            self, env_factory):
+        # failure discipline: stamp I/O must never block a reroute
+        env = env_factory(active="claude")
+        (paths.tandem_home() / "sandbox").write_text("not a directory")
+        r = self._hook(env, "acceptEdits")
+        assert r.exit_code == 0
+        assert json.loads(r.output)["hookSpecificOutput"]["updatedInput"][
+            "subagent_type"] == BRIDGE_AGENT
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_hookroute.py::TestSandboxStamp -v`
+Expected: FAIL — stamp file never created (`FileNotFoundError` on `read_text`)
+
+- [ ] **Step 3: Implement** — in `src/tandem/cli.py`.
+
+Add helpers after `_mark_warned` (line ~404):
+
+```python
+def _sandbox_stamp_path(tandem_id: str) -> Path:
+    # tandem_id comes from our own state store (hex), never from payload
+    # text, so it is safe as a filename component without filtering.
+    return paths.tandem_home() / "sandbox" / tandem_id
+
+
+def _stamp_sandbox(tandem_id: str, value: str) -> None:
+    """Record the dispatching session's current write-consent for this pair.
+    Rewritten on every dispatch so a mode change (including back to default)
+    always wins; best-effort, because no stamp failure may reach the
+    dispatch. Known race: two claude sessions dispatching on the same pair
+    interleave last-write-wins; the window is the relay's spawn time."""
+    try:
+        p = _sandbox_stamp_path(tandem_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(value)
+    except OSError:
+        pass
+
+
+def _read_sandbox_stamp(tandem_id: str) -> str:
+    """The stamped consent, filtered to the one value we ever act on —
+    anything unexpected (corrupt file, hand-edited) degrades to no flag."""
+    try:
+        text = _sandbox_stamp_path(tandem_id).read_text().strip()
+    except OSError:
+        return ""
+    return text if text == "workspace-write" else ""
+```
+
+In `hook_route_cmd`, extend the import line and stamp after session resolution:
+
+```python
+        from .config import load_subagents_config
+        from .hookroute import missed_reroute_notice, route, sandbox_for_mode
+
+        payload = json.loads(sys.stdin.read() or "{}")
+        cwd = payload.get("cwd") or _cwd()
+        cfg = load_subagents_config()
+        with StateStore() as store:
+            session = store.latest_session_for_cwd(cwd)
+        # Consent travels out-of-band: the relay's `tandem sub` reads this
+        # stamp, so it must be current before the dispatch spawns the relay.
+        # Stamped regardless of route config — a manual tandem:gpt dispatch
+        # (never rewritten below) consents via permission mode all the same.
+        if session is not None and payload.get("tool_name") in ("Agent", "Task"):
+            _stamp_sandbox(session.tandem_id,
+                           sandbox_for_mode(payload.get("permission_mode")))
+```
+
+(The rest of the function body is unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_hookroute.py -v`
+Expected: PASS (all, including pre-existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/cli.py tests/test_hookroute.py
+git commit -m "feat: hook-route stamps write-consent per pair from permission_mode"
+```
+
+---
+
+### Task 3: `tandem sub --sandbox` + stamp fallback + codex argv plumbing
+
+**Files:**
+- Modify: `src/tandem/ops.py` (`run_sub`, line ~284), `src/tandem/cli.py` (`sub` command, line ~311)
+- Test: `tests/test_sub.py`
+
+**Interfaces:**
+- Consumes: `_read_sandbox_stamp(tandem_id)` from Task 2.
+- Produces: `run_sub(..., sandbox: str = "")` — when truthy, appends `["--sandbox", sandbox]` to the exec-level argv (before `resume`). `tandem sub` option `--sandbox` with choices `read-only`/`workspace-write`; precedence: explicit flag > stamp > nothing. Task 4 reads `run_sub`'s `sandbox` parameter to decide the retry hint.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_sub.py`:
+
+```python
+class TestSandboxPlumbing:
+    def test_run_sub_passes_sandbox_before_resume(self, env_factory,
+                                                  monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t", sandbox="workspace-write")
+        argv = calls["argv"]
+        i = argv.index("--sandbox")
+        assert argv[i + 1] == "workspace-write"
+        assert i < argv.index("resume")   # exec-level flag, like -m and -o
+
+    def test_run_sub_default_omits_sandbox(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t")
+        assert "--sandbox" not in calls["argv"]
+
+    def test_sub_cli_flag_forwards(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "--sandbox", "workspace-write", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == "workspace-write"
+
+    def test_sub_cli_reads_stamp_when_no_flag(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        stamp = paths.tandem_home() / "sandbox" / env.session.tandem_id
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text("workspace-write")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(cli.main, ["sub", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == "workspace-write"
+
+    def test_sub_cli_flag_beats_stamp(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        stamp = paths.tandem_home() / "sandbox" / env.session.tandem_id
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text("workspace-write")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "--sandbox", "read-only", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == "read-only"
+
+    def test_sub_cli_garbage_stamp_degrades_to_no_flag(self, env_factory,
+                                                       monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        stamp = paths.tandem_home() / "sandbox" / env.session.tandem_id
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text("danger-full-access")   # never act on this
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(cli.main, ["sub", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sub.py::TestSandboxPlumbing -v`
+Expected: FAIL — `run_sub() got an unexpected keyword argument 'sandbox'` / `no such option: --sandbox`
+
+- [ ] **Step 3: Implement.**
+
+In `src/tandem/ops.py`, `run_sub` signature gains `sandbox: str = ""` (after `fanout_feature`), and after the `fanout_feature` argv block (line ~316):
+
+```python
+    if fanout_feature:
+        argv += ["--enable", fanout_feature]
+    if sandbox:
+        # exec-level flag: must precede the `resume` subcommand, like -m.
+        # Value is caller-validated ("read-only"/"workspace-write"); the
+        # brief can never influence it (stdin-only transport).
+        argv += ["--sandbox", sandbox]
+```
+
+In `src/tandem/cli.py`, `sub` command — add the option after `-q/--quiet` and thread it through:
+
+```python
+@click.option("--sandbox", "sandbox",
+              type=click.Choice(["read-only", "workspace-write"]),
+              default=None,
+              help="Codex sandbox for this worker. Default: the consent the "
+                   "dispatching claude session stamped via its permission "
+                   "mode, else codex's configured default.")
+```
+
+```python
+def sub(model: str | None, context_mode: str | None, quiet: bool,
+        sandbox: str | None, task: str | None) -> None:
+```
+
+and inside, after `session = _require_session(store)`:
+
+```python
+        code = ops.run_sub(
+            store, session, task,
+            model=model if model is not None else cfg.model,
+            context=context_mode or ("full" if cfg.context == "full" else "task"),
+            fanout_feature=cfg.fanout_feature,
+            keep_forks=cfg.keep_forks,
+            quiet=quiet,
+            sandbox=sandbox if sandbox is not None
+                    else _read_sandbox_stamp(session.tandem_id),
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sub.py -v`
+Expected: PASS (all, including pre-existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/ops.py src/tandem/cli.py tests/test_sub.py
+git commit -m "feat: tandem sub --sandbox flag with stamped-consent fallback"
+```
+
+---
+
+### Task 4: blocked-write detection + structured escalation footer
+
+**Files:**
+- Modify: `src/tandem/ops.py` (`run_sub` finally block line ~354, `_relay_last_message` neighborhood), `plugin/agents/codex-worker.md`
+- Test: `tests/test_sub.py`, `tests/test_plugin.py`
+
+**Interfaces:**
+- Consumes: `run_sub`'s `sandbox` param (Task 3); `read_jsonl` from `tandem.util`; sub rollout path `sub_path` (already in scope in `run_sub`).
+- Produces: `BLOCKED_HEADER = "[tandem-sub blocked: write]"`; `blocked_write_paths(sub_path) -> list[str]`; `blocked_footer(rejected: list[str], *, retry_hint: bool) -> str`. Footer appended to stdout ONLY in quiet mode, after the relayed message, before disposal. Exit code stays codex's.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_sub.py`:
+
+```python
+class TestBlockedWriteFooter:
+    def _fake_run_blocked(self, last_text="Could not write the file."):
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text(last_text)
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "event_msg",
+                "payload": {"type": "patch_apply_end", "stdout": "",
+                            "success": False,
+                            "changes": {"plugin/README.md": {"type": "add"}}},
+            })
+            return _R(0)
+        return fake_run
+
+    def test_quiet_blocked_write_appends_structured_footer(
+            self, env_factory, monkeypatch, capsys):
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert code == 0                       # exit code stays codex's
+        out = capsys.readouterr().out
+        assert "Could not write the file." in out
+        assert out.index("Could not write") < out.index(ops.BLOCKED_HEADER)
+        assert "plugin/README.md" in out
+        assert "--sandbox workspace-write" in out   # the retry hint
+
+    def test_retry_hint_suppressed_when_already_workspace_write(
+            self, env_factory, monkeypatch, capsys):
+        # blocked even with write access => the hint would be a lie
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        ops.run_sub(env.store, env.session, "t", quiet=True,
+                    sandbox="workspace-write")
+        out = capsys.readouterr().out
+        assert ops.BLOCKED_HEADER in out
+        assert "--sandbox workspace-write`" not in out.split(
+            ops.BLOCKED_HEADER)[1]
+
+    def test_successful_patches_emit_no_footer(self, env_factory,
+                                               monkeypatch, capsys):
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("done")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "event_msg",
+                "payload": {"type": "patch_apply_end", "stdout": "ok",
+                            "success": True,
+                            "changes": {"a.py": {"type": "update"}}},
+            })
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert ops.BLOCKED_HEADER not in capsys.readouterr().out
+
+    def test_non_quiet_never_prints_footer(self, env_factory, monkeypatch,
+                                           capsys):
+        # manual runs stream codex's own output; the footer is bridge
+        # protocol, not user chrome
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        ops.run_sub(env.store, env.session, "t")
+        assert ops.BLOCKED_HEADER not in capsys.readouterr().out
+
+    def test_unreadable_rollout_degrades_to_no_footer(self, env_factory,
+                                                      monkeypatch, capsys):
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("fine")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            sub_path.write_text("not json {{{\n")
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "fine" in out
+        assert ops.BLOCKED_HEADER not in out
+```
+
+Note: if `tandem.util.read_jsonl` raises on malformed lines rather than skipping them, wrap the detector's read in `try/except` (see Step 3) — the last test pins that contract.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sub.py::TestBlockedWriteFooter -v`
+Expected: FAIL with `AttributeError: module 'tandem.ops' has no attribute 'BLOCKED_HEADER'`
+
+- [ ] **Step 3: Implement** — in `src/tandem/ops.py`.
+
+Constants + helpers near `_relay_last_message` (line ~371):
+
+```python
+# The bridge-protocol marker for "codex finished but the sandbox rejected
+# its writes". The orchestrating session matches on this exact line, so it
+# is public API: change it and every dispatching model's instructions rot.
+BLOCKED_HEADER = "[tandem-sub blocked: write]"
+
+
+def blocked_write_paths(sub_path: Path) -> list[str]:
+    """Paths whose apply_patch the sandbox rejected during this run, in
+    event order. Codex records each attempt as event_msg/patch_apply_end
+    with a success flag (docs/formats.md); anything unreadable or
+    unexpected yields [] — detection is advisory, never load-bearing."""
+    try:
+        entries = read_jsonl(sub_path)
+    except Exception:
+        return []
+    rejected: list[str] = []
+    for e in entries:
+        if not isinstance(e, dict) or e.get("type") != "event_msg":
+            continue
+        p = e.get("payload")
+        if not isinstance(p, dict) or p.get("type") != "patch_apply_end":
+            continue
+        if p.get("success"):
+            continue
+        changes = p.get("changes")
+        if isinstance(changes, dict) and changes:
+            rejected += [c for c in changes if c not in rejected]
+        elif "(unknown path)" not in rejected:
+            rejected.append("(unknown path)")
+    return rejected
+
+
+def blocked_footer(rejected: list[str], *, retry_hint: bool) -> str:
+    lines = [
+        BLOCKED_HEADER,
+        "The codex worker's file changes were rejected by its sandbox; "
+        "no files were modified. Rejected: " + ", ".join(rejected[:10]),
+    ]
+    if retry_hint:
+        lines.append(
+            "To grant writes: message this worker to rerun the same task "
+            "with `tandem sub -q --sandbox workspace-write`, or ask it to "
+            "return the content and apply the changes yourself.")
+    return "\n".join(lines) + "\n"
+```
+
+Add the `read_jsonl` import to the existing `tandem.util` import line in `ops.py` (check the top of the file; if `ops.py` has no util import yet, add `from .util import read_jsonl` alongside the existing relative imports).
+
+In `run_sub`'s `finally` block, after `_relay_last_message(...)` and before `marker.unlink(...)`:
+
+```python
+    finally:
+        # The worker's answer is what this run exists to produce; disposal is
+        # bookkeeping. Relay first so a raising cleanup cannot swallow a result
+        # codex already produced and billed for.
+        if quiet:
+            _relay_last_message(last_path, log_path)
+            # Bridge protocol: turn "sandbox rejected the writes" from prose
+            # buried in the answer into a fixed trailer the orchestrating
+            # session can match on. Must read sub_path before disposal below.
+            rejected = blocked_write_paths(sub_path)
+            if rejected:
+                sys.stdout.write(blocked_footer(
+                    rejected, retry_hint=sandbox != "workspace-write"))
+                sys.stdout.flush()
+        marker.unlink(missing_ok=True)
+```
+
+In `plugin/agents/codex-worker.md`, append after step 3:
+
+```markdown
+4. The output may end with a `[tandem-sub blocked: write]` trailer: codex
+   finished, but its sandbox rejected the file changes. Return the whole
+   output verbatim as usual — the trailer is for the session that
+   dispatched you, not for you to act on.
+
+5. The ONE exception to the fixed command form: if the session that
+   dispatched you sends a follow-up message telling you to retry with
+   write access, run the SAME heredoc command again with the flag added:
+   `tandem sub -q --sandbox workspace-write <<'TANDEM_TASK_EOF' ...`.
+   Never add that flag on your own initiative.
+```
+
+Append to `tests/test_plugin.py::test_bridge_agent_definition`:
+
+```python
+    assert "[tandem-sub blocked: write]" in body
+    assert "--sandbox workspace-write" in body
+    assert re.search(r"[Nn]ever add that flag", body)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sub.py tests/test_plugin.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/ops.py plugin/agents/codex-worker.md tests/test_sub.py tests/test_plugin.py
+git commit -m "feat: structured [tandem-sub blocked: write] trailer for sandbox-rejected writes"
+```
+
+---
+
+### Task 5: `route = "manual"` config value
+
+**Files:**
+- Modify: `src/tandem/config.py` (lines 17, 24)
+- Test: `tests/test_config.py`, `tests/test_hookroute.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `"manual"` accepted by `_ROUTES`. Semantics (all already emergent from `route()`/`missed_reroute_notice()` checking `cfg.route != "all"`): no auto-rewrite, no missed-reroute notice; explicit bridge dispatches pass through; sandbox stamping still happens (Task 2 stamps regardless of route).
+
+- [ ] **Step 1: Write the failing tests.**
+
+Append to `tests/test_config.py` (match the file's existing style — it tests `load_subagents_config` with a `TANDEM_HOME` tmp dir; follow the pattern already used there for the `route` key, e.g.):
+
+```python
+def test_route_manual_is_accepted(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path))
+    (tmp_path / "config.toml").write_text('[subagents]\nroute = "manual"\n')
+    from tandem.config import load_subagents_config
+    assert load_subagents_config().route == "manual"
+```
+
+Append to `tests/test_hookroute.py`:
+
+```python
+class TestManualRoute:
+    def test_manual_never_rewrites(self):
+        assert _route(_payload(),
+                      cfg=SubagentsConfig(route="manual")) is None
+
+    def test_manual_never_warns(self):
+        # like "off": an explicit user choice, so silence is the requested
+        # behavior even when nothing could reroute anyway
+        cfg = SubagentsConfig(route="manual")
+        assert _notice(_payload(), cfg=cfg) is None
+        assert _notice(_payload(), cfg=cfg,
+                       has_session=True, codex_ok=False) is None
+
+    def test_manual_still_stamps_sandbox(self, env_factory):
+        env = env_factory(active="claude")
+        (paths.tandem_home() / "config.toml").write_text(
+            '[subagents]\nroute = "manual"\n')
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        payload["permission_mode"] = "acceptEdits"
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        assert r.output == ""            # no rewrite, no notice
+        assert (paths.tandem_home() / "sandbox"
+                / env.session.tandem_id).read_text() == "workspace-write"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py::test_route_manual_is_accepted tests/test_hookroute.py::TestManualRoute -v`
+Expected: `test_route_manual_is_accepted` FAILS (unlisted value degrades to default `"all"`); the hookroute tests may already pass — that's fine, they pin the semantics.
+
+- [ ] **Step 3: Implement** — in `src/tandem/config.py`:
+
+```python
+    route: str = "all"          # "all" | "manual" | "off"
+```
+
+```python
+_ROUTES = ("all", "manual", "off")
+```
+
+(`"manual"`: no auto-reroute and no missed-reroute notice — dispatch to codex only when the model/user explicitly picks a bridge agent (`tandem:gpt`, `tandem:codex-worker`). Distinct from `"off"` only in intent today; it exists so docs can point users at a supported name instead of overloading `"off"`. Add this as a comment on `_ROUTES`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py tests/test_hookroute.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/config.py tests/test_config.py tests/test_hookroute.py
+git commit -m "feat: route=manual config value for explicit-only codex dispatch"
+```
+
+---
+
+### Task 6: `tandem:gpt` user-facing alias agent + loop-guard extension
+
+**Files:**
+- Create: `plugin/agents/gpt.md`
+- Modify: `src/tandem/hookroute.py` (constants line ~20, guard line ~63)
+- Test: `tests/test_hookroute.py`, `tests/test_plugin.py`
+
+**Interfaces:**
+- Consumes: relay protocol text from `plugin/agents/codex-worker.md` (Task 4 version, including the blocked-trailer steps).
+- Produces: `ALIAS_NAME = "gpt"`, `RELAY_NAMES = frozenset({BRIDGE_NAME, ALIAS_NAME})`; guard skips any `subagent_type` whose last `:`-segment is in `RELAY_NAMES`. Agent `tandem:gpt`, selectable by the orchestrating model when the user asks for GPT subagents.
+
+- [ ] **Step 1: Write the failing tests.**
+
+Append to `tests/test_hookroute.py` `TestPassthrough`:
+
+```python
+    def test_gpt_alias_loop_guard(self):
+        # tandem:gpt is the user-facing door to the same relay; rewriting it
+        # to codex-worker would work but erase the explicit choice from the
+        # UI and transcript — and the bare name must behave identically
+        assert _route(_payload(subagent_type="tandem:gpt")) is None
+        assert _route(_payload(subagent_type="gpt")) is None
+```
+
+Append to `tests/test_plugin.py`:
+
+```python
+def test_gpt_alias_agent_definition():
+    text = (PLUGIN / "agents" / "gpt.md").read_text()
+    front = text.split("---")[1]
+    assert re.search(r"^name:\s*gpt\s*$", front, re.M)
+    assert re.search(r"^model:\s*haiku\s*$", front, re.M)
+    assert re.search(r"^tools:\s*Bash\(tandem sub:\*\)\s*$", front, re.M)
+    # user-facing: the description must invite selection (unlike
+    # codex-worker's "not meant for manual selection")
+    desc = re.search(r"^description:\s*(.+)$", front, re.M).group(1)
+    assert "not meant for manual selection" not in desc
+    assert re.search(r"GPT", desc)
+    # same relay contract as codex-worker
+    body = text.split("---", 2)[2]
+    for marker in ("tandem sub -q", "TANDEM_TASK_EOF_", "verbatim",
+                   "[tandem-sub failed]", "[tandem-sub blocked: write]",
+                   "--sandbox workspace-write"):
+        assert marker in body, marker
+    assert re.search(r"never do the task yourself", body, re.I)
+
+
+def test_loop_guard_covers_both_relay_agents():
+    """Every agent under plugin/agents/ must be in hookroute's guard set:
+    a plugin agent missing from RELAY_NAMES gets rewritten away from
+    itself on dispatch (or worse, loops)."""
+    from tandem.hookroute import RELAY_NAMES
+    names = set()
+    for f in (PLUGIN / "agents").glob("*.md"):
+        front = f.read_text().split("---")[1]
+        names.add(re.search(r"^name:\s*(\S+)\s*$", front, re.M).group(1))
+    assert names == set(RELAY_NAMES)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_hookroute.py::TestPassthrough::test_gpt_alias_loop_guard tests/test_plugin.py::test_gpt_alias_agent_definition tests/test_plugin.py::test_loop_guard_covers_both_relay_agents -v`
+Expected: FAIL — guard rewrites `tandem:gpt`; `gpt.md` missing; `RELAY_NAMES` missing
+
+- [ ] **Step 3: Implement.**
+
+`src/tandem/hookroute.py` — after `BRIDGE_AGENT`:
+
+```python
+# The user-facing door to the same relay: selectable by the orchestrating
+# model when the user asks for GPT subagents (route="manual" makes that the
+# only path). Same body contract as the bridge; only the description invites
+# selection.
+ALIAS_NAME = "gpt"
+RELAY_NAMES = frozenset({BRIDGE_NAME, ALIAS_NAME})
+```
+
+and change the guard (line ~63):
+
+```python
+    if subagent_type == "fork" or \
+            subagent_type.rsplit(":", 1)[-1] in RELAY_NAMES:
+        return None
+```
+
+Create `plugin/agents/gpt.md` — frontmatter as below; body copied verbatim from the Task-4 version of `plugin/agents/codex-worker.md` (the two bodies are intentionally identical; `test_gpt_alias_agent_definition` pins the shared markers):
+
+```markdown
+---
+name: gpt
+description: Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex.
+model: haiku
+tools: Bash(tandem sub:*)
+---
+
+<body: byte-for-byte copy of codex-worker.md's body, starting at "You are a relay between this session and a codex worker.">
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_hookroute.py tests/test_plugin.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/agents/gpt.md src/tandem/hookroute.py tests/test_hookroute.py tests/test_plugin.py
+git commit -m "feat: user-selectable tandem:gpt alias agent"
+```
+
+---
+
+### Task 7: docs, version bump, full-suite verification
+
+**Files:**
+- Modify: `README.md` (config block at line ~82-96, commands table line ~164), `plugin/README.md`, `pyproject.toml`, `plugin/.claude-plugin/plugin.json`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: version 0.1.6 in both manifests (equality is test-enforced); user docs for all four features.
+
+- [ ] **Step 1: Update `README.md`.**
+
+In the config block (line ~86-88), change the route comment and add the new pieces:
+
+```toml
+[subagents]
+route = "all"           # all | manual | off
+```
+
+Below the block, add prose (match the README's existing voice):
+
+```markdown
+- `route = "manual"` turns off automatic rerouting; dispatch to codex only
+  when you (or Claude) explicitly pick the `tandem:gpt` agent — e.g. say
+  "use gpt subagents for this".
+- Write access follows your Claude permission mode: in `acceptEdits` or
+  `bypassPermissions` the codex worker runs with `--sandbox
+  workspace-write`; otherwise it is read-only and file-writing tasks come
+  back with a `[tandem-sub blocked: write]` trailer explaining how to
+  grant access (`tandem sub -q --sandbox workspace-write`).
+```
+
+In the commands table (line ~164), update the `tandem sub` row's description to mention `--sandbox`.
+
+- [ ] **Step 2: Update `plugin/README.md`** — add `agents/gpt.md` to the directory walk-through (one short paragraph: user-facing alias, same relay, when to select it). Verify every claim against the files as committed.
+
+- [ ] **Step 3: Bump versions** — `pyproject.toml` `version = "0.1.6"`; `plugin/.claude-plugin/plugin.json` `"version": "0.1.6"`. (The plugin content changed; `plugin marketplace update` skips same-version plugins, so shipped fixes never reach users without this — see `test_plugin_version_matches_pyproject_version`.)
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass, no skips introduced by this work
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md plugin/README.md pyproject.toml plugin/.claude-plugin/plugin.json
+git commit -m "docs: sandbox consent, manual routing, tandem:gpt; release 0.1.6"
+```
+
+---
+
+## Post-plan notes (not tasks)
+
+- **Live E2E after merge:** plugin changes only take effect in Claude sessions started after `claude plugin update tandem@tandem` (hooks and agents register at session startup — the exact failure mode that motivated this work). Verify with one fresh-session dispatch in `acceptEdits` mode: expect reroute, codex writes a file, no blocked trailer.
+- **Known accepted race (documented in `_stamp_sandbox`):** two Claude sessions dispatching on the same pair interleave last-write-wins on the stamp. Degradation is at worst one dispatch running with the other session's consent level on the same repo, same user.
+- **`dontAsk`/`auto` modes deliberately unmapped** — revisit only with documented semantics in hand.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {"name": "tandem"}
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,79 @@
+# tandem's Claude Code plugin
+
+Static registration only — no code lives here. The plugin registers one
+PreToolUse hook and two relay agents; all of the work happens in the
+`tandem` binary the hook shells out to (`uv tool install tandem-cli`).
+Without that binary on PATH the plugin is inert: the hook command exits
+nonzero, `|| true` swallows it, and every dispatch runs natively.
+
+```bash
+claude plugin marketplace add Bhavya6187/tandem   # this repo, as a marketplace
+claude plugin install tandem@tandem
+```
+
+Hacking on the plugin itself? Point Claude at your clone instead:
+`claude --plugin-dir /path/to/tandem/plugin`. Either way, hooks and agents
+register when a Claude session starts, so install or update first, then
+open a fresh session.
+
+## What's in here
+
+- **`.claude-plugin/plugin.json`** — manifest. `name` is `tandem`, and it
+  is load-bearing: Claude resolves a plugin's agents as
+  `<plugin-name>:<agent-name>`, so the hook's rewrite target is
+  `tandem:codex-worker` (the bare name does not resolve). `version` is
+  hand-maintained in lockstep with `pyproject.toml` — a drift-guard test
+  fails if they disagree — because `claude plugin marketplace update` skips
+  a plugin whose resolved version already matches the installed one, so a
+  stale version means shipped fixes never reach users.
+- **`hooks/hooks.json`** — `PreToolUse`, matcher `Agent|Task`, command
+  `tandem hook-route || true`. The `|| true` is load-bearing: click's
+  usage-error path exits 2 (version skew — plugin installed, an older
+  `tandem` on PATH with no `hook-route` subcommand), and exit 2 *blocks* the
+  dispatch. `hook-route` itself always exits 0 and prints nothing when in
+  doubt, so its failure mode is "dispatch natively".
+- **`agents/codex-worker.md`** — the bridge the hook rewrites dispatches
+  to. `model: haiku`, `tools: Bash(tandem sub:*)`. It runs exactly one
+  command — `tandem sub -q` with the brief on stdin via heredoc — and
+  returns that command's stdout as its final message, verbatim; the body's
+  first rule is that it never does the task itself. Its description tells
+  the orchestrating model not to select it by hand.
+- **`agents/gpt.md`** — the same relay, with a user-facing description
+  ("Runs the task on a GPT model via tandem's codex pairing"). This is the
+  agent to select when you ask for GPT subagents by name — and with
+  `[subagents] route = "manual"`, selecting it is how anything reaches codex
+  at all, since nothing is rerouted for you. The body is identical to
+  `codex-worker.md`; only the description differs, so both agents behave
+  the same once dispatched.
+
+Both relay names are in the hook's loop guard, matched on the last segment
+of the agent name in any scope — a dispatch that already names a relay
+(`gpt`, `tandem:gpt`, `codex-worker`, `tandem:codex-worker`) is passed
+through untouched instead of being rewritten into itself.
+
+## What the hook does
+
+For each `Agent`/`Task` dispatch, in any directory that has a paired tandem
+session, it:
+
+- records the dispatching session's write consent (`acceptEdits` /
+  `bypassPermissions` → `--sandbox workspace-write`, every other mode →
+  codex's own default) under `$TANDEM_HOME/sandbox/<tandem-id>`, where the
+  relay's `tandem sub` reads it. Stamped whatever the route setting is: a
+  hand-picked `tandem:gpt` dispatch consents through your permission mode
+  just the same;
+- with `route = "all"` (the default) and a supported codex, rewrites the
+  dispatch to `tandem:codex-worker` on `haiku`, prefixing the dispatched
+  agent's own definition — when it is a file-defined one, from
+  `.claude/agents/` here or under `~/.claude/` — to the brief, so the codex
+  worker gets the same instructions the native agent would have;
+- with `route = "manual"` or `"off"`, rewrites nothing; explicitly selected
+  relay agents still reach codex.
+
+When `route = "all"` but nothing can be rerouted — no paired session for
+this directory, or codex missing/unsupported — it prints a one-time
+`systemMessage` naming the cause (once per Claude session) and the dispatch
+runs natively.
+
+Configuration lives in `~/.tandem/config.toml` under `[subagents]` — see
+the repo [README](../README.md) for the keys and the sandbox/consent story.

--- a/plugin/agents/codex-worker.md
+++ b/plugin/agents/codex-worker.md
@@ -41,3 +41,14 @@ Do exactly this:
 3. If it exits nonzero: return its output prefixed with
    `[tandem-sub failed]` and stop. Do not attempt the task yourself — the
    session that dispatched you decides what happens next.
+
+4. The output may end with a `[tandem-sub blocked: write]` trailer: codex
+   finished, but its sandbox rejected the file changes. Return the whole
+   output verbatim as usual — the trailer is for the session that
+   dispatched you, not for you to act on.
+
+5. The ONE exception to the fixed command form: if the session that
+   dispatched you sends a follow-up message telling you to retry with
+   write access, run the SAME heredoc command again with the flag added:
+   `tandem sub -q --sandbox workspace-write <<'TANDEM_TASK_EOF' ...`.
+   Never add that flag on your own initiative.

--- a/plugin/agents/gpt.md
+++ b/plugin/agents/gpt.md
@@ -1,0 +1,54 @@
+---
+name: gpt
+description: Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex.
+model: haiku
+tools: Bash(tandem sub:*)
+---
+
+You are a relay between this session and a codex worker.
+
+**You never do the task yourself.** Not when it looks trivial, not when one
+command would obviously answer it, not when you already know the answer.
+The whole point of this agent is that the work runs on a codex model
+instead of this one — so `tandem sub` is the ONLY command you may ever run.
+Investigating, searching, reading files, or answering from your own
+knowledge is a failure of this agent, even if the answer is correct.
+
+Do exactly this:
+
+1. Run ONE command: `tandem sub -q` with your ENTIRE task message — every
+   line, byte-for-byte, nothing added or removed — on stdin, via heredoc:
+
+   ```
+   tandem sub -q <<'TANDEM_TASK_EOF'
+   <your entire task message here>
+   TANDEM_TASK_EOF
+   ```
+
+   Choose the delimiter BEFORE writing the command: use `TANDEM_TASK_EOF`
+   unless that string appears anywhere in the task message; in that case
+   append random digits (e.g. `TANDEM_TASK_EOF_84613`) and check again,
+   until the delimiter appears nowhere in the message. A delimiter that
+   collides with a line of the task ends the heredoc early — the brief is
+   truncated and the rest of it runs as shell commands.
+
+   Set the Bash tool's timeout parameter to 600000 (codex runs are long).
+
+2. If the command exits 0: its entire output IS the worker's final message.
+   Return that output as your final message, verbatim — no summary, no
+   commentary, no added headers, nothing trimmed.
+
+3. If it exits nonzero: return its output prefixed with
+   `[tandem-sub failed]` and stop. Do not attempt the task yourself — the
+   session that dispatched you decides what happens next.
+
+4. The output may end with a `[tandem-sub blocked: write]` trailer: codex
+   finished, but its sandbox rejected the file changes. Return the whole
+   output verbatim as usual — the trailer is for the session that
+   dispatched you, not for you to act on.
+
+5. The ONE exception to the fixed command form: if the session that
+   dispatched you sends a follow-up message telling you to retry with
+   write access, run the SAME heredoc command again with the flag added:
+   `tandem sub -q --sandbox workspace-write <<'TANDEM_TASK_EOF' ...`.
+   Never add that flag on your own initiative.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -319,9 +319,15 @@ def run_cmd(target: str, prompt: tuple[str, ...]) -> None:
               help="Print only the worker's final message (raw codex output "
                    "goes to a log under ~/.tandem/subagents/<id>/logs). Used "
                    "by the bridge agent, which relays stdout verbatim.")
+@click.option("--sandbox", "sandbox",
+              type=click.Choice(["read-only", "workspace-write"]),
+              default=None,
+              help="Codex sandbox for this worker. Default: the consent the "
+                   "dispatching claude session stamped via its permission "
+                   "mode, else codex's configured default.")
 @click.argument("task", required=False)
 def sub(model: str | None, context_mode: str | None, quiet: bool,
-        task: str | None) -> None:
+        sandbox: str | None, task: str | None) -> None:
     """Run one delegated subagent task on codex (task argument or stdin).
 
     Used by the tandem plugin's codex-worker bridge; also works manually."""
@@ -344,6 +350,8 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
             fanout_feature=cfg.fanout_feature,
             keep_forks=cfg.keep_forks,
             quiet=quiet,
+            sandbox=sandbox if sandbox is not None
+                    else _read_sandbox_stamp(session.tandem_id),
         )
     sys.exit(code)
 

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -453,6 +453,13 @@ def hook_route_cmd() -> None:
     ALWAYS exits 0 — exit 2 would block the dispatch, and any failure here
     must degrade to native behavior.
 
+    It also has one side effect beyond its output: every Agent/Task dispatch
+    in a paired session writes the permission mode's sandbox consent to
+    `$TANDEM_HOME/sandbox/<tandem_id>`, which the relay's `tandem sub` reads
+    when it is given no `--sandbox` flag. That is how write consent reaches
+    codex at all — it cannot ride the dispatch itself, since the relay's only
+    channel to the worker is the untrusted brief.
+
     When nothing is rerouted because tandem is not usable here — no paired
     session for the cwd, or codex missing/unsupported — it prints a bare
     top-level `{"systemMessage": …}` instead: a user-visible line with NO

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -429,7 +429,10 @@ def _read_sandbox_stamp(tandem_id: str) -> str:
     anything unexpected (corrupt file, hand-edited) degrades to no flag."""
     try:
         text = _sandbox_stamp_path(tandem_id).read_text().strip()
-    except OSError:
+    # ValueError covers the UnicodeDecodeError read_text() raises when the
+    # file is not UTF-8: our caller has no blanket except, so an escaping
+    # read failure would crash the dispatch instead of dropping the flag.
+    except (OSError, ValueError):
         return ""
     return text if text == "workspace-write" else ""
 

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -404,6 +404,36 @@ def _mark_warned(stamp: Path | None) -> None:
             pass
 
 
+def _sandbox_stamp_path(tandem_id: str) -> Path:
+    # tandem_id comes from our own state store (hex), never from payload
+    # text, so it is safe as a filename component without filtering.
+    return paths.tandem_home() / "sandbox" / tandem_id
+
+
+def _stamp_sandbox(tandem_id: str, value: str) -> None:
+    """Record the dispatching session's current write-consent for this pair.
+    Rewritten on every dispatch so a mode change (including back to default)
+    always wins; best-effort, because no stamp failure may reach the
+    dispatch. Known race: two claude sessions dispatching on the same pair
+    interleave last-write-wins; the window is the relay's spawn time."""
+    try:
+        p = _sandbox_stamp_path(tandem_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(value)
+    except OSError:
+        pass
+
+
+def _read_sandbox_stamp(tandem_id: str) -> str:
+    """The stamped consent, filtered to the one value we ever act on —
+    anything unexpected (corrupt file, hand-edited) degrades to no flag."""
+    try:
+        text = _sandbox_stamp_path(tandem_id).read_text().strip()
+    except OSError:
+        return ""
+    return text if text == "workspace-write" else ""
+
+
 @main.command(name="hook-route")
 def hook_route_cmd() -> None:
     """Claude Code PreToolUse hook: reroute subagent dispatches to codex.
@@ -428,13 +458,20 @@ def hook_route_cmd() -> None:
     is what makes exit 2 unreachable in practice."""
     try:
         from .config import load_subagents_config
-        from .hookroute import missed_reroute_notice, route
+        from .hookroute import missed_reroute_notice, route, sandbox_for_mode
 
         payload = json.loads(sys.stdin.read() or "{}")
         cwd = payload.get("cwd") or _cwd()
         cfg = load_subagents_config()
         with StateStore() as store:
             session = store.latest_session_for_cwd(cwd)
+        # Consent travels out-of-band: the relay's `tandem sub` reads this
+        # stamp, so it must be current before the dispatch spawns the relay.
+        # Stamped regardless of route config — a manual tandem:gpt dispatch
+        # (never rewritten below) consents via permission mode all the same.
+        if session is not None and payload.get("tool_name") in ("Agent", "Task"):
+            _stamp_sandbox(session.tandem_id,
+                           sandbox_for_mode(payload.get("permission_mode")))
         codex_ok = False
         if session is not None:
             adapter = get_adapter("codex")

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -23,8 +23,10 @@ class SubagentsConfig:
 
 # "manual": no auto-reroute and no missed-reroute notice — dispatch to codex
 # only when the model/user explicitly picks a bridge agent (`tandem:gpt`,
-# `tandem:codex-worker`). Distinct from "off" only in intent today; it exists
-# so docs can point users at a supported name instead of overloading "off".
+# `tandem:codex-worker`). The hook treats it exactly like "off"; the rest of
+# tandem does not — `doctor._subagent_checks` silences its subagent billing
+# warnings only under "off", because a manual user still dispatches to codex
+# and still wants to know the worker model is unset.
 _ROUTES = ("all", "manual", "off")
 _CONTEXTS = ("match", "task", "full")
 

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -14,14 +14,18 @@ from . import paths
 
 @dataclass(frozen=True)
 class SubagentsConfig:
-    route: str = "all"          # "all" | "off"
+    route: str = "all"          # "all" | "manual" | "off"
     model: str = ""             # "" -> omit -m; codex's configured default
     context: str = "match"      # "match" | "task" | "full"
     fanout_feature: str = ""    # --enable <name>; "" -> flag not passed
     keep_forks: bool = False
 
 
-_ROUTES = ("all", "off")
+# "manual": no auto-reroute and no missed-reroute notice — dispatch to codex
+# only when the model/user explicitly picks a bridge agent (`tandem:gpt`,
+# `tandem:codex-worker`). Distinct from "off" only in intent today; it exists
+# so docs can point users at a supported name instead of overloading "off".
+_ROUTES = ("all", "manual", "off")
 _CONTEXTS = ("match", "task", "full")
 
 

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -21,6 +21,13 @@ BRIDGE_NAME = "codex-worker"
 BRIDGE_AGENT = f"tandem:{BRIDGE_NAME}"
 BRIDGE_MODEL = "haiku"
 
+# The user-facing door to the same relay: selectable by the orchestrating
+# model when the user asks for GPT subagents (route="manual" makes that the
+# only path). Same body contract as the bridge; only the description invites
+# selection.
+ALIAS_NAME = "gpt"
+RELAY_NAMES = frozenset({BRIDGE_NAME, ALIAS_NAME})
+
 # Write-consent propagation: these are the two claude permission modes in
 # which the user has already said "apply edits without asking". Every other
 # value — default, plan, and any mode added after this list was written —
@@ -70,11 +77,12 @@ def route(
     if not isinstance(tool_input, dict):
         return None
     subagent_type = tool_input.get("subagent_type") or ""
-    # forks keep claude's native full-context contract; bridge = loop guard.
-    # The guard is scope-insensitive: the model can (and in live traces does)
-    # ask for the bridge by either the plugin-scoped id or the bare name, and
-    # rewriting either one again would re-enter this hook forever.
-    if subagent_type == "fork" or subagent_type.rsplit(":", 1)[-1] == BRIDGE_NAME:
+    # forks keep claude's native full-context contract; the relays = loop
+    # guard. The guard is scope-insensitive: the model can (and in live traces
+    # does) ask for a relay by either the plugin-scoped id or the bare name,
+    # and rewriting either one again would re-enter this hook forever.
+    if subagent_type == "fork" or \
+            subagent_type.rsplit(":", 1)[-1] in RELAY_NAMES:
         return None
     prompt = tool_input.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -21,6 +21,20 @@ BRIDGE_NAME = "codex-worker"
 BRIDGE_AGENT = f"tandem:{BRIDGE_NAME}"
 BRIDGE_MODEL = "haiku"
 
+# Write-consent propagation: these are the two claude permission modes in
+# which the user has already said "apply edits without asking". Every other
+# value — default, plan, and any mode added after this list was written —
+# maps to "" (codex keeps its configured default, read-only in practice):
+# an unrecognized mode is not consent.
+WRITE_MODES = frozenset({"acceptEdits", "bypassPermissions"})
+
+
+def sandbox_for_mode(permission_mode) -> str:
+    """The codex --sandbox value a dispatch from this claude permission
+    mode has consented to, or "" for 'pass no flag'."""
+    return "workspace-write" if permission_mode in WRITE_MODES else ""
+
+
 # The plugin is installed globally in claude, so its silence is ambiguous:
 # "no tandem session here" and "tandem is broken" look identical from the
 # UI. These two lines are the only thing that distinguishes them, and each

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -326,6 +326,15 @@ def run_sub(
     else:
         sub_id, sub_path = seed_sub_rollout(session)
 
+    # Everything already in the rollout predates this run (a fork inherits the
+    # pair's whole codex history); only patches attempted below are this
+    # worker's. Newline count, as in fast_forward: whole-line JSONL, so it is
+    # the entry index — and an unreadable file just means "count from zero".
+    try:
+        sub_pre_entries = sub_path.read_bytes().count(b"\n")
+    except OSError:
+        sub_pre_entries = 0
+
     sub_root = paths.tandem_home() / "subagents" / session.tandem_id
     last_path = log_path = None
     if quiet:
@@ -363,6 +372,14 @@ def run_sub(
         # codex already produced and billed for.
         if quiet:
             _relay_last_message(last_path, log_path)
+            # Bridge protocol: turn "sandbox rejected the writes" from prose
+            # buried in the answer into a fixed trailer the orchestrating
+            # session can match on. Must read sub_path before disposal below.
+            rejected = blocked_write_paths(sub_path, since=sub_pre_entries)
+            if rejected:
+                sys.stdout.write(blocked_footer(
+                    rejected, retry_hint=sandbox != "workspace-write"))
+                sys.stdout.flush()
         marker.unlink(missing_ok=True)
         if keep_forks:
             sub_root.mkdir(parents=True, exist_ok=True)
@@ -372,6 +389,57 @@ def run_sub(
         else:
             sub_path.unlink(missing_ok=True)
     return code
+
+
+# The bridge-protocol marker for "codex finished but the sandbox rejected
+# its writes". The orchestrating session matches on this exact line, so it
+# is public API: change it and every dispatching model's instructions rot.
+BLOCKED_HEADER = "[tandem-sub blocked: write]"
+
+
+def blocked_write_paths(sub_path: Path, *, since: int = 0) -> list[str]:
+    """Paths whose apply_patch the sandbox rejected during this run, in
+    event order. Codex records each attempt as event_msg/patch_apply_end
+    with a success flag (docs/formats.md); anything unreadable or
+    unexpected yields [] — detection is advisory, never load-bearing.
+
+    `since` is the entry count the rollout had before the run: a
+    `--context full` fork carries the pair's real codex history, failed
+    applies from earlier interactive turns included, and those are not this
+    worker's doing."""
+    try:
+        entries = read_jsonl(sub_path)[since:]
+    except Exception:
+        return []
+    rejected: list[str] = []
+    for e in entries:
+        if not isinstance(e, dict) or e.get("type") != "event_msg":
+            continue
+        p = e.get("payload")
+        if not isinstance(p, dict) or p.get("type") != "patch_apply_end":
+            continue
+        if p.get("success"):
+            continue
+        changes = p.get("changes")
+        if isinstance(changes, dict) and changes:
+            rejected += [c for c in changes if c not in rejected]
+        elif "(unknown path)" not in rejected:
+            rejected.append("(unknown path)")
+    return rejected
+
+
+def blocked_footer(rejected: list[str], *, retry_hint: bool) -> str:
+    lines = [
+        BLOCKED_HEADER,
+        "The codex worker's file changes were rejected by its sandbox; "
+        "no files were modified. Rejected: " + ", ".join(rejected[:10]),
+    ]
+    if retry_hint:
+        lines.append(
+            "To grant writes: message this worker to rerun the same task "
+            "with `tandem sub -q --sandbox workspace-write`, or ask it to "
+            "return the content and apply the changes yourself.")
+    return "\n".join(lines) + "\n"
 
 
 def _relay_last_message(last_path: Path, log_path: Path, tail: int = 50) -> None:

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -289,6 +289,7 @@ def run_sub(
     model: str = "",
     context: str = "task",
     fanout_feature: str = "",
+    sandbox: str = "",
     keep_forks: bool = False,
     quiet: bool = False,
 ) -> int:
@@ -314,6 +315,11 @@ def run_sub(
         argv += ["-m", model]
     if fanout_feature:
         argv += ["--enable", fanout_feature]
+    if sandbox:
+        # exec-level flag: must precede the `resume` subcommand, like -m.
+        # Value is caller-validated ("read-only"/"workspace-write"); the
+        # brief can never influence it (stdin-only transport).
+        argv += ["--sandbox", sandbox]
     if context == "full":
         with _sub_lock():
             sub_id, sub_path = fork_shadow(store, session)

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -397,34 +398,87 @@ def run_sub(
 BLOCKED_HEADER = "[tandem-sub blocked: write]"
 
 
+# Codex's literal marker in a failed exec's output when the sandbox (or an
+# approval policy) refuses an apply_patch: "patch rejected: writing is blocked
+# by read-only sandbox; rejected by user approval settings".
+PATCH_REJECTED = "patch rejected"
+
+# `*** Add File: <path>` out of the patch text. That text usually reaches us
+# embedded in a JS string literal (`tools.apply_patch("*** Begin Patch\n…")`),
+# so a patch line ends at a literal two-char `\n` ESCAPE at least as often as
+# at a real newline — and the last one ends at the closing quote. Stop at all
+# three, or the path swallows the rest of the script.
+_PATCH_TARGET_RE = re.compile(
+    r"""\*\*\* (?:Add|Update|Delete) File: (.+?)(?=\\n|[\n"']|$)""")
+
+
+def _output_text(output) -> str:
+    """Flatten a custom_tool_call_output payload: codex writes either a plain
+    string or a list of {"type": "input_text", "text": …} blocks."""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list):
+        return "\n".join(
+            b["text"] for b in output
+            if isinstance(b, dict) and isinstance(b.get("text"), str))
+    return ""
+
+
 def blocked_write_paths(sub_path: Path, *, since: int = 0) -> list[str]:
-    """Paths whose apply_patch the sandbox rejected during this run, in
-    event order. Codex records each attempt as event_msg/patch_apply_end
-    with a success flag (docs/formats.md); anything unreadable or
-    unexpected yields [] — detection is advisory, never load-bearing.
+    """Paths whose apply_patch the sandbox rejected during this run, in event
+    order. Anything unreadable or unexpected yields [] — detection is
+    advisory, never load-bearing.
+
+    Two shapes, because the obvious one is not the one that fires. Live probe
+    (2026-08-01, `codex exec --sandbox read-only`): a refused write emits NO
+    `patch_apply_end` at all — codex writes that event when a patch APPLIES
+    (every such event on that machine carried success:true). The rejection
+    survives only as the `custom_tool_call` running apply_patch plus its
+    call_id-matched `custom_tool_call_output` carrying `patch rejected`. The
+    `patch_apply_end` success:false branch is kept for other codex flows that
+    may still produce it.
 
     `since` is the entry count the rollout had before the run: a
-    `--context full` fork carries the pair's real codex history, failed
-    applies from earlier interactive turns included, and those are not this
-    worker's doing."""
+    `--context full` fork carries the pair's real codex history, rejections
+    from earlier interactive turns included, and those are not this worker's
+    doing."""
     try:
         entries = read_jsonl(sub_path)[since:]
     except Exception:
         return []
     rejected: list[str] = []
+    scripts: dict[str, str] = {}   # call_id -> the apply_patch invocation
+
+    def add(found: list[str]) -> None:
+        paths_ = [p.strip() for p in found if isinstance(p, str) and p.strip()]
+        rejected.extend(
+            p for p in (paths_ or ["(unknown path)"]) if p not in rejected)
+
     for e in entries:
-        if not isinstance(e, dict) or e.get("type") != "event_msg":
+        if not isinstance(e, dict):
             continue
         p = e.get("payload")
-        if not isinstance(p, dict) or p.get("type") != "patch_apply_end":
+        if not isinstance(p, dict):
             continue
-        if p.get("success"):
-            continue
-        changes = p.get("changes")
-        if isinstance(changes, dict) and changes:
-            rejected += [c for c in changes if c not in rejected]
-        elif "(unknown path)" not in rejected:
-            rejected.append("(unknown path)")
+        ptype = p.get("type")
+        if e.get("type") == "event_msg" and ptype == "patch_apply_end":
+            if p.get("success"):
+                continue
+            changes = p.get("changes")
+            add(list(changes) if isinstance(changes, dict) else [])
+        elif ptype == "custom_tool_call":
+            # the call always precedes its output, so a forward pass resolves
+            # the join without a second scan (and never reaches back past
+            # `since` for a script this run did not run)
+            call_id, src = p.get("call_id"), p.get("input")
+            if isinstance(call_id, str) and isinstance(src, str):
+                scripts[call_id] = src
+        elif ptype == "custom_tool_call_output":
+            if PATCH_REJECTED not in _output_text(p.get("output")):
+                continue
+            call_id = p.get("call_id")
+            src = scripts.get(call_id, "") if isinstance(call_id, str) else ""
+            add(_PATCH_TARGET_RE.findall(src))
     return rejected
 
 

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -303,6 +303,12 @@ def run_sub(
     passed through verbatim, on codex's stdin (`resume <id> -`), never as
     argv. Exit code mirrors codex.
 
+    `sandbox` is codex's `--sandbox` value ("read-only"/"workspace-write"),
+    empty for codex's own configured default. It is caller-validated — the CLI
+    accepts it only from a click.Choice flag or the dispatching session's
+    consent stamp — and can never come from the brief, which reaches codex on
+    stdin and never touches argv.
+
     quiet=True is the bridge-agent mode: codex's raw transcript goes to a log
     file and this command's ENTIRE stdout becomes the worker's final message
     (via codex's own `-o/--output-last-message`). With inherited stdio the
@@ -408,6 +414,14 @@ BLOCKED_HEADER = "[tandem-sub blocked: write]"
 # a real rejection.
 PATCH_REJECTED = "patch rejected"
 
+# Anchored, because "somewhere in the output" is not a rejection. Codex prints
+# the marker as its own line ("Script error:\npatch rejected: …"), while a
+# worker grepping this repo gets it back inside an `rg` hit line, prefixed by
+# `path:lineno:`. Anchoring is what separates the two — and it is the only
+# thing that does once the grep pattern also names the patch tool, since then
+# the call itself looks like a patch to the gate below.
+_PATCH_REJECTED_RE = re.compile("^" + re.escape(PATCH_REJECTED), re.M)
+
 # `*** Add File: <path>` out of the patch text. That text usually reaches us
 # embedded in a JS string literal (`tools.apply_patch("*** Begin Patch\n…")`),
 # so a patch line ends at a literal two-char `\n` ESCAPE at least as often as
@@ -488,7 +502,9 @@ def blocked_write_paths(sub_path: Path, *, since: int = 0) -> list[str]:
             # rejection and push the orchestrator into a needless escalation.
             if "*** Begin Patch" not in src and "apply_patch" not in src:
                 continue
-            if PATCH_REJECTED not in _output_text(p.get("output")):
+            # ... and one grep for both literals passes that gate on its own,
+            # so the marker must also sit where codex puts it: line-anchored.
+            if not _PATCH_REJECTED_RE.search(_output_text(p.get("output"))):
                 continue
             add(_PATCH_TARGET_RE.findall(src))
     return rejected
@@ -497,8 +513,13 @@ def blocked_write_paths(sub_path: Path, *, since: int = 0) -> list[str]:
 def blocked_footer(rejected: list[str], *, retry_hint: bool) -> str:
     lines = [
         BLOCKED_HEADER,
+        # NOT "no files were modified": under workspace-write a run can apply
+        # several patches and have a later one refused (a path outside the
+        # workspace, say), so the only claim this footer can make is about the
+        # patches it actually saw rejected.
         "The codex worker's file changes were rejected by its sandbox; "
-        "no files were modified. Rejected: " + ", ".join(rejected[:10]),
+        "the listed changes were not applied. Rejected: "
+        + ", ".join(rejected[:10]),
     ]
     if retry_hint:
         lines.append(

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -399,8 +399,13 @@ BLOCKED_HEADER = "[tandem-sub blocked: write]"
 
 
 # Codex's literal marker in a failed exec's output when the sandbox (or an
-# approval policy) refuses an apply_patch: "patch rejected: writing is blocked
-# by read-only sandbox; rejected by user approval settings".
+# approval policy) refuses a patch. Observed text: "patch rejected: writing
+# is blocked by read-only sandbox; rejected by user approval settings".
+#
+# Deliberately never on the same physical line as the patch tool's name: a
+# worker that greps this repo for that name would otherwise get a hit line
+# carrying both literals, which is exactly the shape the join below reads as
+# a real rejection.
 PATCH_REJECTED = "patch rejected"
 
 # `*** Add File: <path>` out of the patch text. That text usually reaches us

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -474,10 +474,17 @@ def blocked_write_paths(sub_path: Path, *, since: int = 0) -> list[str]:
             if isinstance(call_id, str) and isinstance(src, str):
                 scripts[call_id] = src
         elif ptype == "custom_tool_call_output":
-            if PATCH_REJECTED not in _output_text(p.get("output")):
-                continue
             call_id = p.get("call_id")
             src = scripts.get(call_id, "") if isinstance(call_id, str) else ""
+            # Only a call that actually tried to patch can be a blocked write.
+            # Matching the marker in ANY tool output false-positives on a
+            # worker that merely grepped for the string — this very file
+            # contains it, so `rg 'patch rejected' src/` was enough to fake a
+            # rejection and push the orchestrator into a needless escalation.
+            if "*** Begin Patch" not in src and "apply_patch" not in src:
+                continue
+            if PATCH_REJECTED not in _output_text(p.get("output")):
+                continue
             add(_PATCH_TARGET_RE.findall(src))
     return rejected
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,15 @@ def test_reads_values(tmp_path, monkeypatch):
     assert cfg.keep_forks is True
 
 
+def test_route_manual_is_accepted(tmp_path, monkeypatch):
+    # unlisted values degrade to "all", so a supported name has to be listed
+    home = tmp_path / ".tandem"
+    home.mkdir()
+    (home / "config.toml").write_text('[subagents]\nroute = "manual"\n')
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+    assert load_subagents_config().route == "manual"
+
+
 def test_invalid_values_fall_back(tmp_path, monkeypatch):
     home = tmp_path / ".tandem"
     home.mkdir()

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -342,3 +342,17 @@ class TestCliNotice:
         r = _run_hook(payload)
         assert r.exit_code == 0
         assert not stale.exists()
+
+
+class TestSandboxForMode:
+    def test_edit_consenting_modes_map_to_workspace_write(self):
+        from tandem.hookroute import sandbox_for_mode
+        assert sandbox_for_mode("acceptEdits") == "workspace-write"
+        assert sandbox_for_mode("bypassPermissions") == "workspace-write"
+
+    def test_everything_else_maps_to_no_flag(self):
+        # unknown/future modes MUST degrade to no-write: an unrecognized
+        # string is not consent
+        from tandem.hookroute import sandbox_for_mode
+        for mode in ("default", "plan", "dontAsk", "auto", "", None, 7):
+            assert sandbox_for_mode(mode) == ""

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -99,6 +99,13 @@ class TestPassthrough:
         assert _route(_payload(subagent_type=BRIDGE_NAME)) is None
         assert _route(_payload(subagent_type=f"other:{BRIDGE_NAME}")) is None
 
+    def test_gpt_alias_loop_guard(self):
+        # tandem:gpt is the user-facing door to the same relay; rewriting it
+        # to codex-worker would work but erase the explicit choice from the
+        # UI and transcript — and the bare name must behave identically
+        assert _route(_payload(subagent_type="tandem:gpt")) is None
+        assert _route(_payload(subagent_type="gpt")) is None
+
     def test_route_off(self):
         assert _route(_payload(), cfg=SubagentsConfig(route="off")) is None
 

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -17,6 +17,7 @@ from tandem.hookroute import (
     find_agent_body,
     missed_reroute_notice,
     route,
+    sandbox_for_mode,
 )
 
 
@@ -346,13 +347,85 @@ class TestCliNotice:
 
 class TestSandboxForMode:
     def test_edit_consenting_modes_map_to_workspace_write(self):
-        from tandem.hookroute import sandbox_for_mode
         assert sandbox_for_mode("acceptEdits") == "workspace-write"
         assert sandbox_for_mode("bypassPermissions") == "workspace-write"
 
     def test_everything_else_maps_to_no_flag(self):
         # unknown/future modes MUST degrade to no-write: an unrecognized
         # string is not consent
-        from tandem.hookroute import sandbox_for_mode
         for mode in ("default", "plan", "dontAsk", "auto", "", None, 7):
             assert sandbox_for_mode(mode) == ""
+
+
+class TestSandboxStamp:
+    def _hook(self, env, mode):
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        payload["session_id"] = "s-1"
+        if mode is not None:
+            payload["permission_mode"] = mode
+        return _run_hook(payload)
+
+    def _stamp(self, env):
+        return (paths.tandem_home() / "sandbox" / env.session.tandem_id)
+
+    def test_accept_edits_stamps_workspace_write(self, env_factory):
+        env = env_factory(active="claude")
+        r = self._hook(env, "acceptEdits")
+        assert r.exit_code == 0
+        assert self._stamp(env).read_text() == "workspace-write"
+        # the rewrite decision itself is unchanged by stamping
+        out = json.loads(r.output)
+        assert out["hookSpecificOutput"]["updatedInput"]["subagent_type"] \
+            == BRIDGE_AGENT
+
+    def test_default_mode_restamps_empty(self, env_factory):
+        # a later default-mode dispatch must revoke an earlier consent
+        env = env_factory(active="claude")
+        self._hook(env, "acceptEdits")
+        self._hook(env, "default")
+        assert self._stamp(env).read_text() == ""
+
+    def test_missing_mode_stamps_empty(self, env_factory):
+        env = env_factory(active="claude")
+        self._hook(env, None)
+        assert self._stamp(env).read_text() == ""
+
+    def test_no_session_writes_no_stamp(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        payload = _payload()
+        payload["cwd"] = str(tmp_path)          # no paired session here
+        payload["permission_mode"] = "acceptEdits"
+        assert _run_hook(payload).exit_code == 0
+        assert not (tmp_path / ".tandem" / "sandbox").exists()
+
+    def test_unwritable_stamp_dir_does_not_break_the_dispatch(
+            self, env_factory):
+        # failure discipline: stamp I/O must never block a reroute
+        env = env_factory(active="claude")
+        (paths.tandem_home() / "sandbox").write_text("not a directory")
+        r = self._hook(env, "acceptEdits")
+        assert r.exit_code == 0
+        assert json.loads(r.output)["hookSpecificOutput"]["updatedInput"][
+            "subagent_type"] == BRIDGE_AGENT
+
+
+class TestReadSandboxStamp:
+    """The reader half of the pair (task 3 consumes it). Its filter is the
+    boundary between a file on disk and a codex sandbox flag, so only the
+    one value we ever act on may survive it."""
+
+    def test_round_trips_the_stamped_consent(self, env_factory):
+        from tandem import cli
+        tid = env_factory(active="claude").session.tandem_id
+        cli._stamp_sandbox(tid, "workspace-write")
+        assert cli._read_sandbox_stamp(tid) == "workspace-write"
+
+    def test_anything_unexpected_degrades_to_no_flag(self, env_factory):
+        from tandem import cli
+        tid = env_factory(active="claude").session.tandem_id
+        assert cli._read_sandbox_stamp(tid) == ""       # never stamped
+        cli._stamp_sandbox(tid, "")                     # consent revoked
+        assert cli._read_sandbox_stamp(tid) == ""
+        cli._stamp_sandbox(tid, "danger-full-access")   # hand-edited
+        assert cli._read_sandbox_stamp(tid) == ""

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -165,6 +165,35 @@ class TestNotice:
             "systemMessage": NOTICE_NO_SESSION}
 
 
+class TestManualRoute:
+    def test_manual_never_rewrites(self):
+        assert _route(_payload(),
+                      cfg=SubagentsConfig(route="manual")) is None
+
+    def test_manual_never_warns(self):
+        # like "off": an explicit user choice, so silence is the requested
+        # behavior even when nothing could reroute anyway
+        cfg = SubagentsConfig(route="manual")
+        assert _notice(_payload(), cfg=cfg) is None
+        assert _notice(_payload(), cfg=cfg,
+                       has_session=True, codex_ok=False) is None
+
+    def test_manual_still_stamps_sandbox(self, env_factory):
+        # the stamp is what an explicit tandem:gpt dispatch consents with,
+        # so it must be written before/regardless of the route decision
+        env = env_factory(active="claude")
+        (paths.tandem_home() / "config.toml").write_text(
+            '[subagents]\nroute = "manual"\n')
+        payload = _payload()
+        payload["cwd"] = env.cwd
+        payload["permission_mode"] = "acceptEdits"
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        assert r.output == ""            # no rewrite, no notice
+        assert (paths.tandem_home() / "sandbox"
+                / env.session.tandem_id).read_text() == "workspace-write"
+
+
 class TestFindAgentBody:
     def test_builtin_and_plugin_scoped_have_no_body(self, tmp_path):
         assert find_agent_body("Explore", str(tmp_path), tmp_path) == ""

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -429,3 +429,14 @@ class TestReadSandboxStamp:
         assert cli._read_sandbox_stamp(tid) == ""
         cli._stamp_sandbox(tid, "danger-full-access")   # hand-edited
         assert cli._read_sandbox_stamp(tid) == ""
+
+    def test_non_utf8_stamp_degrades_instead_of_raising(self, env_factory):
+        # read_text() raises UnicodeDecodeError (a ValueError, NOT an
+        # OSError) on undecodable bytes; `tandem sub` calls this with no
+        # blanket except, so escaping here would crash the relay
+        from tandem import cli
+        tid = env_factory(active="claude").session.tandem_id
+        p = cli._sandbox_stamp_path(tid)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"\xff\xfe")
+        assert cli._read_sandbox_stamp(tid) == ""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -119,3 +119,35 @@ def test_bridge_agent_definition():
     assert "[tandem-sub blocked: write]" in body
     assert "--sandbox workspace-write" in body
     assert re.search(r"[Nn]ever add that flag", body)
+
+
+def test_gpt_alias_agent_definition():
+    text = (PLUGIN / "agents" / "gpt.md").read_text()
+    front = text.split("---")[1]
+    assert re.search(r"^name:\s*gpt\s*$", front, re.M)
+    assert re.search(r"^model:\s*haiku\s*$", front, re.M)
+    assert re.search(r"^tools:\s*Bash\(tandem sub:\*\)\s*$", front, re.M)
+    # user-facing: the description must invite selection (unlike
+    # codex-worker's "not meant for manual selection")
+    desc = re.search(r"^description:\s*(.+)$", front, re.M).group(1)
+    assert "not meant for manual selection" not in desc
+    assert re.search(r"GPT", desc)
+    # same relay contract as codex-worker
+    body = text.split("---", 2)[2]
+    for marker in ("tandem sub -q", "TANDEM_TASK_EOF_", "verbatim",
+                   "[tandem-sub failed]", "[tandem-sub blocked: write]",
+                   "--sandbox workspace-write"):
+        assert marker in body, marker
+    assert re.search(r"never do the task yourself", body, re.I)
+
+
+def test_loop_guard_covers_both_relay_agents():
+    """Every agent under plugin/agents/ must be in hookroute's guard set:
+    a plugin agent missing from RELAY_NAMES gets rewritten away from
+    itself on dispatch (or worse, loops)."""
+    from tandem.hookroute import RELAY_NAMES
+    names = set()
+    for f in (PLUGIN / "agents").glob("*.md"):
+        front = f.read_text().split("---")[1]
+        names.add(re.search(r"^name:\s*(\S+)\s*$", front, re.M).group(1))
+    assert names == set(RELAY_NAMES)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -116,3 +116,6 @@ def test_bridge_agent_definition():
     # containing that line truncates the brief and runs the rest as shell
     assert "TANDEM_TASK_EOF_" in body
     assert re.search(r"unless .*appears|appears .*in the task", body)
+    assert "[tandem-sub blocked: write]" in body
+    assert "--sandbox workspace-write" in body
+    assert re.search(r"[Nn]ever add that flag", body)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,5 @@
-"""The plugin is static registration only — validate the three files."""
+"""The plugin is static registration only — validate its manifests (plugin,
+marketplace, hooks) and its two agent definitions."""
 
 import json
 import re
@@ -139,6 +140,13 @@ def test_gpt_alias_agent_definition():
                    "--sandbox workspace-write"):
         assert marker in body, marker
     assert re.search(r"never do the task yourself", body, re.I)
+    # The alias differs ONLY in frontmatter: it is the same relay, offered for
+    # manual selection. Byte equality is the real pin — the markers above only
+    # sample the contract, so an edit to one body that the other misses (a
+    # reworded rule, a new guard) would otherwise slip through as two agents
+    # that behave differently under the same name.
+    assert body == (PLUGIN / "agents" / "codex-worker.md").read_text(
+    ).split("---", 2)[2]
 
 
 def test_loop_guard_covers_both_relay_agents():

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -684,3 +684,116 @@ class TestSandboxPlumbing:
         r = click.testing.CliRunner().invoke(cli.main, ["sub", "brief"])
         assert r.exit_code == 0
         assert calls["kw"]["sandbox"] == ""
+
+
+class TestBlockedWriteFooter:
+    def _fake_run_blocked(self, last_text="Could not write the file."):
+        def fake_run(argv, cwd=None, **kw):
+            # non-quiet runs pass no `-o`: stdio is inherited and codex
+            # writes no last-message file. The rejected patch still lands.
+            if "-o" in argv:
+                Path(argv[argv.index("-o") + 1]).write_text(last_text)
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "event_msg",
+                "payload": {"type": "patch_apply_end", "stdout": "",
+                            "success": False,
+                            "changes": {"plugin/README.md": {"type": "add"}}},
+            })
+            return _R(0)
+        return fake_run
+
+    def test_quiet_blocked_write_appends_structured_footer(
+            self, env_factory, monkeypatch, capsys):
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert code == 0                       # exit code stays codex's
+        out = capsys.readouterr().out
+        assert "Could not write the file." in out
+        assert out.index("Could not write") < out.index(ops.BLOCKED_HEADER)
+        assert "plugin/README.md" in out
+        assert "--sandbox workspace-write" in out   # the retry hint
+
+    def test_retry_hint_suppressed_when_already_workspace_write(
+            self, env_factory, monkeypatch, capsys):
+        # blocked even with write access => the hint would be a lie
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        ops.run_sub(env.store, env.session, "t", quiet=True,
+                    sandbox="workspace-write")
+        out = capsys.readouterr().out
+        assert ops.BLOCKED_HEADER in out
+        assert "--sandbox workspace-write`" not in out.split(
+            ops.BLOCKED_HEADER)[1]
+
+    def test_successful_patches_emit_no_footer(self, env_factory,
+                                               monkeypatch, capsys):
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("done")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "event_msg",
+                "payload": {"type": "patch_apply_end", "stdout": "ok",
+                            "success": True,
+                            "changes": {"a.py": {"type": "update"}}},
+            })
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert ops.BLOCKED_HEADER not in capsys.readouterr().out
+
+    def test_non_quiet_never_prints_footer(self, env_factory, monkeypatch,
+                                           capsys):
+        # manual runs stream codex's own output; the footer is bridge
+        # protocol, not user chrome
+        env = env_factory(active="claude")
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        ops.run_sub(env.store, env.session, "t")
+        assert ops.BLOCKED_HEADER not in capsys.readouterr().out
+
+    def test_unreadable_rollout_degrades_to_no_footer(self, env_factory,
+                                                      monkeypatch, capsys):
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("fine")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            sub_path.write_text("not json {{{\n")
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "fine" in out
+        assert ops.BLOCKED_HEADER not in out
+
+    def test_full_context_ignores_patches_from_before_this_run(
+            self, env_factory, monkeypatch, capsys):
+        """A `--context full` fork inherits the pair's real codex rollout —
+        apply_patch failures from earlier interactive turns included. Those
+        are not this worker's doing, and reporting them sends the
+        orchestrator retrying a write this run never attempted."""
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        write_line(env.codex_shadow, {
+            "timestamp": "t", "type": "event_msg",
+            "payload": {"type": "patch_apply_end", "stdout": "",
+                        "success": False,
+                        "changes": {"old/stale.py": {"type": "add"}}},
+        })
+        monkeypatch.setattr(ops, "_run", self._fake_run_blocked())
+        ops.run_sub(env.store, env.session, "t", quiet=True, context="full")
+        out = capsys.readouterr().out
+        # this run's own rejection is still reported ...
+        assert ops.BLOCKED_HEADER in out
+        assert "plugin/README.md" in out
+        # ... the inherited one is not
+        assert "old/stale.py" not in out

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -594,3 +594,93 @@ class TestDoctorAndStatus:
         assert r.exit_code == 0
         assert "subagent running: gpt-x-mini (task) audit the README" in r.output
         assert r.output.count("subagent running:") == 1
+
+
+class TestSandboxPlumbing:
+    def test_run_sub_passes_sandbox_before_resume(self, env_factory,
+                                                  monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t", sandbox="workspace-write")
+        argv = calls["argv"]
+        i = argv.index("--sandbox")
+        assert argv[i + 1] == "workspace-write"
+        assert i < argv.index("resume")   # exec-level flag, like -m and -o
+
+    def test_run_sub_default_omits_sandbox(self, env_factory, monkeypatch):
+        env = env_factory(active="claude")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "_run",
+            lambda argv, cwd=None, **kw: calls.update(argv=argv) or _R(0),
+        )
+        ops.run_sub(env.store, env.session, "t")
+        assert "--sandbox" not in calls["argv"]
+
+    def test_sub_cli_flag_forwards(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "--sandbox", "workspace-write", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == "workspace-write"
+
+    def test_sub_cli_reads_stamp_when_no_flag(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        stamp = paths.tandem_home() / "sandbox" / env.session.tandem_id
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text("workspace-write")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(cli.main, ["sub", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == "workspace-write"
+
+    def test_sub_cli_flag_beats_stamp(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        stamp = paths.tandem_home() / "sandbox" / env.session.tandem_id
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text("workspace-write")
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "--sandbox", "read-only", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == "read-only"
+
+    def test_sub_cli_garbage_stamp_degrades_to_no_flag(self, env_factory,
+                                                       monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        stamp = paths.tandem_home() / "sandbox" / env.session.tandem_id
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text("danger-full-access")   # never act on this
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(cli.main, ["sub", "brief"])
+        assert r.exit_code == 0
+        assert calls["kw"]["sandbox"] == ""

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -872,3 +872,67 @@ class TestBlockedWriteFooter:
         out = capsys.readouterr().out
         assert ops.BLOCKED_HEADER not in out
         assert "probe.txt" not in out
+
+    def test_non_patch_output_mentioning_the_marker_is_ignored(
+            self, env_factory, monkeypatch, capsys):
+        """Dogfooding hazard: this repo's own ops.py contains the literal
+        marker, so a worker grepping for it gets the string straight back in
+        ordinary tool output. Matching that as a blocked write escalates the
+        orchestrator to workspace-write after a run that patched nothing."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("Found 3 matches.")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "response_item",
+                "payload": {"type": "custom_tool_call", "call_id": "c-rg",
+                            "name": "exec",
+                            "input": "rg -n 'patch rejected' src/"}})
+            write_line(sub_path, {
+                "timestamp": "t", "type": "response_item",
+                "payload": {"type": "custom_tool_call_output",
+                            "call_id": "c-rg", "output": [
+                                {"type": "input_text",
+                                 "text": "src/tandem/ops.py:404:"
+                                         'PATCH_REJECTED = "patch rejected"\n'
+                                         "src/tandem/ops.py:437:carrying "
+                                         "`patch rejected`. The\n"}]}})
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "t", quiet=True)
+        out = capsys.readouterr().out
+        assert "Found 3 matches." in out
+        assert ops.BLOCKED_HEADER not in out
+
+    def test_rejected_patch_with_unparseable_targets_still_reports(
+            self, env_factory, monkeypatch, capsys):
+        """The narrowing gates on the CALL looking like a patch, not on the
+        targets parsing: a real rejection whose paths cannot be extracted must
+        still reach the orchestrator, as "(unknown path)"."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("could not write")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "response_item",
+                "payload": {"type": "custom_tool_call", "call_id": "c-p",
+                            "name": "exec",
+                            "input": "await tools.apply_patch(supplied);\n"}})
+            write_line(sub_path, {
+                "timestamp": "t", "type": "response_item",
+                "payload": {"type": "custom_tool_call_output",
+                            "call_id": "c-p",
+                            "output": "Script error:\npatch rejected: writing "
+                                      "is blocked by read-only sandbox"}})
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "t", quiet=True)
+        out = capsys.readouterr().out
+        assert ops.BLOCKED_HEADER in out
+        assert "(unknown path)" in out

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -668,6 +668,24 @@ class TestSandboxPlumbing:
         assert r.exit_code == 0
         assert calls["kw"]["sandbox"] == "read-only"
 
+    def test_sub_cli_rejects_danger_full_access(self, env_factory, monkeypatch):
+        """Global constraint: tandem never grants codex an unsandboxed run.
+        `danger-full-access` is not in the Choice, so click kills the invocation
+        with a usage error (exit 2) before run_sub is reached — the value is
+        unreachable through the flag, whatever the brief asks for."""
+        import click.testing
+        env = env_factory(active="claude")
+        cli = TestSubCli()._cli_env(env, monkeypatch)
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(kw=kw) or 0,
+        )
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "--sandbox", "danger-full-access", "brief"])
+        assert r.exit_code == 2
+        assert not calls
+
     def test_sub_cli_garbage_stamp_degrades_to_no_flag(self, env_factory,
                                                        monkeypatch):
         import click.testing
@@ -905,6 +923,42 @@ class TestBlockedWriteFooter:
         ops.run_sub(env.store, env.session, "t", quiet=True)
         out = capsys.readouterr().out
         assert "Found 3 matches." in out
+        assert ops.BLOCKED_HEADER not in out
+
+    def test_combined_grep_hit_is_ignored(self, env_factory, monkeypatch,
+                                          capsys):
+        """The narrowing above gates on the CALL looking like a patch, which a
+        single grep for BOTH literals satisfies by itself: the pattern puts the
+        patch tool's name in the call input, and this repo's own source hands
+        the marker back in the output. A real rejection prints the marker at
+        the START of a line ("Script error:\\npatch rejected: …"); an rg hit
+        line never does — it is prefixed by `path:lineno:`."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("Found 2 matches.")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            write_line(sub_path, {
+                "timestamp": "t", "type": "response_item",
+                "payload": {"type": "custom_tool_call", "call_id": "c-rg2",
+                            "name": "exec",
+                            "input": "rg -n 'apply_patch|patch rejected' src/"}})
+            write_line(sub_path, {
+                "timestamp": "t", "type": "response_item",
+                "payload": {"type": "custom_tool_call_output",
+                            "call_id": "c-rg2", "output": [
+                                {"type": "input_text",
+                                 "text": "src/tandem/ops.py:404:"
+                                         'PATCH_REJECTED = "patch rejected"\n'
+                                         "src/tandem/ops.py:437:carrying "
+                                         "`patch rejected`. The\n"}]}})
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "t", quiet=True)
+        out = capsys.readouterr().out
+        assert "Found 2 matches." in out
         assert ops.BLOCKED_HEADER not in out
 
     def test_rejected_patch_with_unparseable_targets_still_reports(

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -797,3 +797,78 @@ class TestBlockedWriteFooter:
         assert "plugin/README.md" in out
         # ... the inherited one is not
         assert "old/stale.py" not in out
+
+    # Modeled byte-for-byte on a live read-only rejection (controller probe,
+    # 2026-08-01, rollout 019fbfe6-…): codex emits NO patch_apply_end when the
+    # sandbox refuses a write — the rejection exists only as this call/output
+    # pair. The patch sits inside a JS string literal, so its line breaks are
+    # literal two-char `\n` escapes; only the JS statements use real newlines.
+    _LIVE_EXEC_INPUT = (
+        'const patch = "*** Begin Patch\\n*** Add File: probe.txt'
+        '\\n+hello\\n*** End Patch";\n'
+        'const result = await tools.apply_patch(patch);\ntext(result);\n'
+    )
+
+    def _rejection_pair(self, call_id="call_GLGqPXu3fYY5aw9m3cmzCyl4"):
+        return [
+            {"timestamp": "t", "type": "response_item",
+             "payload": {"type": "custom_tool_call", "status": "completed",
+                         "call_id": call_id, "name": "exec",
+                         "input": self._LIVE_EXEC_INPUT}},
+            {"timestamp": "t", "type": "response_item",
+             "payload": {"type": "custom_tool_call_output", "call_id": call_id,
+                         "output": [
+                             {"type": "input_text",
+                              "text": "Script failed\nWall time 0.0 seconds\n"
+                                      "Output:\n"},
+                             {"type": "input_text",
+                              "text": "Script error:\npatch rejected: writing "
+                                      "is blocked by read-only sandbox; "
+                                      "rejected by user approval settings"},
+                         ]}},
+        ]
+
+    def test_custom_tool_call_rejection_is_detected(self, env_factory,
+                                                    monkeypatch, capsys):
+        """The real rejection path. Matching only patch_apply_end left the
+        feature dead in production: codex emits that event when a patch
+        APPLIES, not when the sandbox refuses it."""
+        env = env_factory(active="claude")
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text(
+                "I was unable to create the file.")
+            sub_path = paths.find_codex_rollout(
+                argv[argv.index("resume") + 1])
+            for e in self._rejection_pair():
+                write_line(sub_path, e)
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        code = ops.run_sub(env.store, env.session, "t", quiet=True)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert ops.BLOCKED_HEADER in out
+        # the path is parsed out of the JS-escaped patch, stopping at the
+        # `\n` escape rather than swallowing the rest of the string literal
+        assert "Rejected: probe.txt" in out
+        assert "+hello" not in out
+
+    def test_custom_tool_call_rejection_below_watermark_is_ignored(
+            self, env_factory, monkeypatch, capsys):
+        """Same real shape, but inherited by a --context full fork from an
+        earlier interactive turn: not this worker's rejection."""
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        for e in self._rejection_pair():
+            write_line(env.codex_shadow, e)
+
+        def fake_run(argv, cwd=None, **kw):
+            Path(argv[argv.index("-o") + 1]).write_text("no edits attempted")
+            return _R(0)
+
+        monkeypatch.setattr(ops, "_run", fake_run)
+        ops.run_sub(env.store, env.session, "t", quiet=True, context="full")
+        out = capsys.readouterr().out
+        assert ops.BLOCKED_HEADER not in out
+        assert "probe.txt" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What this does

Four features on the codex-subagent pipeline, from the write-permission discussion:

1. **Permission-mode → sandbox consent.** The PreToolUse hook reads the dispatching Claude session's `permission_mode` and stamps write-consent to `$TANDEM_HOME/sandbox/<tandem_id>`; `tandem sub` picks it up and passes `--sandbox workspace-write` to codex. Only `acceptEdits` and `bypassPermissions` grant writes — every other or unknown mode stays read-only. Explicit `tandem sub --sandbox read-only|workspace-write` overrides the stamp; `danger-full-access` is unreachable from both flag and stamp.
2. **Structured escalation trailer.** When codex's sandbox rejects writes, quiet-mode `tandem sub` appends a `[tandem-sub blocked: write]` trailer naming the rejected paths and the retry command. The detector was live-verified against a real rejection rollout: codex emits **no** `patch_apply_end` on rejection — the plan's original event-based detector would have shipped dead; detection now matches the real `custom_tool_call`/`custom_tool_call_output` shape, line-anchored and gated on patch-looking calls to kill grep false positives, with a since-this-run watermark so `--context full` forks don't report inherited history.
3. **`route = "manual"`.** No auto-reroute, no notice; dispatch to codex only by explicitly picking a bridge agent. Sandbox stamping still applies.
4. **`tandem:gpt` alias agent.** User-facing door to the same relay ("run gpt subagents" now routes naturally); loop guard extended so neither relay name is ever rewritten.

Docs updated (README, new plugin/README, formats.md rejection-path note) and version bumped to 0.1.6 (gates marketplace update delivery).

## Process

7-task TDD plan (docs/plans/2026-08-01-sandbox-consent-and-manual-routing.md), fresh implementer + reviewer subagent per task, 4 fix rounds across tasks (incl. two live-probe-driven detector corrections), final whole-branch review + fix wave. 254 tests, all green.

## Known follow-ups (deliberately out of scope)

- Sandbox stamps have no TTL; a flagless manual `tandem sub` inherits the last dispatch's consent until restamped.
- Detection couples to codex's literal `patch rejected` output text (unversioned) — needs a periodic live probe.
- Relay escalation is instruction-guarded only (documented in README's trust-model note); a relay-side handshake would harden it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)