### PR TITLE
release: 0.1.9 — gpt/codex standins for the default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ you set it.
   your codex install's own catalog before codex is ever invoked; say the
   name however you say it out loud, since matching ignores case and
   punctuation. A name that resolves to nothing fails fast, listing the
-  slugs your account actually offers, and a reply from a model-pinned
-  dispatch ends with a `[tandem-sub model: …]` trailer naming what ran.
+  slugs your account actually offers, while a generic one ("gpt", "codex")
+  names no model at all and just runs your `model` above — or your codex
+  account's default, reported as `codex default`. A reply from a
+  model-pinned dispatch ends with a `[tandem-sub model: …]` trailer naming
+  what ran.
   (`route = "off"` is the same routing silence, but `manual` keeps `tandem
   doctor`'s subagent checks on, since you still send work to codex.)
 - `route = "all"` reroutes every native subagent dispatch to codex

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -140,3 +140,28 @@ untouched — so first-line-only parsing is safe.
   paired session and confirm the header is emitted by the orchestrator,
   `-m` lands in the codex argv, and the trailer comes back — the two runs
   that failed in the research become the acceptance test.
+
+## Addendum (2026-08-04) — generic-name standins, ships as 0.1.9
+
+Operator decision after 0.1.8 merged: a requested model name that
+normalizes to `gpt` or `codex` is a **standin for "no preference"** — it
+resolves to the empty model and falls through the existing precedence
+chain (`[subagents] model`, else codex's own default) instead of failing
+as ambiguous. Rationale: the description's "never emit a header for a
+bare 'gpt'" clause is prompt-level guidance the CLI cannot enforce; with
+the standin, an orchestrator that obeys and one that emits
+`tandem-model: gpt` converge on identical behavior, and the 0.1.8
+residual (bare "ask gpt" hard-failing where 0.1.7 just ran) disappears.
+
+- Ordering: exact catalog match wins over the standin (a future literal
+  `gpt` slug resolves exactly); the standin wins over substring matching
+  (which is what made `gpt` ambiguous-fail). With an unreadable catalog
+  the standin still applies — `gpt` must never reach `codex -m` verbatim.
+- Feedback: when a header was present but the model that runs is the
+  empty fallback, the quiet trailer and the non-quiet announcement say
+  `codex default` instead of naming a slug (also fixes the empty
+  `[tandem-sub model: ]` cosmetic when `-m ""` co-occurs with a header).
+  When `[subagents] model` fills the fallback, they name that model.
+- The `gpt.md` description is unchanged: not emitting a header for a bare
+  "gpt" remains the instructed behavior; the standin is the enforcement
+  backstop, not the new contract.

--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -96,7 +96,8 @@ not the haiku relay — does the parsing.
   exec), the README already points users at it, and reading the wrapped
   CLI's own files is tandem's established method (`docs/formats.md`).
   `codex debug models` remains the human-facing debugging surface for the
-  same data. Resolution (run only when a header is present):
+  same data. Resolution (run only when a header is present) — *superseded
+  for the generic names `gpt`/`codex`, see the Addendum below*:
   - Normalize both sides: lowercase, strip non-alphanumerics.
   - Exact normalized match on a slug or display name wins.
   - Else a normalized-substring match (header inside candidate) that hits

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.8"
+version = "0.1.9"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -334,7 +334,9 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
     A brief whose first line is `tandem-model: <name>` picks the codex
     model for this worker: the name is resolved against codex's own model
     catalog (~/.codex/models_cache.json), and a malformed or unresolvable
-    name fails here, before codex is invoked, with the valid slugs listed."""
+    name fails here, before codex is invoked, with the valid slugs listed.
+    A generic name (`gpt`, `codex`) asks for no particular model and runs
+    the configured default."""
     from . import modelcat, ops
     from .config import load_subagents_config
 
@@ -358,9 +360,12 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
             click.secho(f"error: {e}", fg="red", err=True)
             sys.exit(1)
     cfg = load_subagents_config()
+    # A standin header ("gpt") resolves to "" and falls through to the config
+    # default here, exactly like no header at all; the flag still outranks both.
     worker_model = model if model is not None else (resolved or cfg.model)
     if requested and not quiet:
-        click.secho(f"worker model: {worker_model}", err=True)
+        click.secho(f"worker model: {modelcat.model_label(worker_model)}",
+                    err=True)
     with StateStore() as store:
         session = _require_session(store)
         code = ops.run_sub(

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -141,6 +141,8 @@ def _pair_session(store: StateStore, cwd: str, active: str) -> PairedSession:
 @main.command()
 def status() -> None:
     """Show the paired session for this directory."""
+    from . import modelcat
+
     with StateStore() as store:
         session = _require_session(store)
         versions = _check_versions(warn_only=True)
@@ -182,8 +184,11 @@ def status() -> None:
                     continue
                 if not isinstance(d, dict):
                     continue  # non-object marker: skip it, never traceback
+                # One wording owns "nobody picked a model" — the same phrase
+                # the sub trailer and announcement use, so status and a
+                # relayed reply describe the same worker the same way.
                 click.echo(
-                    f"  subagent running: {d.get('model') or 'default-model'} "
+                    f"  subagent running: {modelcat.model_label(d.get('model') or '')} "
                     f"({d.get('context')}) {d.get('task_preview', '')}"
                 )
         kept = sorted(sub_root.glob("rollout-*.jsonl")) if sub_root.is_dir() else []

--- a/src/tandem/modelcat.py
+++ b/src/tandem/modelcat.py
@@ -30,6 +30,20 @@ _HEADER_RE = re.compile(
     rf"^{re.escape(HEADER_PREFIX)}[ \t]*({_NAME})$", re.IGNORECASE)
 
 
+# Names that pick a *harness*, not a model. "ask gpt" names nothing to
+# translate, so a header carrying one is a standin for "no preference": it
+# resolves to the empty model and falls through the usual precedence
+# (`[subagents] model`, else codex's own default). The gpt agent description
+# still tells the orchestrator not to emit a header for a bare "gpt" — this is
+# the backstop for the ones that do, so obeying and not obeying converge
+# instead of one of them hard-failing. Compared against _norm()'d names, so
+# entries here are normalized (lowercase, alphanumerics only).
+STANDIN_MODELS = frozenset({"gpt", "codex"})
+# What to call the empty model in user-facing feedback: nothing was picked
+# here, so naming a slug would be a lie and "" reads as a bug.
+DEFAULT_MODEL_LABEL = "codex default"
+
+
 class UnknownModel(ValueError):
     """The requested name matched nothing (or too much) in the catalog."""
 
@@ -81,22 +95,31 @@ def _norm(s: str) -> str:
 
 
 def resolve(name: str, models: list[dict] | None) -> str:
-    """The exact slug for a user-worded model name.
+    """The exact slug for a user-worded model name, or "" for no preference.
 
-    Exact normalized match on slug or display name wins; else a normalized
+    Exact normalized match on slug or display name wins; else a generic
+    standin (STANDIN_MODELS) resolves to the empty model; else a normalized
     substring match that hits exactly one visible model; else UnknownModel
     listing the visible slugs — raised before codex is invoked, so the
-    round-trip that would 400 is never spent."""
+    round-trip that would 400 is never spent.
+
+    The standin sits after exact matching so a codex that really ships a
+    model named `gpt` still resolves it, and before substring matching
+    because substrings are what made `gpt` ambiguous-fail in the first
+    place. It applies with no catalog too: `gpt` must never reach
+    `codex -m` verbatim, which 400s after a full round-trip."""
+    n = _norm(name)
     if models is None:
-        return name
+        return "" if n in STANDIN_MODELS else name
     visible = [m for m in models
                if m.get("visibility") != "hide"
                and isinstance(m.get("slug"), str)]
-    n = _norm(name)
     for m in visible:
         if n and (n == _norm(m["slug"])
                   or n == _norm(str(m.get("display_name") or ""))):
             return m["slug"]
+    if n in STANDIN_MODELS:
+        return ""
     hits = {m["slug"] for m in visible
             if n and (n in _norm(m["slug"])
                       or n in _norm(str(m.get("display_name") or "")))}
@@ -107,5 +130,13 @@ def resolve(name: str, models: list[dict] | None) -> str:
         + ", ".join(m["slug"] for m in visible))
 
 
+def model_label(slug: str) -> str:
+    """What to call the model that actually ran, for humans and for the
+    dispatching session. Empty means nobody picked one — a standin header,
+    or no config default — so codex chose, and the feedback says that
+    rather than printing an empty name."""
+    return slug or DEFAULT_MODEL_LABEL
+
+
 def model_footer(slug: str) -> str:
-    return f"[tandem-sub model: {slug}]"
+    return f"[tandem-sub model: {model_label(slug)}]"

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -14,6 +14,13 @@ CATALOG = [
      "visibility": "hide"},
 ]
 
