### PR TITLE
release: 0.1.8 — manual routing by default, tandem-model pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ tandem run --on codex "second opinion: why is this test flaky?"
 
 ### 🐣 Subagents on the cheap model.
 
-Load tandem's Claude Code plugin and Claude's subagent dispatches run on
-the codex model you choose instead — automatically, with the task brief
-forwarded verbatim and the result returned through Claude's own machinery.
-Claude orchestrates; codex does the legwork; your Claude quota stays on the
+Load tandem's Claude Code plugin and GPT subagents are one ask away: "ask
+gpt to review this migration" runs the dispatch on a codex model instead of
+Claude's, with the task brief forwarded verbatim. Name a model — "ask
+gpt-5.4-mini to review it" — and the worker runs on exactly that one. Want
+every dispatch rerouted without asking each time? Set `route = "all"`.
+Either way the result comes back through Claude's own machinery. Claude
+orchestrates; codex does the legwork; your Claude quota stays on the
 main thread. Two pieces: the `tandem` binary the hook shells out to, and
 the plugin that registers the hook — the plugin lives in this repo, not in
 the wheel, and without the binary on PATH it is inert.
@@ -87,28 +90,40 @@ behind your back: the first-launch offer asks before touching anything, and
 you pull new versions when you run `claude plugin marketplace update` (or
 `/plugin marketplace update` inside Claude).
 
-Then create `~/.tandem/config.toml` and pick your plan's cheap model (ids
-are listed in `~/.codex/models_cache.json`):
+Then create `~/.tandem/config.toml` and pick your plan's cheap model as the
+worker default — the ids your account can actually use are listed in
+`~/.codex/models_cache.json`, the same catalog a per-dispatch model request
+resolves against:
 
 ```toml
 [subagents]
 model = "gpt-5.6-luna"  # ← the whole point: set this
-route = "all"           # all | manual | off
+route = "manual"        # manual | all | off
 context = "match"       # match | task | full
 keep_forks = false      # keep each worker's rollout for debugging
 ```
 
 **Without `model`, workers run on your codex account's default model —
 probably not the cheap one.** Every other key above is already the default;
-that one is not, and routing is on as soon as the plugin loads, so
-`tandem doctor` warns until you set it.
+that one is not, and an explicitly asked-for gpt subagent bills that
+default just as automatic rerouting would, so `tandem doctor` warns until
+you set it.
 
