### PR TITLE
build: sync uv.lock with the 0.1.7 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
#22 bumped `pyproject.toml` to 0.1.7 without re-locking, so `uv sync --locked` — and with it CI on main — fails on the stale lockfile. One-line version sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)