+# Purpose-built: a codex that really does ship a model *named* `gpt`. The
+# standin must never shadow an exact catalog match.
+CATALOG_WITH_LITERAL_GPT = [
+    {"slug": "gpt", "display_name": "GPT", "visibility": "list"},
+    {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
+]
+
 
 class TestSplitModelHeader:
     def test_header_is_stripped_and_returned(self):
@@ -116,10 +123,13 @@ class TestResolve:
         assert modelcat.resolve("5.4 mini", CATALOG) == "gpt-5.4-mini"
 
     def test_ambiguous_lists_visible_slugs(self):
+        # `gpt-5` is a family, not a model: it substring-hits every slug here.
+        # Only the exact names `gpt`/`codex` are standins — not a prefix rule —
+        # so this still fails loudly with the choices spelled out.
         with pytest.raises(modelcat.UnknownModel) as e:
-            modelcat.resolve("gpt", CATALOG)
+            modelcat.resolve("gpt-5", CATALOG)
         msg = str(e.value)
-        assert "unknown model 'gpt'" in msg
+        assert "unknown model 'gpt-5'" in msg
         assert "gpt-5.6-sol" in msg and "gpt-5.4-mini" in msg
         assert "codex-auto-review" not in msg
 
@@ -134,6 +144,52 @@ class TestResolve:
 
     def test_none_catalog_passes_name_through(self):
         assert modelcat.resolve("anything-goes", None) == "anything-goes"
+
+
+class TestGenericNameStandins:
+    """`gpt`/`codex` name the harness, not a model: they mean "no
+    preference", so they resolve to the empty model and fall through the
+    normal precedence (`[subagents] model`, else codex's own default)
+    instead of failing as ambiguous."""
+
+    def test_gpt_is_a_standin_for_the_default(self):
+        assert modelcat.resolve("gpt", CATALOG) == ""
+
+    def test_codex_is_a_standin_for_the_default(self):
+        assert modelcat.resolve("codex", CATALOG) == ""
+
+    def test_standin_beats_substring_ambiguity(self):
+        # pre-0.1.9 this raised UnknownModel: "gpt" is inside every slug
+        assert modelcat.resolve("gpt", CATALOG) == ""
+        assert modelcat.resolve("codex", CATALOG + [
+            {"slug": "codex-mini", "display_name": "Codex Mini",
+             "visibility": "list"}]) == ""
+
+    def test_exact_catalog_match_beats_the_standin(self):
+        assert modelcat.resolve("gpt", CATALOG_WITH_LITERAL_GPT) == "gpt"
+
+    def test_exact_display_name_match_beats_the_standin(self):
+        assert modelcat.resolve("G.P.T.", CATALOG_WITH_LITERAL_GPT) == "gpt"
+
+    def test_standin_applies_without_a_catalog(self):
+        # `gpt` must never reach `codex -m` verbatim, catalog or not
+        assert modelcat.resolve("gpt", None) == ""
+        assert modelcat.resolve("codex", None) == ""
+
+    def test_standin_is_case_and_punctuation_insensitive(self):
+        for name in ("GPT", "Gpt", " gpt ", "g.p.t", "CODEX", "Codex!"):
+            assert modelcat.resolve(name, CATALOG) == "", name
+
+    def test_standin_is_exact_not_a_prefix_rule(self):
+        # "gpt-5.4-mini" resolves as itself; "gpt 5" is still ambiguous
+        assert modelcat.resolve("gpt-5.4-mini", CATALOG) == "gpt-5.4-mini"
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("gpt 5", CATALOG)
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("gptx", CATALOG)
+
+    def test_standin_set_is_public_and_normalized(self):
+        assert modelcat.STANDIN_MODELS == frozenset({"gpt", "codex"})
 
 
 class TestLoadCatalog:
@@ -172,3 +228,13 @@ class TestLoadCatalog:
 
 def test_model_footer_exact_text():
     assert modelcat.model_footer("gpt-5.6-sol") == "[tandem-sub model: gpt-5.6-sol]"
+
+
+def test_model_footer_names_the_empty_model_codex_default():
+    # an empty model is not a name to print: codex picks, so say so
+    assert modelcat.model_footer("") == "[tandem-sub model: codex default]"
+
+
+def test_model_label_is_the_shared_name_for_what_ran():
+    assert modelcat.model_label("gpt-5.4-mini") == "gpt-5.4-mini"
+    assert modelcat.model_label("") == "codex default"

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -15,9 +15,17 @@ CATALOG = [
 ]
 
 # Purpose-built: a codex that really does ship a model *named* `gpt`. The
-# standin must never shadow an exact catalog match.
+# standin must never shadow an exact catalog match. The display name is
+# deliberately NOT "GPT" so the slug arm is the only thing that can match.
 CATALOG_WITH_LITERAL_GPT = [
-    {"slug": "gpt", "display_name": "GPT", "visibility": "list"},
+    {"slug": "gpt", "display_name": "GPT Classic", "visibility": "list"},
+    {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
+]
+
+# The mirror case: no slug normalizes to `gpt`, but a *display name* does.
+# Exact matching covers both arms, so this must resolve too.
+CATALOG_WITH_GENERIC_DISPLAY_NAME = [
+    {"slug": "gpt-legacy", "display_name": "GPT", "visibility": "list"},
     {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
 ]
 
@@ -165,11 +173,19 @@ class TestGenericNameStandins:
             {"slug": "codex-mini", "display_name": "Codex Mini",
              "visibility": "list"}]) == ""
 
-    def test_exact_catalog_match_beats_the_standin(self):
+    def test_exact_slug_match_beats_the_standin(self):
         assert modelcat.resolve("gpt", CATALOG_WITH_LITERAL_GPT) == "gpt"
+        assert modelcat.resolve("G.P.T.", CATALOG_WITH_LITERAL_GPT) == "gpt"
 
     def test_exact_display_name_match_beats_the_standin(self):
-        assert modelcat.resolve("G.P.T.", CATALOG_WITH_LITERAL_GPT) == "gpt"
+        # no slug here normalizes to "gpt" — only the display name does, so
+        # this fails if the standin short-circuits the display-name arm
+        assert not any(m["slug"] == "gpt"
+                       for m in CATALOG_WITH_GENERIC_DISPLAY_NAME)
+        assert modelcat.resolve("gpt", CATALOG_WITH_GENERIC_DISPLAY_NAME) \
+            == "gpt-legacy"
+        assert modelcat.resolve("GPT", CATALOG_WITH_GENERIC_DISPLAY_NAME) \
+            == "gpt-legacy"
 
     def test_standin_applies_without_a_catalog(self):
         # `gpt` must never reach `codex -m` verbatim, catalog or not

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -658,6 +658,91 @@ class TestSubModelHeader:
         assert "empty task brief" in r.output
         assert calls == {}
 
+    # --- generic-name standins: "gpt"/"codex" mean "no preference" ---
+
+    def test_standin_header_runs_the_codex_default(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="tandem-model: gpt\ndo the thing\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "do the thing"
+        assert calls["kw"]["model"] == ""     # no -m: codex's own default
+        assert r.output.rstrip().endswith("[tandem-sub model: codex default]")
+
+    def test_standin_header_uses_the_configured_model(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        (paths.tandem_home() / "config.toml").write_text(
+            '[subagents]\nmodel = "gpt-5.4-mini"\n')
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="tandem-model: codex\ntask\n")
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "gpt-5.4-mini"
+        assert r.output.rstrip().endswith("[tandem-sub model: gpt-5.4-mini]")
+
+    def test_standin_header_announces_codex_default_non_quiet(
+            self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: GPT\ntask\n")
+        assert r.exit_code == 0
+        assert "worker model: codex default" in r.output
+
+    def test_flag_beats_standin_header(self, env_factory, monkeypatch):
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-m", "gpt-5.6-sol"],
+            input="tandem-model: gpt\ntask\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "task"
+        assert calls["kw"]["model"] == "gpt-5.6-sol"
+        assert "worker model: gpt-5.6-sol" in r.output
+
+    def test_standin_without_a_catalog_still_runs_the_default(
+            self, env_factory, monkeypatch):
+        # `gpt` must never reach `codex -m` verbatim, even unreadable-catalog
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        # no _catalog(): CODEX_HOME has no models_cache.json
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="tandem-model: codex\ntask\n")
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == ""
+        assert r.output.rstrip().endswith("[tandem-sub model: codex default]")
+
+    def test_family_name_still_fails_loudly(self, env_factory, monkeypatch):
+        # the standin is exactly `gpt`/`codex`, not a prefix rule
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: gpt-5\ntask\n")
+        assert r.exit_code == 1
+        assert "unknown model 'gpt-5'" in r.output
+        assert "gpt-5.6-sol" in r.output and "gpt-5.4-mini" in r.output
+        assert calls == {}
+
 
 class TestDoctorAndStatus:
     def test_doctor_warns_on_api_key_env(self, env_factory, monkeypatch):

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -804,6 +804,30 @@ class TestDoctorAndStatus:
         assert "subagent running: gpt-x-mini (task) audit the README" in r.output
         assert "retained forks: 1" in r.output
 
+    def test_status_names_the_empty_model_like_the_trailer(
+            self, env_factory, monkeypatch):
+        """A worker with no model picked is the same state everywhere — one
+        wording owns it, so status must not invent its own name for what the
+        trailer and the announcement call `codex default`."""
+        import click.testing
+        from tandem import cli, modelcat, paths
+        env = env_factory(active="claude")
+        monkeypatch.setattr(cli, "_cwd", lambda: env.cwd)
+        monkeypatch.setattr(
+            cli, "_check_versions",
+            lambda warn_only=False: {"claude": "2.1.220", "codex": "0.145.0"},
+        )
+        run_dir = (paths.tandem_home() / "subagents" / env.session.tandem_id
+                   / "running")
+        run_dir.mkdir(parents=True)
+        (run_dir / "r1.json").write_text(json.dumps(
+            {"model": "", "context": "task", "task_preview": "audit", "pid": 1}))
+        r = click.testing.CliRunner().invoke(cli.main, ["status"])
+        assert r.exit_code == 0
+        assert f"subagent running: {modelcat.model_label('')} (task) audit" \
+            in r.output
+        assert "codex default" in r.output
+
     def test_doctor_survives_non_object_auth_json(self, env_factory, monkeypatch):
         """auth.json that is valid JSON but not an object must not crash
         doctor: `.get` on a list raises AttributeError, not ValueError."""

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Follow-up to #24. A `tandem-model:` header whose name normalizes to exactly `gpt` or `codex` is now a **standin for the default model**: it resolves to the empty model and falls through the existing precedence chain (`[subagents] model`, else codex's own default) instead of hard-failing as ambiguous.

- Ordering: an exact catalog match (slug **or** display name) beats the standin; the standin beats substring matching. With an unreadable catalog the standin still applies — `gpt` never reaches `codex -m` verbatim.
- Feedback: when the model that runs is the empty fallback, the quiet trailer and non-quiet announcement say `codex default` (also fixes the empty `[tandem-sub model: ]` when `-m ""` co-occurs with a header). `tandem status` now uses the same wording via the shared `model_label()` — `default-model` is gone.
- `plugin/agents/gpt.md` is unchanged: "never emit a header for a bare 'gpt'" remains the instructed behavior; the standin is the enforcement backstop when the orchestrator emits one anyway. This closes the residual risk flagged in #24's final review (bare "ask gpt" could hard-fail where 0.1.7 just ran) — both orchestrator behaviors now converge on the default model.
- Version 0.1.9 in `pyproject.toml`/`plugin.json` lockstep, `uv.lock` synced.

Spec: addendum at the end of `docs/specs/2026-08-03-manual-default-model-passthrough-design.md`.

## Test plan

- 335 tests passing (18 new: standin resolution incl. exact-match-beats-standin for slug and display-name separately, standin-beats-ambiguity, no-catalog standin, CLI trailer/announcement wording, `-m` precedence, non-standin loudness unchanged, status-line wording pinned to the trailer's).
- Behavior deliberately unchanged and pinned: `gpt-5`-style multi-match names still fail loudly with the slug listing; malformed headers still exit 1.
- Not live-exercised: a real paired dispatch returning `[tandem-sub model: codex default]` — same interactive check as #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