-- `route = "manual"` turns off automatic rerouting: dispatches stay on
-  Claude until you explicitly ask for the `tandem:gpt` agent — "use gpt
-  subagents for this". (`route = "off"` is the same silence, but `manual`
-  keeps `tandem doctor`'s subagent checks on, since you still send work to
-  codex.) Explicit `tandem:gpt` dispatches work under `route = "all"` too;
-  there they're just not the only way in.
+- `route = "manual"` (the default) keeps dispatches on Claude until you ask
+  for codex — "use gpt subagents for this", "ask codex to review the
+  migration". Name a model in the ask and the request rides along as a
+  `tandem-model:` first line in the brief, which tandem resolves against
+  your codex install's own catalog before codex is ever invoked; say the
+  name however you say it out loud, since matching ignores case and
+  punctuation. A name that resolves to nothing fails fast, listing the
+  slugs your account actually offers, and a reply from a model-pinned
+  dispatch ends with a `[tandem-sub model: …]` trailer naming what ran.
+  (`route = "off"` is the same routing silence, but `manual` keeps `tandem
+  doctor`'s subagent checks on, since you still send work to codex.)
+- `route = "all"` reroutes every native subagent dispatch to codex
+  automatically, no asking. It's all or nothing, though: under `all`, "have
+  Claude and GPT both review this" comes back as codex twice — `manual` is
+  the mode where mix-and-match works.
 - Write access follows your Claude permission mode. Dispatch while you're in
   `acceptEdits` or `bypassPermissions` and the codex worker runs with
   `--sandbox workspace-write`; in any other mode tandem passes no sandbox
@@ -126,11 +141,14 @@ that one is not, and routing is on as soon as the plugin loads, so
   loop guard matches on the last segment of the agent name in any scope — so
   a local `.claude/agents/gpt.md` of yours keeps dispatching natively.
 
-Fork dispatches stay on Claude, each worker's full codex log is kept under
-`~/.tandem/subagents/`, and `tandem status` lists the workers running right
-now. The plugin is installed for every Claude session, so in a directory
-with no paired tandem session, dispatches simply run natively — the first
-one says so once, then the session stays quiet. `claude plugin uninstall
+Fork dispatches stay on Claude even under `route = "all"`, each worker's
+full codex log is kept under `~/.tandem/subagents/`, and `tandem status`
+lists the workers running right now. The plugin is installed for every
+Claude session, but nothing reaches codex from a directory with no paired
+tandem session: dispatches run natively (under `route = "all"` the first
+one says so once, then the session stays quiet), and a hand-picked gpt
+subagent there comes back telling you to run `tandem` in that directory
+first. `claude plugin uninstall
 tandem@tandem` and Claude is stock again — add `claude plugin marketplace
 remove tandem` to also unregister the marketplace.
 

--- a/docs/plans/2026-08-03-manual-default-model-passthrough.md
+++ b/docs/plans/2026-08-03-manual-default-model-passthrough.md
@@ -1,0 +1,707 @@
+# Manual Default + Model Pass-Through Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 0.1.8: `route = "manual"` becomes the default, and "ask gpt-5.6-luna to …" reaches codex with the right `-m` via a `tandem-model:` brief header resolved against codex's model catalog.
+
+**Architecture:** A new `modelcat.py` owns the header protocol (parse, resolve against `~/.codex/models_cache.json`, footer text); `cli.py sub()` wires it around the existing `ops.run_sub` (which is untouched — its `model=` kwarg already exists). The plugin change is one description sentence in `gpt.md`; the relay bodies stay byte-for-byte identical. Spec: `docs/specs/2026-08-03-manual-default-model-passthrough-design.md`.
+
+**Tech Stack:** Python 3.11+ (tomllib), click, pytest with the repo's `env_factory` fixture (fake `TANDEM_HOME`/`CODEX_HOME` per test).
+
+## Global Constraints
+
+- Version goes to `0.1.8` in BOTH `pyproject.toml` and `plugin/.claude-plugin/plugin.json` (drift-guard test in `tests/test_plugin.py` fails on disagreement); run `uv lock` after the bump (precedent: commit `fa44504`).
+- Relay agent BODIES (`plugin/agents/gpt.md`, `plugin/agents/codex-worker.md`) must remain byte-for-byte identical to each other; only `gpt.md`'s frontmatter `description:` changes.
+- Header grammar (public protocol): first line of the brief, exactly `tandem-model:` + optional spaces/tabs + a name matching `[A-Za-z0-9._/:-]{1,64}`, nothing else on the line.
+- Footer (public protocol, like `ops.BLOCKED_HEADER`): `[tandem-sub model: <slug>]`.
+- Precedence: `-m` flag > header > `[subagents] model` config > codex default. A recognized header is stripped even when `-m` overrides it; the footer names the model that actually ran.
+- Cross-version compatibility is out of scope (spec Section 3).
+- Catalog source is `~/.codex/models_cache.json` (same `models` array `codex debug models` renders; codex maintains the file, README already points users at it). Unreadable/absent catalog → pass the requested name through verbatim.
+- The error for an unresolvable name must list the visible slugs and reach stderr before codex is invoked: `error: unknown model 'o3'; this codex offers: gpt-5.6-sol, gpt-5.6-terra, …`
+
+---
+
+### Task 1: `modelcat.py` — header protocol and catalog resolution
+
+**Files:**
+- Create: `src/tandem/modelcat.py`
+- Create: `tests/test_modelcat.py`
+- Modify: `src/tandem/paths.py` (one helper, after `codex_sessions_dir()` at line ~64)
+- Modify: `docs/specs/2026-08-03-manual-default-model-passthrough-design.md` (catalog source amendment)
+
+**Interfaces:**
+- Consumes: `paths.codex_home()` (exists).
+- Produces (Task 2 relies on these exact names):
+  - `modelcat.split_model_header(task: str) -> tuple[str, str]` — `(requested_name or "", task_without_header)`
+  - `modelcat.load_catalog() -> list[dict] | None`
+  - `modelcat.resolve(name: str, models: list[dict] | None) -> str` — slug, or `name` verbatim when `models is None`; raises `modelcat.UnknownModel`
+  - `modelcat.model_footer(slug: str) -> str` — `"[tandem-sub model: <slug>]"`
+  - `paths.codex_models_cache_path() -> Path`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_modelcat.py
+"""tandem-model header parsing and catalog resolution."""
+
+import json
+
+import pytest
+
+from tandem import modelcat, paths
+
+CATALOG = [
+    {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
+    {"slug": "gpt-5.6-terra", "display_name": "GPT-5.6-Terra", "visibility": "list"},
+    {"slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini", "visibility": "list"},
+    {"slug": "codex-auto-review", "display_name": "Codex Auto Review",
+     "visibility": "hide"},
+]
+
+
+class TestSplitModelHeader:
+    def test_header_is_stripped_and_returned(self):
+        got = modelcat.split_model_header("tandem-model: gpt-5.6-sol\nreview x")
+        assert got == ("gpt-5.6-sol", "review x")
+
+    def test_no_header_passes_through(self):
+        assert modelcat.split_model_header("review x\nline 2") == ("", "review x\nline 2")
+
+    def test_header_requires_first_line(self):
+        task = "review x\ntandem-model: gpt-5.6-sol"
+        assert modelcat.split_model_header(task) == ("", task)
+
+    def test_malformed_name_left_in_place(self):
+        # trailing prose after the name is not a header
+        task = "tandem-model: gpt-5.6-sol please\nreview x"
+        assert modelcat.split_model_header(task) == ("", task)
+
+    def test_overlong_name_left_in_place(self):
+        task = f"tandem-model: {'x' * 65}\nreview x"
+        assert modelcat.split_model_header(task) == ("", task)
+
+    def test_header_only_brief_yields_empty_task(self):
+        assert modelcat.split_model_header("tandem-model: gpt-5.6-sol") == \
+            ("gpt-5.6-sol", "")
+
+    def test_no_space_after_colon_still_parses(self):
+        assert modelcat.split_model_header("tandem-model:sol\nt") == ("sol", "t")
+
+
+class TestResolve:
+    def test_exact_slug(self):
+        assert modelcat.resolve("gpt-5.6-sol", CATALOG) == "gpt-5.6-sol"
+
+    def test_display_name_case_and_punctuation_insensitive(self):
+        assert modelcat.resolve("GPT 5.6 Sol", CATALOG) == "gpt-5.6-sol"
+
+    def test_unique_substring(self):
+        assert modelcat.resolve("sol", CATALOG) == "gpt-5.6-sol"
+        assert modelcat.resolve("5.4 mini", CATALOG) == "gpt-5.4-mini"
+
+    def test_ambiguous_lists_visible_slugs(self):
+        with pytest.raises(modelcat.UnknownModel) as e:
+            modelcat.resolve("gpt", CATALOG)
+        msg = str(e.value)
+        assert "unknown model 'gpt'" in msg
+        assert "gpt-5.6-sol" in msg and "gpt-5.4-mini" in msg
+        assert "codex-auto-review" not in msg
+
+    def test_no_match_lists_visible_slugs(self):
+        with pytest.raises(modelcat.UnknownModel) as e:
+            modelcat.resolve("o3", CATALOG)
+        assert "unknown model 'o3'; this codex offers: gpt-5.6-sol" in str(e.value)
+
+    def test_hidden_models_never_match(self):
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("auto review", CATALOG)
+
+    def test_none_catalog_passes_name_through(self):
+        assert modelcat.resolve("anything-goes", None) == "anything-goes"
+
+
+class TestLoadCatalog:
+    def test_reads_models_array(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text(
+            json.dumps({"fetched_at": "t", "models": CATALOG}))
+        assert modelcat.load_catalog() == CATALOG
+
+    def test_missing_file_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        assert modelcat.load_catalog() is None
+
+    def test_broken_json_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text("{nope")
+        assert modelcat.load_catalog() is None
+
+    def test_models_not_a_list_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text(json.dumps({"models": 7}))
+        assert modelcat.load_catalog() is None
+
+
+def test_model_footer_exact_text():
+    assert modelcat.model_footer("gpt-5.6-sol") == "[tandem-sub model: gpt-5.6-sol]"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_modelcat.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tandem.modelcat'`
+
+- [ ] **Step 3: Add the paths helper**
+
+In `src/tandem/paths.py`, directly under `codex_sessions_dir()`:
+
+```python
+def codex_models_cache_path() -> Path:
+    """Codex's on-disk model catalog (observed: codex-cli 0.145.0 writes
+    {fetched_at, etag, client_version, models:[{slug, display_name,
+    visibility, …}]} and refreshes it on every exec)."""
+    return codex_home() / "models_cache.json"
+```
+
+- [ ] **Step 4: Write `src/tandem/modelcat.py`**
+
+```python
+"""The tandem-model brief header: how a dispatching session asks for a
+specific codex model.
+
+The orchestrating model can only reach the relay through prompt text, so
+the request travels as the brief's first line (`tandem-model: <name>`); the
+relay forwards it byte-for-byte and `tandem sub` — this module — does the
+parsing and the translation. Translation resolves the user's words against
+codex's own on-disk catalog because codex needs an exact slug: a wrong one
+costs a full API round-trip and 400s with no suggestions (observed live,
+codex-cli 0.145.0 on a ChatGPT account, 2026-08-03), and the valid set is
+account- and version-specific, so no hardcoded table can stay fresh."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from . import paths
+
+# Public protocol, like ops.BLOCKED_HEADER: the plugin's gpt agent
+# description tells the orchestrator to emit this exact line shape, and
+# dispatching models match on the footer. Change either and instructions rot.
+HEADER_PREFIX = "tandem-model:"
+_HEADER_RE = re.compile(r"^tandem-model:[ \t]*([A-Za-z0-9._/:-]{1,64})$")
+
+
+class UnknownModel(ValueError):
+    """The requested name matched nothing (or too much) in the catalog."""
+
+
+def split_model_header(task: str) -> tuple[str, str]:
+    """(requested model, task without the header line). A first line that
+    does not full-match the grammar stays in the brief untouched — no
+    guessing, no partial strips."""
+    first, sep, rest = task.partition("\n")
+    m = _HEADER_RE.match(first)
+    if not m:
+        return "", task
+    return m.group(1), rest if sep else ""
+
+
+def load_catalog() -> list[dict] | None:
+    """The catalog's models array, or None when it cannot be read — the
+    caller then passes the requested name through verbatim rather than
+    refusing to dispatch over bookkeeping."""
+    try:
+        data = json.loads(paths.codex_models_cache_path().read_text())
+    except (OSError, ValueError):
+        return None
+    models = data.get("models") if isinstance(data, dict) else None
+    if not isinstance(models, list):
+        return None
+    return [m for m in models if isinstance(m, dict)]
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def resolve(name: str, models: list[dict] | None) -> str:
+    """The exact slug for a user-worded model name.
+
+    Exact normalized match on slug or display name wins; else a normalized
+    substring match that hits exactly one visible model; else UnknownModel
+    listing the visible slugs — raised before codex is invoked, so the
+    round-trip that would 400 is never spent."""
+    if models is None:
+        return name
+    visible = [m for m in models
+               if m.get("visibility") != "hide"
+               and isinstance(m.get("slug"), str)]
+    n = _norm(name)
+    for m in visible:
+        if n and (n == _norm(m["slug"])
+                  or n == _norm(str(m.get("display_name") or ""))):
+            return m["slug"]
+    hits = {m["slug"] for m in visible
+            if n and (n in _norm(m["slug"])
+                      or n in _norm(str(m.get("display_name") or "")))}
+    if len(hits) == 1:
+        return next(iter(hits))
+    raise UnknownModel(
+        f"unknown model {name!r}; this codex offers: "
+        + ", ".join(m["slug"] for m in visible))
+
+
+def model_footer(slug: str) -> str:
+    return f"[tandem-sub model: {slug}]"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_modelcat.py -q`
+Expected: PASS (19 tests)
+
+- [ ] **Step 6: Amend the spec's catalog source**
+
+In `docs/specs/2026-08-03-manual-default-model-passthrough-design.md`, replace the sentence beginning `Instead, `tandem sub` resolves the header value against `codex debug models`` so the bullet reads that resolution uses **`~/.codex/models_cache.json`** (the same `models` array `codex debug models` renders; codex maintains the file and the README already points users at it; reading the wrapped CLI's files is tandem's established method per `docs/formats.md`), with `codex debug models` noted as the debugging surface. Keep the fallback sentence: unreadable catalog → verbatim pass-through.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tandem/modelcat.py src/tandem/paths.py tests/test_modelcat.py \
+  docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+git commit -m "feat: tandem-model header protocol + catalog resolution (modelcat)"
+```
+
+---
+
+### Task 2: wire the header through `tandem sub`
+
+**Files:**
+- Modify: `src/tandem/cli.py` — inside `def sub(...)` (lines 329–356)
+- Test: `tests/test_sub.py` — new `TestSubModelHeader` class next to the existing `TestSubCommand` (which holds the `_cli_env` helper pattern to copy, line ~440)
+
+**Interfaces:**
+- Consumes: `modelcat.split_model_header`, `modelcat.load_catalog`, `modelcat.resolve`, `modelcat.UnknownModel`, `modelcat.model_footer` (Task 1); `ops.run_sub(store, session, task, *, model=..., ...)` (exists, unchanged).
+- Produces: `tandem sub` behavior relied on by the plugin: header consumed, `-m` precedence, stderr `worker model:` line (non-quiet), stdout footer (quiet), pre-codex failure on unknown model.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_sub.py` (module already imports `json`, `ops`; the class copies `TestSubCommand`'s `_cli_env` helper shape):
+
+```python
+class TestSubModelHeader:
+    def _cli_env(self, env, monkeypatch):
+        from tandem import cli
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        return cli
+
+    def _catalog(self):
+        from tandem import paths
+        p = paths.codex_models_cache_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"models": [
+            {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol",
+             "visibility": "list"},
+            {"slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini",
+             "visibility": "list"},
+        ]}))
+
+    def _capture(self, monkeypatch):
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(
+                task=task, kw=kw) or 0,
+        )
+        return calls
+
+    def test_header_resolves_and_is_stripped(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\ndo the thing\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "do the thing"
+        assert calls["kw"]["model"] == "gpt-5.6-sol"
+
+    def test_flag_beats_header_but_header_still_stripped(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-m", "flag-model"],
+            input="tandem-model: sol\ntask\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "task"
+        assert calls["kw"]["model"] == "flag-model"
+
+    def test_unknown_model_fails_before_codex(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: o3\ntask\n")
+        assert r.exit_code == 1
+        assert "unknown model 'o3'" in r.output
+        assert "gpt-5.6-sol" in r.output
+        assert calls == {}          # codex was never invoked
+
+    def test_quiet_appends_model_footer(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="tandem-model: sol\ntask\n")
+        assert r.output.rstrip().endswith("[tandem-sub model: gpt-5.6-sol]")
+
+    def test_no_header_no_footer(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="just a task\n")
+        assert "[tandem-sub model:" not in r.output
+        assert calls["kw"]["model"] == ""   # config default: unset
+
+    def test_non_quiet_announces_worker_model(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\ntask\n")
+        assert "worker model: gpt-5.6-sol" in r.output
+
+    def test_missing_catalog_passes_name_verbatim(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        # no _catalog() call: CODEX_HOME has no models_cache.json
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: mystery-model\ntask\n")
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "mystery-model"
+
+    def test_header_only_brief_is_an_empty_task_error(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\n")
+        assert r.exit_code == 1
+        assert "empty task brief" in r.output
+        assert calls == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_sub.py::TestSubModelHeader -q`
+Expected: FAIL — header reaches `run_sub` as task text, `model` is `""`, no footer.
+
+- [ ] **Step 3: Wire `sub()` in `src/tandem/cli.py`**
+
+Replace the body of `sub()` (currently lines 334–356) with:
+
+```python
+    """Run one delegated subagent task on codex (task argument or stdin).
+
+    Used by the tandem plugin's codex-worker bridge; also works manually.
+    A brief whose first line is `tandem-model: <name>` picks the codex
+    model for this worker: the name is resolved against codex's own model
+    catalog (~/.codex/models_cache.json), and an unresolvable name fails
+    here, before codex is invoked, with the valid slugs listed."""
+    from . import modelcat, ops
+    from .config import load_subagents_config
+
+    if task is None or task == "-":
+        task = sys.stdin.read()
+    task = task.strip()
+    requested, task = modelcat.split_model_header(task)
+    task = task.strip()
+    if not task:
+        click.secho("error: empty task brief.", fg="red", err=True)
+        sys.exit(1)
+    resolved = ""
+    if requested:
+        try:
+            resolved = modelcat.resolve(requested, modelcat.load_catalog())
+        except modelcat.UnknownModel as e:
+            click.secho(f"error: {e}", fg="red", err=True)
+            sys.exit(1)
+    cfg = load_subagents_config()
+    worker_model = model if model is not None else (resolved or cfg.model)
+    if requested and not quiet:
+        click.secho(f"worker model: {worker_model}", err=True)
+    with StateStore() as store:
+        session = _require_session(store)
+        code = ops.run_sub(
+            store, session, task,
+            model=worker_model,
+            context=context_mode or ("full" if cfg.context == "full" else "task"),
+            fanout_feature=cfg.fanout_feature,
+            keep_forks=cfg.keep_forks,
+            quiet=quiet,
+            sandbox=sandbox if sandbox is not None
+                    else _read_sandbox_stamp(session.tandem_id),
+        )
+    if requested and quiet:
+        sys.stdout.write("\n" + modelcat.model_footer(worker_model) + "\n")
+        sys.stdout.flush()
+    sys.exit(code)
+```
+
+(The only changes from the current body: the docstring's second paragraph, the `modelcat` import, the `split_model_header`/`resolve` block before the empty-task check's new position, `model=worker_model` instead of the inline conditional, the stderr announcement, and the footer write before `sys.exit`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_sub.py -q`
+Expected: PASS — the new class and every pre-existing `TestSubCommand` test (the empty-brief and stdin tests must still pass; if `test_sub_reads_task_from_stdin` fails, the wiring reordered something it shouldn't have).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/cli.py tests/test_sub.py
+git commit -m "feat: tandem sub honors the tandem-model brief header"
+```
+
+---
+
+### Task 3: flip the routing default to manual
+
+**Files:**
+- Modify: `src/tandem/config.py:17` and the comment block at lines 24–30
+- Modify: `tests/test_config.py:10`
+- Modify: `tests/test_hookroute.py:32` (+ one new test in the manual-mode class at line ~176)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `SubagentsConfig().route == "manual"` — the shipped default every module reads.
+
+- [ ] **Step 1: Update the tests first**
+
+In `tests/test_config.py` line 10, the missing-file default becomes:
+
+```python
+    assert (cfg.route, cfg.model, cfg.context) == ("manual", "", "match")
+```
+
+In `tests/test_hookroute.py` line 32, the module-level config the rewrite
+tests use stops leaning on the default (they test all-mode behavior):
+
+```python
+CFG = SubagentsConfig(route="all")
+```
+
+In the class holding `test_manual_never_rewrites` (line ~176), add:
+
+```python
+    def test_default_config_never_rewrites(self):
+        # the shipped default IS manual now — no cfg file, no rewrite
+        assert _route(_payload(), cfg=SubagentsConfig()) is None
+```
+
+- [ ] **Step 2: Run tests to verify the new expectations fail**
+
+Run: `uv run pytest tests/test_config.py tests/test_hookroute.py -q`
+Expected: `test_defaults_when_file_missing` and `test_default_config_never_rewrites` FAIL (default is still `"all"`); everything else PASSES (line 32 made the rewrite tests explicit).
+
+- [ ] **Step 3: Flip the default**
+
+In `src/tandem/config.py`:
+
+```python
+    route: str = "manual"       # "manual" | "all" | "off"
+```
+
+and rewrite the comment block above `_ROUTES` (lines 24–30) to:
+
+```python
+# "manual" — the default: no auto-reroute and no missed-reroute notice —
+# dispatch to codex only when the model/user explicitly picks a bridge agent
+# (`tandem:gpt`, `tandem:codex-worker`). The hook treats it exactly like
+# "off"; the rest of tandem does not — `doctor._subagent_checks` silences
+# its subagent billing warnings only under "off", because a manual user
+# still dispatches to codex and still wants to know the worker model is
+# unset. "all" opts back in to rerouting every native dispatch.
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS. Any other failure means a test leaned on the `"all"` default this plan missed — fix it by passing `SubagentsConfig(route="all")` explicitly in that test, since such tests exercise all-mode behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/config.py tests/test_config.py tests/test_hookroute.py
+git commit -m "feat!: route defaults to manual — dispatches stay on claude unless asked"
+```
+
+---
+
+### Task 4: teach the orchestrator the header (gpt.md description)
+
+**Files:**
+- Modify: `plugin/agents/gpt.md:3` (frontmatter `description:` only)
+
+**Interfaces:**
+- Consumes: the header grammar from Global Constraints.
+- Produces: the description text the orchestrating model acts on; Task 6's live acceptance depends on it.
+
+- [ ] **Step 1: Extend the description**
+
+Line 3 of `plugin/agents/gpt.md` becomes (one line):
+
+```yaml
+description: Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex. If the user asked for a specific model, put `tandem-model: <name as the user said it>` alone on the first line of the task; tandem translates it to an exact codex model.
+```
+
+- [ ] **Step 2: Verify the bodies are still identical**
+
+Run (from the repo root):
+
+```bash
+awk 'f{print} /^---$/{c++; if(c==2) f=1}' plugin/agents/gpt.md > /tmp/gpt-body.txt
+awk 'f{print} /^---$/{c++; if(c==2) f=1}' plugin/agents/codex-worker.md > /tmp/cw-body.txt
+diff /tmp/gpt-body.txt /tmp/cw-body.txt && echo BODIES-IDENTICAL
+```
+
+Expected: `BODIES-IDENTICAL` (only frontmatter differs between the two files).
+
+- [ ] **Step 3: Run the plugin tests**
+
+Run: `uv run pytest tests/test_plugin.py -q`
+Expected: PASS (nothing asserts on the description text; this catches accidental frontmatter breakage).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/agents/gpt.md
+git commit -m "feat: gpt agent description solicits a tandem-model header for named models"
+```
+
+---
+
+### Task 5: rewrite the README copy around the new default
+
+**Files:**
+- Modify: `README.md` (lines 62–70 intro paragraph; lines 93–111 config block and mode bullets)
+- Modify: `plugin/README.md` (lines 45–51 gpt.md bullet; lines 58–81 hook behavior; lines 83–94 configuration)
+
+**Interfaces:**
+- Consumes: the shipped behavior from Tasks 1–4.
+- Produces: user-facing truth; no other task depends on it.
+
+- [ ] **Step 1: README.md — intro paragraph**
+
+Replace lines 64–66 ("Load tandem's Claude Code plugin and Claude's subagent dispatches run on the codex model you choose instead — automatically, with the task brief") with copy stating the new contract: load the plugin and GPT subagents are one ask away — say "ask gpt to review this" and the dispatch runs on a codex model, "ask gpt-5.4-mini" and it runs on that exact model; set `route = "all"` if you want every subagent dispatch rerouted automatically. Keep the rest of the paragraph (result returned through Claude's machinery, quota point, two-pieces sentence) intact.
+
+- [ ] **Step 2: README.md — config block and bullets**
+
+Line 96 becomes:
+
+```toml
+route = "manual"        # manual | all | off
+```
+
+Rewrite the bullet at lines 106–111 as two bullets:
+
+- `route = "manual"` (the default): dispatches stay on Claude until you ask — "use gpt subagents", "ask codex to …". Name a model — "ask gpt-5.4-mini to …" — and the request travels as a `tandem-model:` first line in the brief that tandem resolves against your codex install's own model catalog (`~/.codex/models_cache.json`); a name that doesn't resolve fails fast listing what your account actually offers, and the worker's reply carries a `[tandem-sub model: …]` trailer naming what ran. (`route = "off"` is the same routing silence, but `manual` keeps `tandem doctor`'s subagent checks on.)
+- `route = "all"` reroutes every native subagent dispatch to codex automatically. In this mode a "have Claude and GPT both review it" ask becomes codex twice — manual is the mode where mix-and-match works.
+
+Also update lines 101–104: "routing is on as soon as the plugin loads" is no longer true — the model-unset warning story stays, but tie it to dispatching (`tandem doctor` warns until you set `model`, since explicit gpt dispatches still bill your codex account's default model otherwise).
+
+- [ ] **Step 3: plugin/README.md**
+
+- Lines 46–51 (`agents/gpt.md` bullet): after "This is the agent to select when you ask for GPT subagents by name", add: a brief whose first line is `tandem-model: <name>` picks the worker model — the description solicits it from the orchestrating model when the user names one, and `tandem sub` resolves the name against codex's catalog. Drop "and with `[subagents] route = "manual"` …" framing that implies manual is the exception; manual is now the default and selecting this agent is the normal path to codex.
+- Line 69 ("with `route = "all"` (the default)") → `with route = "all" (opt-in; the default is "manual")`.
+- Lines 75–76: "with `route = "manual"` or `"off"`, rewrites nothing" → "with `route = "manual"` (the default) or `"off"`, rewrites nothing".
+- Lines 85–91 (Configuration): "Routing is enabled by default." → "Dispatches reach codex when you ask for the `tandem:gpt` agent; set `route = "all"` to reroute every dispatch automatically." Flip the example TOML to show `route = "all"` (since manual needs no config).
+
+- [ ] **Step 4: Proofread render**
+
+Run: `grep -n "route" README.md plugin/README.md`
+Expected: no surviving claim that `all` is the default or that routing is automatic out of the box.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md plugin/README.md
+git commit -m "docs: README copy for manual-default routing and model pass-through"
+```
+
+---
+
+### Task 6: version 0.1.8 + full verification + live acceptance
+
+**Files:**
+- Modify: `pyproject.toml:3` (`version = "0.1.8"`)
+- Modify: `plugin/.claude-plugin/plugin.json:4` (`"version": "0.1.8"`)
+- Modify: `uv.lock` (via `uv lock`)
+
+**Interfaces:**
+- Consumes: everything prior.
+- Produces: the releasable tree.
+
+- [ ] **Step 1: Bump both versions**
+
+`pyproject.toml` line 3 → `version = "0.1.8"`; `plugin/.claude-plugin/plugin.json` line 4 → `"version": "0.1.8",`
+
+- [ ] **Step 2: Sync the lockfile**
+
+Run: `uv lock`
+Expected: `uv.lock` updates the `tandem-cli` version only.
+
+- [ ] **Step 3: Full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS, including the plugin.json/pyproject drift guard in `tests/test_plugin.py`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml plugin/.claude-plugin/plugin.json uv.lock
+git commit -m "release: 0.1.8 — manual routing by default, tandem-model pass-through"
+```
+
+- [ ] **Step 5: Live acceptance (operator-run; needs a paired session + reinstalled plugin)**
+
+The two phrases that failed in the research are the acceptance test. In a scratch project with a real paired tandem session (`tandem` running there) and the 0.1.8 plugin picked up by a fresh Claude session:
+
+```bash
+claude -p "Ask gpt-5.4-mini to review utils.py" --output-format stream-json --verbose --max-turns 8 > accept1.jsonl
+claude -p "Ask o3 to review utils.py" --output-format stream-json --verbose --max-turns 8 > accept2.jsonl
+```
+
+Verify in `accept1.jsonl`: the `tandem:gpt` dispatch's prompt begins `tandem-model: gpt-5.4-mini` (or the user's wording), the relay's Bash result ends with `[tandem-sub model: gpt-5.4-mini]`, and `~/.tandem/subagents/<id>/logs` shows the codex run on that model. Verify in `accept2.jsonl`: the relay's result contains `[tandem-sub failed] error: unknown model 'o3'; this codex offers: …` and the orchestrating session surfaces the available slugs instead of flailing into `codex exec`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** default flip → Task 3; description sentence → Task 4; header parse/precedence/trailer → Tasks 1–2; catalog resolution + fail-fast listing + hidden exclusion + verbatim fallback → Task 1; README copy → Task 5; versioning → Task 6; unit matrix from spec Section 4 → Tasks 1–3 tests; live acceptance → Task 6 Step 5. Spec's `codex debug models` line is amended to `models_cache.json` in Task 1 Step 6.
+- **Placeholders:** none — every step carries the code or the exact edit.
+- **Type consistency:** `split_model_header`, `load_catalog`, `resolve`, `UnknownModel`, `model_footer`, `codex_models_cache_path` are named identically in Task 1 (producer) and Task 2 (consumer); `run_sub`'s signature is untouched.

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -74,8 +74,13 @@ not the haiku relay — does the parsing.
   set is account- and version-specific (this machine: `gpt-5.6-sol`,
   `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`),
   so no hardcoded alias table can stay fresh. Instead, `tandem sub`
-  resolves the header value against `codex debug models` (local render of
-  the catalog JSON, ~140 ms, run only when a header is present):
+  resolves the header value against **`~/.codex/models_cache.json`** — the
+  same `models` array `codex debug models` renders, but read straight from
+  disk with no subprocess: codex maintains the file (refreshed on every
+  exec), the README already points users at it, and reading the wrapped
+  CLI's own files is tandem's established method (`docs/formats.md`).
+  `codex debug models` remains the human-facing debugging surface for the
+  same data. Resolution (run only when a header is present):
   - Normalize both sides: lowercase, strip non-alphanumerics.
   - Exact normalized match on a slug or display name wins.
   - Else a normalized-substring match (header inside candidate) that hits
@@ -87,9 +92,9 @@ not the haiku relay — does the parsing.
     `[tandem-sub failed]`, so the orchestrating session can retry with a
     valid slug or surface the choice to the user.
   - Hidden catalog entries (`visibility: "hide"`, e.g. `codex-auto-review`)
-    are excluded from matching and from the error listing. If
-    `codex debug models` itself fails, fall back to passing the header
-    value through as `-m` verbatim.
+    are excluded from matching and from the error listing. If the catalog
+    cannot be read (absent, unreadable, malformed JSON, no `models` array),
+    fall back to passing the header value through as `-m` verbatim.
   The description sentence tells the orchestrator to pass the model name
   as the user said it — translation is the CLI's job, not the model's.
 
@@ -108,10 +113,10 @@ untouched — so first-line-only parsing is safe.
 
 - Unit: config default-flip assertions; header parse (match, no-match,
   malformed name), precedence, and trailer cases alongside the existing
-  `sub` tests; catalog resolution against a fixtured `codex debug models`
+  `sub` tests; catalog resolution against a fixtured `models_cache.json`
   payload (exact slug, display-name, case/punctuation-insensitive,
   unique-substring, ambiguous → error listing, no-match → error listing,
-  hidden entries excluded, catalog-command failure → verbatim fallback);
+  hidden entries excluded, unreadable catalog → verbatim fallback);
   manual-mode hook tests already assert never-rewrites / never-warns and
   stay unchanged.
 - Live acceptance: re-run the phrase-lab bed ("ask gpt-5", "ask o3") with a

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -93,8 +93,9 @@ not the haiku relay — does the parsing.
     valid slug or surface the choice to the user.
   - Hidden catalog entries (`visibility: "hide"`, e.g. `codex-auto-review`)
     are excluded from matching and from the error listing. If the catalog
-    cannot be read (absent, unreadable, malformed JSON, no `models` array),
-    fall back to passing the header value through as `-m` verbatim.
+    cannot be read (absent, unreadable, malformed JSON, no `models` array,
+    or no usable entries in it), fall back to passing the header value
+    through as `-m` verbatim.
   The description sentence tells the orchestrator to pass the model name
   as the user said it — translation is the CLI's job, not the model's.
 

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -1,0 +1,95 @@
+# Manual routing by default + model pass-through — design
+
+2026-08-03. Ships as 0.1.8.
+
+## Why
+
+Live phrase testing (headless `claude -p`, opus orchestrator, plugin 0.1.7,
+`route = "manual"`, one run per phrase) showed that agent *selection* is not
+manual mode's weakness: all ten GPT-invoking phrasings — "ask GPT", "use
+codex", "ask ChatGPT", "OpenAI's model", "ask gpt-5", "ask o3", "second
+opinion from gpt", "what does GPT think", and a GPT+Claude mix-and-match —
+dispatched `tandem:gpt`, while the control ("use a subagent") correctly
+stayed native. The mix-and-match case is also the argument for the default
+flip: under `route = "all"` the hook rewrites the Claude-side dispatch to
+codex too, so "compare Claude and GPT" silently becomes "codex twice".
+
+What broke was everything after selection:
+
+- **Named models are dropped or mangled.** "ask gpt-5" ran the config
+  default silently. "ask o3" made the orchestrator write meta-instructions
+  into the brief ("Use tandem sub to have the o3 model review…" — passed
+  verbatim to codex as the task) and the haiku relay went off-script
+  (`tandem sub --help`, an invented `--model o3`). `tandem sub -m` exists;
+  the relay's fixed command form never exposes it, and nothing ever reports
+  which model actually ran.
+- On failure, relay and orchestrator flail (retries, `--help`, raw
+  `codex exec` fallback that bypasses sandbox-consent stamping).
+- Manual mode gives no "run `tandem` here" hint in unpaired directories.
+
+Scope decision: this change ships the default flip and the model
+pass-through only. Failure-path hardening, the unpaired-directory notice
+under manual, and a mode-switch command are explicitly deferred.
+
+## Section 1 — default flip
+
+`SubagentsConfig.route` default changes `"all"` → `"manual"` in
+`config.py`. The `all` code path is unchanged and stays documented; users
+who want auto-reroute set it explicitly. The missed-reroute notice keeps
+its `route == "all"` gate. `doctor` needs no change (its subagent checks
+already stay on under manual). Copy that claims auto-routing is the
+default is rewritten around the new story: root README `[subagents]` block
+and mode bullets, plugin README ("Routing is enabled by default", hook
+behavior section).
+
+## Section 2 — model pass-through
+
+The orchestrator can only reach the relay through prompt text, so the
+model name travels as a structured first line of the brief, and the CLI —
+not the haiku relay — does the parsing.
+
+- **Description** (`plugin/agents/gpt.md` frontmatter only) gains: "If the
+  user asked for a specific model, put `tandem-model: <name>` as the first
+  line of the task." Both relay bodies stay byte-for-byte identical to each
+  other; `codex-worker.md` does not solicit headers.
+- **Parsing** (`tandem sub`, quiet or not): if the brief's first line
+  full-matches `tandem-model: <name>` with `<name>` matching
+  `[A-Za-z0-9._/:-]{1,64}`, strip the line and use `<name>` as the codex
+  model. A first line that does not full-match stays in the brief
+  untouched — no guessing, no partial strips.
+- **Precedence**: explicit `-m` flag > header > `[subagents] model` config
+  > codex's own default. The flag wins because only a human at the CLI
+  types it. A recognized header line is stripped from the brief even when
+  the flag overrides it, and the trailer names the model that actually ran,
+  not the one the header asked for.
+- **Feedback**: quiet mode appends a `[tandem-sub model: <name>]` trailer
+  to stdout only when a header was present (blocked-write-trailer pattern;
+  the relay echoes it verbatim upstream). Non-quiet mode prints
+  `worker model: <name>` to stderr. The worker log always records the
+  resolved model, header or not.
+- **Unknown models**: passed through verbatim; codex's own error surfaces
+  via the existing nonzero-exit path. No alias table.
+
+## Section 3 — compatibility
+
+- New plugin + old tandem: the header reaches codex as brief text — a
+  mostly harmless meta line; behavior degrades to today's.
+- Old plugin + new tandem: no headers are ever emitted; nothing changes.
+- Under `route = "all"`, hook rewrites target `codex-worker` (whose
+  description doesn't solicit headers) and explicit `tandem:gpt` dispatches
+  pass the hook untouched, so when a header exists it is always the brief's
+  first line. First-line-only parsing is therefore safe; the hook's
+  agent-body prefixing never lands in front of a header.
+- Version: 0.1.8 in `pyproject.toml` and `plugin/.claude-plugin/plugin.json`
+  in lockstep (drift-guard test enforces).
+
+## Section 4 — testing
+
+- Unit: config default-flip assertions; header parse (match, no-match,
+  malformed name), precedence, and trailer cases alongside the existing
+  `sub` tests; manual-mode hook tests already assert never-rewrites /
+  never-warns and stay unchanged.
+- Live acceptance: re-run the phrase-lab bed ("ask gpt-5", "ask o3") with a
+  paired session and confirm the header is emitted by the orchestrator,
+  `-m` lands in the codex argv, and the trailer comes back — the two runs
+  that failed in the research become the acceptance test.

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -67,28 +67,53 @@ not the haiku relay — does the parsing.
   the relay echoes it verbatim upstream). Non-quiet mode prints
   `worker model: <name>` to stderr. The worker log always records the
   resolved model, header or not.
-- **Unknown models**: passed through verbatim; codex's own error surfaces
-  via the existing nonzero-exit path. No alias table.
+- **Resolution against the live catalog**: codex needs an exact slug —
+  probed live (codex-cli 0.145.0, ChatGPT account): `-m gpt-5` and `-m o3`
+  both 400 with "The '…' model is not supported when using Codex with a
+  ChatGPT account", no suggestions, after a full API round-trip. The valid
+  set is account- and version-specific (this machine: `gpt-5.6-sol`,
+  `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`),
+  so no hardcoded alias table can stay fresh. Instead, `tandem sub`
+  resolves the header value against `codex debug models` (local render of
+  the catalog JSON, ~140 ms, run only when a header is present):
+  - Normalize both sides: lowercase, strip non-alphanumerics.
+  - Exact normalized match on a slug or display name wins.
+  - Else a normalized-substring match (header inside candidate) that hits
+    exactly one visible model wins — "sol" → `gpt-5.6-sol`,
+    "5.4 mini" → `gpt-5.4-mini`.
+  - Else fail fast before invoking codex, nonzero, with an error that
+    lists the visible slugs: `unknown model 'o3'; this codex offers:
+    gpt-5.6-sol, gpt-5.6-terra, …`. The relay returns that verbatim as
+    `[tandem-sub failed]`, so the orchestrating session can retry with a
+    valid slug or surface the choice to the user.
+  - Hidden catalog entries (`visibility: "hide"`, e.g. `codex-auto-review`)
+    are excluded from matching and from the error listing. If
+    `codex debug models` itself fails, fall back to passing the header
+    value through as `-m` verbatim.
+  The description sentence tells the orchestrator to pass the model name
+  as the user said it — translation is the CLI's job, not the model's.
 
-## Section 3 — compatibility
+## Section 3 — versioning
 
-- New plugin + old tandem: the header reaches codex as brief text — a
-  mostly harmless meta line; behavior degrades to today's.
-- Old plugin + new tandem: no headers are ever emitted; nothing changes.
-- Under `route = "all"`, hook rewrites target `codex-worker` (whose
-  description doesn't solicit headers) and explicit `tandem:gpt` dispatches
-  pass the hook untouched, so when a header exists it is always the brief's
-  first line. First-line-only parsing is therefore safe; the hook's
-  agent-body prefixing never lands in front of a header.
-- Version: 0.1.8 in `pyproject.toml` and `plugin/.claude-plugin/plugin.json`
-  in lockstep (drift-guard test enforces).
+Cross-version compatibility is explicitly out of scope for now (operator
+call, 2026-08-03): plugin and CLI are assumed to update together. Version
+goes to 0.1.8 in `pyproject.toml` and `plugin/.claude-plugin/plugin.json`
+in lockstep (drift-guard test enforces). One structural note stands
+because it justifies the parser: when a header exists it is always the
+brief's first line — hook rewrites target `codex-worker`, which never
+solicits headers, and explicit `tandem:gpt` dispatches pass the hook
+untouched — so first-line-only parsing is safe.
 
 ## Section 4 — testing
 
 - Unit: config default-flip assertions; header parse (match, no-match,
   malformed name), precedence, and trailer cases alongside the existing
-  `sub` tests; manual-mode hook tests already assert never-rewrites /
-  never-warns and stay unchanged.
+  `sub` tests; catalog resolution against a fixtured `codex debug models`
+  payload (exact slug, display-name, case/punctuation-insensitive,
+  unique-substring, ambiguous → error listing, no-match → error listing,
+  hidden entries excluded, catalog-command failure → verbatim fallback);
+  manual-mode hook tests already assert never-rewrites / never-warns and
+  stay unchanged.
 - Live acceptance: re-run the phrase-lab bed ("ask gpt-5", "ask o3") with a
   paired session and confirm the header is emitted by the orchestrator,
   `-m` lands in the codex argv, and the trailer comes back — the two runs

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -50,13 +50,29 @@ not the haiku relay — does the parsing.
 
 - **Description** (`plugin/agents/gpt.md` frontmatter only) gains: "If the
   user asked for a specific model, put `tandem-model: <name>` as the first
-  line of the task." Both relay bodies stay byte-for-byte identical to each
-  other; `codex-worker.md` does not solicit headers.
-- **Parsing** (`tandem sub`, quiet or not): if the brief's first line
-  full-matches `tandem-model: <name>` with `<name>` matching
-  `[A-Za-z0-9._/:-]{1,64}`, strip the line and use `<name>` as the codex
-  model. A first line that does not full-match stays in the brief
-  untouched — no guessing, no partial strips.
+  line of the task" — scoped to a *named* model, never a bare "ask gpt",
+  which has no name to translate and would only invent an unresolvable one.
+  Both relay bodies stay byte-for-byte identical to each other;
+  `codex-worker.md` does not solicit headers.
+- **Parsing** (`tandem sub`, quiet or not): the brief's first line is
+  right-stripped (a trailing space, tab, or a CRLF's `\r` must not
+  disqualify it), then matched case-insensitively against
+  `tandem-model:` + optional spaces/tabs + `<name>`, where `<name>` is
+  1–64 chars of `[A-Za-z0-9._/ :-]` that neither starts nor ends with a
+  space. Internal spaces are legal because users *speak* model names
+  ("5.4 mini"); resolution normalizes them away. On a match the line is
+  stripped from the brief and `<name>` is the requested model.
+  - A first line that does not open with the prefix is ordinary task text,
+    returned untouched — no guessing, no partial strips.
+  - A first line that *does* open with the prefix but does not match is a
+    hard failure: `error: malformed tandem-model header: <line>` on
+    stderr, exit 1, before any catalog read or session lookup. Silently
+    passing a near-miss through is the exact bug this section exists to
+    kill — the worker would run the config default while the stray line
+    shipped to codex as task text, with nothing said to anyone. The cost
+    is that a brief whose first line genuinely opens with the literal
+    `tandem-model:` (prose about the protocol) is rejected; that is the
+    accepted trade, and it fails loudly enough to reword.
 - **Precedence**: explicit `-m` flag > header > `[subagents] model` config
   > codex's own default. The flag wins because only a human at the CLI
   types it. A recognized header line is stripped from the brief even when

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": {"name": "tandem"}
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -79,8 +79,9 @@ this directory, or codex missing/unsupported — it prints a one-time
 `systemMessage` naming the cause (once per Claude session) and the dispatch
 runs natively.
 
-Configuration lives in `~/.tandem/config.toml` under `[subagents]`, and out
-of the box it needs none: dispatches reach codex when you ask for the
+Configuration lives in `~/.tandem/config.toml` under `[subagents]`, and
+routing needs no config: dispatches reach codex when you ask for the
 `tandem:gpt` agent, and `route = "all"` is the opt-in that reroutes every
-dispatch automatically. See the repo [README](../README.md) for the keys
-and the sandbox/consent story.
+dispatch automatically. See the repo [README](../README.md) for the keys —
+`model` first, since an unset one puts every worker on your codex account's
+default — and the sandbox/consent story.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -40,11 +40,14 @@ open a fresh session.
   the orchestrating model not to select it by hand.
 - **`agents/gpt.md`** — the same relay, with a user-facing description
   ("Runs the task on a GPT model via tandem's codex pairing"). This is the
-  agent to select when you ask for GPT subagents by name — and with
-  `[subagents] route = "manual"`, selecting it is how anything reaches codex
-  at all, since nothing is rerouted for you. The body is identical to
-  `codex-worker.md`; only the description differs, so both agents behave
-  the same once dispatched.
+  agent to select when you ask for GPT subagents by name, and under the
+  `route = "manual"` default it is the normal path to codex — nothing is
+  rerouted for you. A brief whose first line is `tandem-model: <name>`
+  picks the worker's model: the description asks the orchestrating model to
+  emit that line (one space-free token) whenever you name a model, and
+  `tandem sub` resolves the name against codex's own catalog. The body is
+  identical to `codex-worker.md`; only the description differs, so both
+  agents behave the same once dispatched.
 
 Both relay names are in the hook's loop guard, matched on the last segment
 of the agent name in any scope — a dispatch that already names a relay
@@ -62,18 +65,22 @@ session, it:
   relay's `tandem sub` reads it. Stamped whatever the route setting is: a
   hand-picked `tandem:gpt` dispatch consents through your permission mode
   just the same;
-- with `route = "all"` (the default) and a supported codex, rewrites the
-  dispatch to `tandem:codex-worker` on `haiku`, prefixing the dispatched
-  agent's own definition — when it is a file-defined one, from
-  `.claude/agents/` here or under `~/.claude/` — to the brief, so the codex
-  worker gets the same instructions the native agent would have;
-- with `route = "manual"` or `"off"`, rewrites nothing; explicitly selected
-  relay agents still reach codex.
+- with `route = "all"` (opt-in; the default is `"manual"`) and a supported
+  codex, rewrites the dispatch to `tandem:codex-worker` on `haiku`,
+  prefixing the dispatched agent's own definition — when it is a
+  file-defined one, from `.claude/agents/` here or under `~/.claude/` — to
+  the brief, so the codex worker gets the same instructions the native
+  agent would have;
+- with `route = "manual"` (the default) or `"off"`, rewrites nothing;
+  explicitly selected relay agents still reach codex.
 
 When `route = "all"` but nothing can be rerouted — no paired session for
 this directory, or codex missing/unsupported — it prints a one-time
 `systemMessage` naming the cause (once per Claude session) and the dispatch
 runs natively.
 
-Configuration lives in `~/.tandem/config.toml` under `[subagents]` — see
-the repo [README](../README.md) for the keys and the sandbox/consent story.
+Configuration lives in `~/.tandem/config.toml` under `[subagents]`, and out
+of the box it needs none: dispatches reach codex when you ask for the
+`tandem:gpt` agent, and `route = "all"` is the opt-in that reroutes every
+dispatch automatically. See the repo [README](../README.md) for the keys
+and the sandbox/consent story.

--- a/plugin/agents/gpt.md
+++ b/plugin/agents/gpt.md
@@ -1,6 +1,6 @@
 ---
 name: gpt
-description: "Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex. If the user asked for a specific model, make the first line of the task read tandem-model: NAME and put nothing else on that line, where NAME is the model name the user said written as one hyphenated token with no spaces; tandem translates it to an exact codex model."
+description: "Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex. Only when the user named a specific model — never for a bare 'gpt' or 'codex' — make the first line of the task read tandem-model: NAME and put nothing else on that line, where NAME is the model name the user said written as one hyphenated token with no spaces; tandem translates it to an exact codex model. With no model named there is nothing to translate, so send the task with no such line and tandem picks the configured default; a guessed NAME fails the dispatch."
 model: haiku
 tools: Bash(tandem sub:*)
 ---

--- a/plugin/agents/gpt.md
+++ b/plugin/agents/gpt.md
@@ -1,6 +1,6 @@
 ---
 name: gpt
-description: Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex.
+description: Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex. If the user asked for a specific model, put `tandem-model: <name as the user said it>` alone on the first line of the task; tandem translates it to an exact codex model.
 model: haiku
 tools: Bash(tandem sub:*)
 ---

--- a/plugin/agents/gpt.md
+++ b/plugin/agents/gpt.md
@@ -1,6 +1,6 @@
 ---
 name: gpt
-description: Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex. If the user asked for a specific model, put `tandem-model: <name as the user said it>` alone on the first line of the task; tandem translates it to an exact codex model.
+description: "Runs the task on a GPT model via tandem's codex pairing. Select this when the user asks for GPT subagents or to run something on GPT/codex. If the user asked for a specific model, make the first line of the task read tandem-model: NAME and put nothing else on that line, where NAME is the model name the user said written as one hyphenated token with no spaces; tandem translates it to an exact codex model."
 model: haiku
 tools: Bash(tandem sub:*)
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.7"
+version = "0.1.8"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -330,22 +330,38 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
         sandbox: str | None, task: str | None) -> None:
     """Run one delegated subagent task on codex (task argument or stdin).
 
-    Used by the tandem plugin's codex-worker bridge; also works manually."""
-    from . import ops
+    Used by the tandem plugin's codex-worker bridge; also works manually.
+    A brief whose first line is `tandem-model: <name>` picks the codex
+    model for this worker: the name is resolved against codex's own model
+    catalog (~/.codex/models_cache.json), and an unresolvable name fails
+    here, before codex is invoked, with the valid slugs listed."""
+    from . import modelcat, ops
     from .config import load_subagents_config
 
     if task is None or task == "-":
         task = sys.stdin.read()
     task = task.strip()
+    requested, task = modelcat.split_model_header(task)
+    task = task.strip()
     if not task:
         click.secho("error: empty task brief.", fg="red", err=True)
         sys.exit(1)
+    resolved = ""
+    if requested:
+        try:
+            resolved = modelcat.resolve(requested, modelcat.load_catalog())
+        except modelcat.UnknownModel as e:
+            click.secho(f"error: {e}", fg="red", err=True)
+            sys.exit(1)
     cfg = load_subagents_config()
+    worker_model = model if model is not None else (resolved or cfg.model)
+    if requested and not quiet:
+        click.secho(f"worker model: {worker_model}", err=True)
     with StateStore() as store:
         session = _require_session(store)
         code = ops.run_sub(
             store, session, task,
-            model=model if model is not None else cfg.model,
+            model=worker_model,
             context=context_mode or ("full" if cfg.context == "full" else "task"),
             fanout_feature=cfg.fanout_feature,
             keep_forks=cfg.keep_forks,
@@ -353,6 +369,9 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
             sandbox=sandbox if sandbox is not None
                     else _read_sandbox_stamp(session.tandem_id),
         )
+    if requested and quiet:
+        sys.stdout.write("\n" + modelcat.model_footer(worker_model) + "\n")
+        sys.stdout.flush()
     sys.exit(code)
 
 

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -333,15 +333,19 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
     Used by the tandem plugin's codex-worker bridge; also works manually.
     A brief whose first line is `tandem-model: <name>` picks the codex
     model for this worker: the name is resolved against codex's own model
-    catalog (~/.codex/models_cache.json), and an unresolvable name fails
-    here, before codex is invoked, with the valid slugs listed."""
+    catalog (~/.codex/models_cache.json), and a malformed or unresolvable
+    name fails here, before codex is invoked, with the valid slugs listed."""
     from . import modelcat, ops
     from .config import load_subagents_config
 
     if task is None or task == "-":
         task = sys.stdin.read()
     task = task.strip()
-    requested, task = modelcat.split_model_header(task)
+    try:
+        requested, task = modelcat.split_model_header(task)
+    except modelcat.MalformedHeader as e:
+        click.secho(f"error: {e}", fg="red", err=True)
+        sys.exit(1)
     task = task.strip()
     if not task:
         click.secho("error: empty task brief.", fg="red", err=True)

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -14,19 +14,20 @@ from . import paths
 
 @dataclass(frozen=True)
 class SubagentsConfig:
-    route: str = "all"          # "all" | "manual" | "off"
+    route: str = "manual"       # "manual" | "all" | "off"
     model: str = ""             # "" -> omit -m; codex's configured default
     context: str = "match"      # "match" | "task" | "full"
     fanout_feature: str = ""    # --enable <name>; "" -> flag not passed
     keep_forks: bool = False
 
 
-# "manual": no auto-reroute and no missed-reroute notice — dispatch to codex
-# only when the model/user explicitly picks a bridge agent (`tandem:gpt`,
-# `tandem:codex-worker`). The hook treats it exactly like "off"; the rest of
-# tandem does not — `doctor._subagent_checks` silences its subagent billing
-# warnings only under "off", because a manual user still dispatches to codex
-# and still wants to know the worker model is unset.
+# "manual" — the default: no auto-reroute and no missed-reroute notice —
+# dispatch to codex only when the model/user explicitly picks a bridge agent
+# (`tandem:gpt`, `tandem:codex-worker`). The hook treats it exactly like
+# "off"; the rest of tandem does not — `doctor._subagent_checks` silences
+# its subagent billing warnings only under "off", because a manual user
+# still dispatches to codex and still wants to know the worker model is
+# unset. "all" opts back in to rerouting every native dispatch.
 _ROUTES = ("all", "manual", "off")
 _CONTEXTS = ("match", "task", "full")
 

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -234,9 +234,11 @@ def run_doctor(store, session, live: bool = False) -> DoctorReport:
 
 
 def _subagent_checks(report: DoctorReport, session) -> None:
-    """Subagent routing hygiene: routing is on by default but the model is
-    not chosen for you, billing follows codex auth, and codex workers only
-    see CLAUDE.md content inside the tandem:shared block."""
+    """Subagent hygiene for everyone who has not turned routing off. Under
+    the manual default nothing reaches codex unless the user picks a bridge
+    agent, but every dispatch they do make still runs on a model nobody
+    chose for them, still bills whatever codex is authed as, and still sees
+    only the CLAUDE.md content inside the tandem:shared block."""
     from . import paths
     from .config import load_subagents_config
 
@@ -244,10 +246,12 @@ def _subagent_checks(report: DoctorReport, session) -> None:
     if cfg.route == "off":
         return
     # model="" means no `-m`, i.e. the codex account default — the frontier
-    # tier on every plan seen so far. Combined with the route="all" default
-    # that silently sends every dispatch to the most expensive model, so it
-    # is a warning, not a note. The dataclass default stays empty on
-    # purpose: a baked-in id would 400 on accounts that lack it.
+    # tier on every plan seen so far. Picking `tandem:gpt` is a choice about
+    # which harness runs the task, never a choice to pay top tier for it, so
+    # a manual user with [subagents] model unset is billed the most
+    # expensive option on every worker without having asked for it: a
+    # warning, not a note. The dataclass default stays empty on purpose: a
+    # baked-in id would 400 on accounts that lack it.
     if not cfg.model:
         report.warn(
             "subagents: no model configured — workers will use your codex "

--- a/src/tandem/modelcat.py
+++ b/src/tandem/modelcat.py
@@ -42,7 +42,11 @@ def split_model_header(task: str) -> tuple[str, str]:
 def load_catalog() -> list[dict] | None:
     """The catalog's models array, or None when it cannot be read — the
     caller then passes the requested name through verbatim rather than
-    refusing to dispatch over bookkeeping."""
+    refusing to dispatch over bookkeeping.
+
+    A catalog with no usable entries is None, not []: an empty list is a
+    catalog that answers "no such model" to everything, which would refuse
+    every dispatch with an error listing nothing."""
     try:
         data = json.loads(paths.codex_models_cache_path().read_text())
     except (OSError, ValueError):
@@ -50,7 +54,7 @@ def load_catalog() -> list[dict] | None:
     models = data.get("models") if isinstance(data, dict) else None
     if not isinstance(models, list):
         return None
-    return [m for m in models if isinstance(m, dict)]
+    return [m for m in models if isinstance(m, dict)] or None
 
 
 def _norm(s: str) -> str:

--- a/src/tandem/modelcat.py
+++ b/src/tandem/modelcat.py
@@ -21,21 +21,40 @@ from . import paths
 # description tells the orchestrator to emit this exact line shape, and
 # dispatching models match on the footer. Change either and instructions rot.
 HEADER_PREFIX = "tandem-model:"
-_HEADER_RE = re.compile(r"^tandem-model:[ \t]*([A-Za-z0-9._/:-]{1,64})$")
+# NAME may carry internal spaces ("5.4 mini") because models get spoken, not
+# typed; resolve() normalizes punctuation and spaces away. It may not start or
+# end with one, and the line's trailing whitespace is stripped before matching
+# — a stray space or a CRLF must not turn a header into task text.
+_NAME = r"[A-Za-z0-9._/:-](?:[A-Za-z0-9._/ :-]{0,62}[A-Za-z0-9._/:-])?"
+_HEADER_RE = re.compile(
+    rf"^{re.escape(HEADER_PREFIX)}[ \t]*({_NAME})$", re.IGNORECASE)
 
 
 class UnknownModel(ValueError):
     """The requested name matched nothing (or too much) in the catalog."""
 
 
+class MalformedHeader(ValueError):
+    """The first line announced a header but the name is unusable."""
+
+
 def split_model_header(task: str) -> tuple[str, str]:
-    """(requested model, task without the header line). A first line that
-    does not full-match the grammar stays in the brief untouched — no
-    guessing, no partial strips."""
+    """(requested model, task without the header line).
+
+    A first line that does not open with `tandem-model:` is ordinary task
+    text and is returned untouched. One that does open with it must parse:
+    a near-miss (decorated name, empty name, an over-long one, prose) raises
+    MalformedHeader rather than silently falling through, because the
+    fall-through is the exact failure this protocol exists to prevent — the
+    worker would run on the config default and the header line would ship to
+    codex as part of the brief, with nothing said to anyone."""
     first, sep, rest = task.partition("\n")
+    first = first.rstrip()
+    if not first.lower().startswith(HEADER_PREFIX):
+        return "", task
     m = _HEADER_RE.match(first)
     if not m:
-        return "", task
+        raise MalformedHeader(f"malformed tandem-model header: {first}")
     return m.group(1), rest if sep else ""
 
 

--- a/src/tandem/modelcat.py
+++ b/src/tandem/modelcat.py
@@ -1,0 +1,88 @@
+"""The tandem-model brief header: how a dispatching session asks for a
+specific codex model.
+
+The orchestrating model can only reach the relay through prompt text, so
+the request travels as the brief's first line (`tandem-model: <name>`); the
+relay forwards it byte-for-byte and `tandem sub` — this module — does the
+parsing and the translation. Translation resolves the user's words against
+codex's own on-disk catalog because codex needs an exact slug: a wrong one
+costs a full API round-trip and 400s with no suggestions (observed live,
+codex-cli 0.145.0 on a ChatGPT account, 2026-08-03), and the valid set is
+account- and version-specific, so no hardcoded table can stay fresh."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from . import paths
+
+# Public protocol, like ops.BLOCKED_HEADER: the plugin's gpt agent
+# description tells the orchestrator to emit this exact line shape, and
+# dispatching models match on the footer. Change either and instructions rot.
+HEADER_PREFIX = "tandem-model:"
+_HEADER_RE = re.compile(r"^tandem-model:[ \t]*([A-Za-z0-9._/:-]{1,64})$")
+
+
+class UnknownModel(ValueError):
+    """The requested name matched nothing (or too much) in the catalog."""
+
+
+def split_model_header(task: str) -> tuple[str, str]:
+    """(requested model, task without the header line). A first line that
+    does not full-match the grammar stays in the brief untouched — no
+    guessing, no partial strips."""
+    first, sep, rest = task.partition("\n")
+    m = _HEADER_RE.match(first)
+    if not m:
+        return "", task
+    return m.group(1), rest if sep else ""
+
+
+def load_catalog() -> list[dict] | None:
+    """The catalog's models array, or None when it cannot be read — the
+    caller then passes the requested name through verbatim rather than
+    refusing to dispatch over bookkeeping."""
+    try:
+        data = json.loads(paths.codex_models_cache_path().read_text())
+    except (OSError, ValueError):
+        return None
+    models = data.get("models") if isinstance(data, dict) else None
+    if not isinstance(models, list):
+        return None
+    return [m for m in models if isinstance(m, dict)]
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def resolve(name: str, models: list[dict] | None) -> str:
+    """The exact slug for a user-worded model name.
+
+    Exact normalized match on slug or display name wins; else a normalized
+    substring match that hits exactly one visible model; else UnknownModel
+    listing the visible slugs — raised before codex is invoked, so the
+    round-trip that would 400 is never spent."""
+    if models is None:
+        return name
+    visible = [m for m in models
+               if m.get("visibility") != "hide"
+               and isinstance(m.get("slug"), str)]
+    n = _norm(name)
+    for m in visible:
+        if n and (n == _norm(m["slug"])
+                  or n == _norm(str(m.get("display_name") or ""))):
+            return m["slug"]
+    hits = {m["slug"] for m in visible
+            if n and (n in _norm(m["slug"])
+                      or n in _norm(str(m.get("display_name") or "")))}
+    if len(hits) == 1:
+        return next(iter(hits))
+    raise UnknownModel(
+        f"unknown model {name!r}; this codex offers: "
+        + ", ".join(m["slug"] for m in visible))
+
+
+def model_footer(slug: str) -> str:
+    return f"[tandem-sub model: {slug}]"

--- a/src/tandem/paths.py
+++ b/src/tandem/paths.py
@@ -64,6 +64,13 @@ def codex_sessions_dir() -> Path:
     return codex_home() / "sessions"
 
 
+def codex_models_cache_path() -> Path:
+    """Codex's on-disk model catalog (observed: codex-cli 0.145.0 writes
+    {fetched_at, etag, client_version, models:[{slug, display_name,
+    visibility, …}]} and refreshes it on every exec)."""
+    return codex_home() / "models_cache.json"
+
+
 _ROLLOUT_RE = re.compile(
     r"rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-([0-9a-f-]{36})\.jsonl$"
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ def test_defaults_when_file_missing(tmp_path, monkeypatch):
     monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
     cfg = load_subagents_config()
     assert cfg == SubagentsConfig()
-    assert (cfg.route, cfg.model, cfg.context) == ("all", "", "match")
+    assert (cfg.route, cfg.model, cfg.context) == ("manual", "", "match")
     assert (cfg.fanout_feature, cfg.keep_forks) == ("", False)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,12 +27,20 @@ def test_reads_values(tmp_path, monkeypatch):
     assert cfg.keep_forks is True
 
 
-def test_route_manual_is_accepted(tmp_path, monkeypatch):
-    # unlisted values degrade to "all", so a supported name has to be listed
+def test_routes_are_accepted_not_just_defaulted(tmp_path, monkeypatch):
+    # Unlisted values degrade to the default, which is now "manual" — so
+    # `route = "manual"` alone proves nothing: it passes even if "manual"
+    # were dropped from _ROUTES. Pin the listing itself, and read back a
+    # non-default name that only survives by being listed.
+    from tandem import config
+
+    assert set(config._ROUTES) == {"all", "manual", "off"}
     home = tmp_path / ".tandem"
     home.mkdir()
-    (home / "config.toml").write_text('[subagents]\nroute = "manual"\n')
     monkeypatch.setenv("TANDEM_HOME", str(home))
+    (home / "config.toml").write_text('[subagents]\nroute = "all"\n')
+    assert load_subagents_config().route == "all"
+    (home / "config.toml").write_text('[subagents]\nroute = "manual"\n')
     assert load_subagents_config().route == "manual"
 
 

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -29,7 +29,7 @@ def _payload(subagent_type="Explore", prompt="find the tests", **extra):
             "cwd": "/tmp/x", "tool_input": ti}
 
 
-CFG = SubagentsConfig()
+CFG = SubagentsConfig(route="all")
 
 
 def _route(payload, cfg=CFG, has_session=True, codex_ok=True,
@@ -51,6 +51,16 @@ def _run_hook(payload):
     from tandem import cli
     return click.testing.CliRunner().invoke(
         cli.main, ["hook-route"], input=json.dumps(payload))
+
+
+def _route_all():
+    """Opt the current TANDEM_HOME into all-mode. The CLI tests below
+    exercise rerouting and the missed-reroute notice, both of which are
+    all-mode behavior; the shipped default is manual, and the hook reads its
+    config off disk, so there is no cfg object to pass in."""
+    home = paths.tandem_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.toml").write_text('[subagents]\nroute = "all"\n')
 
 
 class TestRewrite:
@@ -177,6 +187,10 @@ class TestManualRoute:
         assert _route(_payload(),
                       cfg=SubagentsConfig(route="manual")) is None
 
+    def test_default_config_never_rewrites(self):
+        # the shipped default IS manual now — no cfg file, no rewrite
+        assert _route(_payload(), cfg=SubagentsConfig()) is None
+
     def test_manual_never_warns(self):
         # like "off": an explicit user choice, so silence is the requested
         # behavior even when nothing could reroute anyway
@@ -223,6 +237,7 @@ class TestCli:
         import click.testing
         from tandem import cli
         env = env_factory(active="claude")
+        _route_all()
         payload = _payload()
         payload["cwd"] = env.cwd
         r = click.testing.CliRunner().invoke(
@@ -261,6 +276,7 @@ class TestCliNotice:
 
     def _unpaired(self, tmp_path, monkeypatch, session_id="s-1"):
         monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+        _route_all()
         payload = _payload()
         payload["cwd"] = str(tmp_path)      # no paired session here
         if session_id is not None:
@@ -303,6 +319,7 @@ class TestCliNotice:
             self, env_factory, monkeypatch):
         from tandem.harness.codex import CodexAdapter
         env = env_factory(active="claude")
+        _route_all()
         monkeypatch.setattr(CodexAdapter, "detect_version", lambda self: None)
         payload = _payload()
         payload["cwd"] = env.cwd
@@ -338,6 +355,7 @@ class TestCliNotice:
         it), exit 0, and write nothing inside or outside TANDEM_HOME."""
         home = tmp_path / "home"            # `warned/../../x` escapes to here
         monkeypatch.setenv("TANDEM_HOME", str(home / ".tandem"))
+        _route_all()
         payload = _payload()
         payload["cwd"] = str(tmp_path)      # no paired session here
         payload["session_id"] = bad_id
@@ -395,6 +413,7 @@ class TestSandboxForMode:
 
 class TestSandboxStamp:
     def _hook(self, env, mode):
+        _route_all()                # the stamp rides along with a reroute
         payload = _payload()
         payload["cwd"] = env.cwd
         payload["session_id"] = "s-1"

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -27,21 +27,81 @@ class TestSplitModelHeader:
         task = "review x\ntandem-model: gpt-5.6-sol"
         assert modelcat.split_model_header(task) == ("", task)
 
-    def test_malformed_name_left_in_place(self):
-        # trailing prose after the name is not a header
-        task = "tandem-model: gpt-5.6-sol please\nreview x"
-        assert modelcat.split_model_header(task) == ("", task)
-
-    def test_overlong_name_left_in_place(self):
-        task = f"tandem-model: {'x' * 65}\nreview x"
-        assert modelcat.split_model_header(task) == ("", task)
-
     def test_header_only_brief_yields_empty_task(self):
         assert modelcat.split_model_header("tandem-model: gpt-5.6-sol") == \
             ("gpt-5.6-sol", "")
 
     def test_no_space_after_colon_still_parses(self):
         assert modelcat.split_model_header("tandem-model:sol\nt") == ("sol", "t")
+
+    # --- near-misses that used to fall through as "no header" (live-probed) ---
+
+    def test_trailing_space_still_parses(self):
+        assert modelcat.split_model_header("tandem-model: gpt-5.6-sol  \nreview x") \
+            == ("gpt-5.6-sol", "review x")
+
+    def test_trailing_tab_still_parses(self):
+        assert modelcat.split_model_header("tandem-model: gpt-5.6-sol\t\nreview x") \
+            == ("gpt-5.6-sol", "review x")
+
+    def test_crlf_line_ending_still_parses(self):
+        assert modelcat.split_model_header("tandem-model: gpt-5.6-sol\r\nreview x") \
+            == ("gpt-5.6-sol", "review x")
+
+    def test_mixed_case_prefix_still_parses(self):
+        assert modelcat.split_model_header("Tandem-Model: gpt-5.6-sol\nreview x") \
+            == ("gpt-5.6-sol", "review x")
+        assert modelcat.split_model_header("TANDEM-MODEL:gpt-5.6-sol\nreview x") \
+            == ("gpt-5.6-sol", "review x")
+
+    def test_spoken_multi_word_name_parses_and_resolves(self):
+        # internal spaces are legal; resolve() normalizes them away
+        name, rest = modelcat.split_model_header("tandem-model: 5.4 mini\nreview x")
+        assert (name, rest) == ("5.4 mini", "review x")
+        assert modelcat.resolve(name, CATALOG) == "gpt-5.4-mini"
+
+    def test_prose_after_the_name_parses_and_fails_loudly_at_resolve(self):
+        # with internal spaces legal this is one (unresolvable) name — the
+        # failure is loud at resolve() instead of a silent pass-through
+        name, rest = modelcat.split_model_header(
+            "tandem-model: gpt-5.6-sol please\nreview x")
+        assert (name, rest) == ("gpt-5.6-sol please", "review x")
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve(name, CATALOG)
+
+    # --- near-misses that are LOUD errors, never silent pass-through ---
+
+    def test_decorated_name_is_malformed(self):
+        with pytest.raises(modelcat.MalformedHeader) as e:
+            modelcat.split_model_header("tandem-model: <gpt-5.4-mini>\nreview x")
+        assert str(e.value) == \
+            "malformed tandem-model header: tandem-model: <gpt-5.4-mini>"
+
+    def test_overlong_name_is_malformed(self):
+        with pytest.raises(modelcat.MalformedHeader):
+            modelcat.split_model_header(f"tandem-model: {'x' * 65}\nreview x")
+
+    def test_empty_name_is_malformed(self):
+        with pytest.raises(modelcat.MalformedHeader):
+            modelcat.split_model_header("tandem-model:\nreview x")
+        with pytest.raises(modelcat.MalformedHeader):
+            modelcat.split_model_header("tandem-model:   \nreview x")
+
+    def test_prose_that_opens_with_the_prefix_is_a_loud_error_by_design(self):
+        # A brief whose first line talks *about* the protocol is rare; a brief
+        # whose first line is a near-miss header is not. Pinned decision: any
+        # first line starting with the prefix must resolve or fail loudly, so
+        # this errors rather than shipping the line to codex as task text.
+        with pytest.raises(modelcat.MalformedHeader):
+            modelcat.split_model_header(
+                "tandem-model: is a protocol, not a topic\nexplain it")
+
+    def test_malformed_header_is_a_value_error(self):
+        assert issubclass(modelcat.MalformedHeader, ValueError)
+
+    def test_line_not_starting_with_the_prefix_is_untouched_task_text(self):
+        task = "the tandem-model: header is documented below\nmore"
+        assert modelcat.split_model_header(task) == ("", task)
 
 
 class TestResolve:

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -1,0 +1,102 @@
+"""tandem-model header parsing and catalog resolution."""
+
+import json
+
+import pytest
+
+from tandem import modelcat, paths
+
+CATALOG = [
+    {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
+    {"slug": "gpt-5.6-terra", "display_name": "GPT-5.6-Terra", "visibility": "list"},
+    {"slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini", "visibility": "list"},
+    {"slug": "codex-auto-review", "display_name": "Codex Auto Review",
+     "visibility": "hide"},
+]
+
+
+class TestSplitModelHeader:
+    def test_header_is_stripped_and_returned(self):
+        got = modelcat.split_model_header("tandem-model: gpt-5.6-sol\nreview x")
+        assert got == ("gpt-5.6-sol", "review x")
+
+    def test_no_header_passes_through(self):
+        assert modelcat.split_model_header("review x\nline 2") == ("", "review x\nline 2")
+
+    def test_header_requires_first_line(self):
+        task = "review x\ntandem-model: gpt-5.6-sol"
+        assert modelcat.split_model_header(task) == ("", task)
+
+    def test_malformed_name_left_in_place(self):
+        # trailing prose after the name is not a header
+        task = "tandem-model: gpt-5.6-sol please\nreview x"
+        assert modelcat.split_model_header(task) == ("", task)
+
+    def test_overlong_name_left_in_place(self):
+        task = f"tandem-model: {'x' * 65}\nreview x"
+        assert modelcat.split_model_header(task) == ("", task)
+
+    def test_header_only_brief_yields_empty_task(self):
+        assert modelcat.split_model_header("tandem-model: gpt-5.6-sol") == \
+            ("gpt-5.6-sol", "")
+
+    def test_no_space_after_colon_still_parses(self):
+        assert modelcat.split_model_header("tandem-model:sol\nt") == ("sol", "t")
+
+
+class TestResolve:
+    def test_exact_slug(self):
+        assert modelcat.resolve("gpt-5.6-sol", CATALOG) == "gpt-5.6-sol"
+
+    def test_display_name_case_and_punctuation_insensitive(self):
+        assert modelcat.resolve("GPT 5.6 Sol", CATALOG) == "gpt-5.6-sol"
+
+    def test_unique_substring(self):
+        assert modelcat.resolve("sol", CATALOG) == "gpt-5.6-sol"
+        assert modelcat.resolve("5.4 mini", CATALOG) == "gpt-5.4-mini"
+
+    def test_ambiguous_lists_visible_slugs(self):
+        with pytest.raises(modelcat.UnknownModel) as e:
+            modelcat.resolve("gpt", CATALOG)
+        msg = str(e.value)
+        assert "unknown model 'gpt'" in msg
+        assert "gpt-5.6-sol" in msg and "gpt-5.4-mini" in msg
+        assert "codex-auto-review" not in msg
+
+    def test_no_match_lists_visible_slugs(self):
+        with pytest.raises(modelcat.UnknownModel) as e:
+            modelcat.resolve("o3", CATALOG)
+        assert "unknown model 'o3'; this codex offers: gpt-5.6-sol" in str(e.value)
+
+    def test_hidden_models_never_match(self):
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("auto review", CATALOG)
+
+    def test_none_catalog_passes_name_through(self):
+        assert modelcat.resolve("anything-goes", None) == "anything-goes"
+
+
+class TestLoadCatalog:
+    def test_reads_models_array(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text(
+            json.dumps({"fetched_at": "t", "models": CATALOG}))
+        assert modelcat.load_catalog() == CATALOG
+
+    def test_missing_file_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        assert modelcat.load_catalog() is None
+
+    def test_broken_json_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text("{nope")
+        assert modelcat.load_catalog() is None
+
+    def test_models_not_a_list_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text(json.dumps({"models": 7}))
+        assert modelcat.load_catalog() is None
+
+
+def test_model_footer_exact_text():
+    assert modelcat.model_footer("gpt-5.6-sol") == "[tandem-sub model: gpt-5.6-sol]"

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -97,6 +97,18 @@ class TestLoadCatalog:
         (tmp_path / "models_cache.json").write_text(json.dumps({"models": 7}))
         assert modelcat.load_catalog() is None
 
+    def test_empty_models_array_is_none(self, tmp_path, monkeypatch):
+        # an empty catalog is as unusable as a missing one: [] would make
+        # every dispatch fail with "this codex offers: " and nothing after it
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text(json.dumps({"models": []}))
+        assert modelcat.load_catalog() is None
+
+    def test_models_without_objects_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "models_cache.json").write_text(json.dumps({"models": ["junk"]}))
+        assert modelcat.load_catalog() is None
+
 
 def test_model_footer_exact_text():
     assert modelcat.model_footer("gpt-5.6-sol") == "[tandem-sub model: gpt-5.6-sol]"

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from tandem import ops, paths, runner
+from tandem import modelcat, ops, paths, runner
 from tandem.runner import await_codex_rollout
 from tandem.util import read_jsonl
 
@@ -611,6 +611,39 @@ class TestSubModelHeader:
             cli.main, ["sub"], input="tandem-model: mystery-model\ntask\n")
         assert r.exit_code == 0
         assert calls["kw"]["model"] == "mystery-model"
+
+    def test_malformed_header_fails_before_catalog_or_session(
+            self, env_factory, monkeypatch):
+        # a near-miss header must never fall through as task text: that is
+        # the silent-wrong-model failure this protocol exists to eliminate
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        # no _catalog(): the failure has to land before any catalog read
+        monkeypatch.setattr(
+            modelcat, "load_catalog",
+            lambda: pytest.fail("catalog read before the header was validated"))
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: <gpt-5.4-mini>\ntask\n")
+        assert r.exit_code == 1
+        assert ("error: malformed tandem-model header: "
+                "tandem-model: <gpt-5.4-mini>") in r.output
+        assert calls == {}
+
+    def test_header_near_misses_still_reach_the_worker(
+            self, env_factory, monkeypatch):
+        # trailing space + CRLF + mixed-case prefix + a spoken name
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="Tandem-Model: 5.4 mini \r\ndo the thing\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "do the thing"
+        assert calls["kw"]["model"] == "gpt-5.4-mini"
 
     def test_header_only_brief_is_an_empty_task_error(
             self, env_factory, monkeypatch):

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -500,6 +500,132 @@ class TestSubCli:
         assert "empty task" in r.output
 
 
+class TestSubModelHeader:
+    def _cli_env(self, env, monkeypatch):
+        from tandem import cli
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        return cli
+
+    def _catalog(self):
+        from tandem import paths
+        p = paths.codex_models_cache_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"models": [
+            {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol",
+             "visibility": "list"},
+            {"slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini",
+             "visibility": "list"},
+        ]}))
+
+    def _capture(self, monkeypatch):
+        calls = {}
+        monkeypatch.setattr(
+            ops, "run_sub",
+            lambda store, session, task, **kw: calls.update(
+                task=task, kw=kw) or 0,
+        )
+        return calls
+
+    def test_header_resolves_and_is_stripped(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\ndo the thing\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "do the thing"
+        assert calls["kw"]["model"] == "gpt-5.6-sol"
+
+    def test_flag_beats_header_but_header_still_stripped(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-m", "flag-model"],
+            input="tandem-model: sol\ntask\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "task"
+        assert calls["kw"]["model"] == "flag-model"
+
+    def test_unknown_model_fails_before_codex(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: o3\ntask\n")
+        assert r.exit_code == 1
+        assert "unknown model 'o3'" in r.output
+        assert "gpt-5.6-sol" in r.output
+        assert calls == {}          # codex was never invoked
+
+    def test_quiet_appends_model_footer(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="tandem-model: sol\ntask\n")
+        assert r.output.rstrip().endswith("[tandem-sub model: gpt-5.6-sol]")
+
+    def test_no_header_no_footer(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="just a task\n")
+        assert "[tandem-sub model:" not in r.output
+        assert calls["kw"]["model"] == ""   # config default: unset
+
+    def test_non_quiet_announces_worker_model(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\ntask\n")
+        assert "worker model: gpt-5.6-sol" in r.output
+
+    def test_missing_catalog_passes_name_verbatim(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        # no _catalog() call: CODEX_HOME has no models_cache.json
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: mystery-model\ntask\n")
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "mystery-model"
+
+    def test_header_only_brief_is_an_empty_task_error(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\n")
+        assert r.exit_code == 1
+        assert "empty task brief" in r.output
+        assert calls == {}
+
+
 class TestDoctorAndStatus:
     def test_doctor_warns_on_api_key_env(self, env_factory, monkeypatch):
         from tandem.doctor import run_doctor

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -670,9 +670,11 @@ class TestDoctorAndStatus:
 
     def test_doctor_warns_when_no_model_is_configured(self, env_factory,
                                                       monkeypatch):
-        """The shipped defaults are route="all" + model="" — everything is
-        rerouted, but with no `-m` the worker runs on the codex account's
-        default, which is the frontier tier (S1: gpt-5.6-sol). Silently
+        """The shipped defaults are route="manual" + model="" — nothing is
+        rerouted, so every codex worker is one the user hand-picked. That is
+        exactly why the warning still matters: picking `tandem:gpt` chooses a
+        harness, never a price, and with no `-m` the worker runs on the codex
+        account's default — the frontier tier (S1: gpt-5.6-sol). Silently
         spending frontier money is the one surprise doctor must call out."""
         from tandem import paths
         from tandem.doctor import run_doctor

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **`route = "manual"` is now the shipped default** (`feat!`): subagent dispatches stay on Claude unless the user explicitly selects `tandem:gpt`; `route = "all"` becomes the opt-in for auto-rerouting. The `all` code path, missed-reroute notice gating, and sandbox-consent stamping are unchanged and test-pinned.
- **`tandem-model:` brief-header protocol**: the `gpt` agent description asks the orchestrating model to emit `tandem-model: NAME` as the brief's first line — only when the user actually named a model. `tandem sub` strips the header, resolves NAME against codex's own catalog (`~/.codex/models_cache.json`: slug + display name, case/punctuation-insensitive, unique-substring, hidden entries excluded), and fails fast **before** spending a codex round-trip: `error: unknown model 'o3'; this codex offers: gpt-5.6-sol, …`. Quiet mode appends a `[tandem-sub model: <slug>]` trailer so the dispatching session sees what actually ran. `-m` still beats the header; near-miss headers (trailing whitespace, CRLF, case, malformed names) fail loudly instead of silently running the config default. Unreadable/empty catalog degrades to verbatim pass-through.
- Doctor rationale + both READMEs rewritten around the new default; 0.1.8 in `pyproject.toml`/`plugin.json` lockstep, `uv.lock` synced.

Spec: `docs/specs/2026-08-03-manual-default-model-passthrough-design.md` · Plan: `docs/plans/2026-08-03-manual-default-model-passthrough.md`

## Why

Live phrase research (headless opus, plugin 0.1.7): agent *selection* under manual mode is 10/10 across phrasings ("ask GPT", "ChatGPT", "OpenAI's model", "gpt-5", "o3", mix-and-match GPT+Claude) — the failures were all post-selection: named models silently dropped, and under `route = "all"` a "have Claude and GPT both review this" ask becomes codex twice. Codex needs an exact model slug (probed: `-m gpt-5` and `-m o3` both 400 with no suggestions on a ChatGPT account), and the valid set is account/version-specific — hence live-catalog resolution over any hardcoded alias table.

## Test plan

- 317 tests passing (42 new: header grammar incl. near-miss loudness, catalog resolution, CLI precedence/trailer/streams, default-flip guards).
- Live headless acceptance: a real orchestrator emitted the header verbatim for "ask gpt-5.4-mini" and "ask o3" with the new double-quoted frontmatter registered; CLI probes against the real catalog confirmed fail-fast slug listing and resolution.
- **Remaining manual check before release**: one interactive paired-session run — bare "ask gpt to review X" (must NOT emit a header), spoken "ask gpt 5.4 mini to review X", and a full round-trip observing the model trailer (headless permission gates block relay execution in `-p`).

## Upgrade note (`feat!`)

Existing 0.1.7 users with no `config.toml` silently stop auto-rerouting on upgrade — it fails safe (work stays on Claude, no surprise codex spend), but call it out in the release notes; `route = "all"` restores the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
