### PR TITLE
release: 0.1.7 — plugin auto-install

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.6"
+version = "0.1.7"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps `tandem-cli` and the `tandem` plugin to 0.1.7 so the features merged since v0.1.5 ship in a tagged release:

- #21 plugin auto-install: first-run offer + `tandem plugin install` one-command wrapper
- #20 sandbox consent, blocked-write trailer, `tandem:gpt` alias, `route=manual`
- #18 `tandem --version` crash fix without a 'tandem' dist
- #17 marketplace install for the plugin + one-time missed-reroute notice
- #16 codex-model subagents — plugin + hook reroute + `tandem sub`

(0.1.6 was bumped in #20 but never tagged or published; #21 landed after it, so both move to 0.1.7.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)