### PR TITLE
release: 0.1.10 — family-prefix stripping in model resolution

### DIFF
--- a/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
+++ b/docs/specs/2026-08-03-manual-default-model-passthrough-design.md
@@ -166,3 +166,24 @@ residual (bare "ask gpt" hard-failing where 0.1.7 just ran) disappears.
 - The `gpt.md` description is unchanged: not emitting a header for a bare
   "gpt" remains the instructed behavior; the standin is the enforcement
   backstop, not the new contract.
+
+## Addendum 2 (2026-08-04) — family-prefix stripping, ships as 0.1.10
+
+Observed live: agents asked for "gpt terra" emit `tandem-model: gpt-terra`,
+which fails resolution — normalization keeps the query contiguous
+(`gptterra` cannot sit inside `gpt56terra`) even though the intent is
+unambiguous. Fix: one more resolution pass. After the full-query substring
+match fails, strip a single leading `gpt` or `codex` token from the
+*normalized* query and retry the same visible-substring match:
+`gpt-terra` → `terra` → `gpt-5.6-terra`; `gpt-mini`/`codex-mini` →
+`gpt-5.4-mini`.
+
+- Ordering (unchanged guarantees, one new step): exact slug/display match
+  → standin (`gpt`/`codex` alone still mean "default") → full-query
+  substring → **stripped-query substring** → loud `unknown model` listing.
+- Ambiguity stays loud: `gpt-5` strips to `5`, which hits several models,
+  so it still fails with the slug listing. A stripped query that is empty
+  is not retried (that case is the standin). No path resolves silently to
+  something the user did not ask for.
+- The strip operates in normalized space, so `gpt terra`, `GPT.Terra`,
+  and `gpt-terra` behave identically.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.1.9"
+version = "0.1.10"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/src/tandem/modelcat.py
+++ b/src/tandem/modelcat.py
@@ -94,20 +94,38 @@ def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9]", "", s.lower())
 
 
+def _substring_hits(n: str, visible: list[dict]) -> set[str]:
+    """Slugs whose slug or display name contains the normalized query `n`.
+
+    An empty query hits nothing on purpose: "" sits inside every string, so
+    matching it would resolve to whatever the catalog happens to list —
+    a model nobody asked for. That guard is what makes the callers below
+    safe to write branchlessly."""
+    return {m["slug"] for m in visible
+            if n and (n in _norm(m["slug"])
+                      or n in _norm(str(m.get("display_name") or "")))}
+
+
 def resolve(name: str, models: list[dict] | None) -> str:
     """The exact slug for a user-worded model name, or "" for no preference.
 
     Exact normalized match on slug or display name wins; else a generic
     standin (STANDIN_MODELS) resolves to the empty model; else a normalized
-    substring match that hits exactly one visible model; else UnknownModel
-    listing the visible slugs — raised before codex is invoked, so the
-    round-trip that would 400 is never spent.
+    substring match that hits exactly one visible model; else the same
+    substring match retried with one leading family token stripped; else
+    UnknownModel listing the visible slugs — raised before codex is
+    invoked, so the round-trip that would 400 is never spent.
 
     The standin sits after exact matching so a codex that really ships a
     model named `gpt` still resolves it, and before substring matching
     because substrings are what made `gpt` ambiguous-fail in the first
     place. It applies with no catalog too: `gpt` must never reach
-    `codex -m` verbatim, which 400s after a full round-trip."""
+    `codex -m` verbatim, which 400s after a full round-trip.
+
+    The stripped retry sits last so nothing it can do changes an answer the
+    earlier passes already gave, and it keeps the one-hit rule: `gpt-5`
+    strips to `5`, still hits several models, and still fails loudly. No
+    pass resolves to a model the user did not ask for."""
     n = _norm(name)
     if models is None:
         return "" if n in STANDIN_MODELS else name
@@ -120,9 +138,19 @@ def resolve(name: str, models: list[dict] | None) -> str:
             return m["slug"]
     if n in STANDIN_MODELS:
         return ""
-    hits = {m["slug"] for m in visible
-            if n and (n in _norm(m["slug"])
-                      or n in _norm(str(m.get("display_name") or "")))}
+    hits = _substring_hits(n, visible)
+    if len(hits) == 1:
+        return next(iter(hits))
+    # Observed live: an agent asked for "gpt terra" emits `gpt-terra`, and
+    # normalization keeps that query contiguous — `gptterra` cannot sit
+    # inside `gpt56terra` — so the pass above misses an unambiguous intent.
+    # Strip one leading family token and retry. At most one standin can
+    # prefix a given query, so the set's iteration order cannot matter, and
+    # a query that *was* just the token already returned at the standin arm
+    # — the remainder here is never empty, and an empty one would hit
+    # nothing anyway.
+    stripped = next((n[len(t):] for t in STANDIN_MODELS if n.startswith(t)), "")
+    hits = _substring_hits(stripped, visible)
     if len(hits) == 1:
         return next(iter(hits))
     raise UnknownModel(

--- a/src/tandem/modelcat.py
+++ b/src/tandem/modelcat.py
@@ -99,8 +99,8 @@ def _substring_hits(n: str, visible: list[dict]) -> set[str]:
 
     An empty query hits nothing on purpose: "" sits inside every string, so
     matching it would resolve to whatever the catalog happens to list —
-    a model nobody asked for. That guard is what makes the callers below
-    safe to write branchlessly."""
+    a model nobody asked for. The stripped-retry call site guards its own
+    query too — this is the backstop, not the only line of defense."""
     return {m["slug"] for m in visible
             if n and (n in _norm(m["slug"])
                       or n in _norm(str(m.get("display_name") or "")))}
@@ -144,15 +144,21 @@ def resolve(name: str, models: list[dict] | None) -> str:
     # Observed live: an agent asked for "gpt terra" emits `gpt-terra`, and
     # normalization keeps that query contiguous — `gptterra` cannot sit
     # inside `gpt56terra` — so the pass above misses an unambiguous intent.
-    # Strip one leading family token and retry. At most one standin can
-    # prefix a given query, so the set's iteration order cannot matter, and
-    # a query that *was* just the token already returned at the standin arm
-    # — the remainder here is never empty, and an empty one would hit
-    # nothing anyway.
-    stripped = next((n[len(t):] for t in STANDIN_MODELS if n.startswith(t)), "")
-    hits = _substring_hits(stripped, visible)
-    if len(hits) == 1:
-        return next(iter(hits))
+    # Strip one leading family token and retry. Longest match wins, so a
+    # standin added later that prefixes another one cannot make the result
+    # depend on the set's iteration order.
+    token = max((t for t in STANDIN_MODELS if n.startswith(t)),
+                key=len, default="")
+    stripped = n[len(token):] if token else ""
+    # An empty remainder is not retried: a query that *was* just the token
+    # already returned at the standin arm above, so this is unreachable —
+    # but an empty query is inside every name, and the one shape where
+    # that resolves instead of erroring (a single-model catalog) is the
+    # shape where silently running the wrong model is least visible.
+    if stripped:
+        hits = _substring_hits(stripped, visible)
+        if len(hits) == 1:
+            return next(iter(hits))
     raise UnknownModel(
         f"unknown model {name!r}; this codex offers: "
         + ", ".join(m["slug"] for m in visible))

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -29,6 +29,14 @@ CATALOG_WITH_GENERIC_DISPLAY_NAME = [
     {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
 ]
 
+# Same purpose as CATALOG_WITH_LITERAL_GPT, one rung down: a codex that
+# really ships `gpt-terra`. Prefix stripping must never shadow it. The
+# display name deliberately does not contain "GPT Terra", so the exact slug
+# arm is the only thing that can match.
+CATALOG_WITH_LITERAL_GPT_TERRA = CATALOG + [
+    {"slug": "gpt-terra", "display_name": "Terra Classic", "visibility": "list"},
+]
+
 
 class TestSplitModelHeader:
     def test_header_is_stripped_and_returned(self):
@@ -206,6 +214,81 @@ class TestGenericNameStandins:
 
     def test_standin_set_is_public_and_normalized(self):
         assert modelcat.STANDIN_MODELS == frozenset({"gpt", "codex"})
+
+
+class TestFamilyPrefixStripping:
+    """Live-observed wording: an agent asked for "gpt terra" emits
+    `tandem-model: gpt-terra`. Normalization keeps the query contiguous, so
+    `gptterra` cannot sit inside `gpt56terra` and the full-query substring
+    pass misses. One leading `gpt`/`codex` token is stripped and the same
+    visible-substring match is retried."""
+
+    def test_family_prefixed_name_resolves(self):
+        assert modelcat.resolve("gpt-terra", CATALOG) == "gpt-5.6-terra"
+
+    def test_either_family_token_strips(self):
+        # the token names the harness, not the family the model is in:
+        # asking codex for "mini" lands on the same model as asking gpt
+        assert modelcat.resolve("gpt-mini", CATALOG) == "gpt-5.4-mini"
+        assert modelcat.resolve("codex-mini", CATALOG) == "gpt-5.4-mini"
+
+    def test_strip_happens_in_normalized_space(self):
+        # spoken, typed and punctuated forms are the same query
+        assert modelcat.resolve("gpt terra", CATALOG) == "gpt-5.6-terra"
+        assert modelcat.resolve("GPT.Terra", CATALOG) == "gpt-5.6-terra"
+
+    def test_exact_match_beats_the_strip(self):
+        # a codex that ships a literal `gpt-terra` resolves it as itself,
+        # never as the stripped-retry hit
+        assert modelcat.resolve("gpt-terra", CATALOG_WITH_LITERAL_GPT_TERRA) \
+            == "gpt-terra"
+
+    def test_full_query_substring_beats_the_strip(self):
+        # `gptterra` sits whole inside `gpt-terra-x`, so the full query wins
+        # outright — the stripped retry would be ambiguous (two terras) and
+        # raise, which is what a wrong pass order would produce here
+        catalog = CATALOG + [
+            {"slug": "gpt-terra-x", "display_name": "GPT Terra X",
+             "visibility": "list"}]
+        assert modelcat.resolve("gpt-terra", catalog) == "gpt-terra-x"
+
+    def test_ambiguous_stripped_query_still_fails_loudly(self):
+        # `gpt-5` strips to `5`, which hits every model here: the family
+        # name stays a loud error with the choices spelled out
+        with pytest.raises(modelcat.UnknownModel) as e:
+            modelcat.resolve("gpt-5", CATALOG)
+        msg = str(e.value)
+        assert "unknown model 'gpt-5'" in msg
+        assert "gpt-5.6-sol" in msg and "gpt-5.4-mini" in msg
+
+    def test_stripped_query_that_hits_nothing_still_fails_loudly(self):
+        with pytest.raises(modelcat.UnknownModel) as e:
+            modelcat.resolve("gpt-o3", CATALOG)
+        assert "unknown model 'gpt-o3'; this codex offers: gpt-5.6-sol" \
+            in str(e.value)
+
+    def test_hidden_models_never_match_the_stripped_query(self):
+        # `codex-auto-review` is hidden; `gpt-auto-review` must not reach it
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("gpt-auto-review", CATALOG)
+
+    def test_bare_standins_are_untouched(self):
+        # the standin arm answers first, so no strip ever sees an empty
+        # remainder
+        assert modelcat.resolve("gpt", CATALOG) == ""
+        assert modelcat.resolve("codex", CATALOG) == ""
+
+    def test_only_one_token_is_stripped(self):
+        # `gpt-codex-mini` strips to `codexmini`, which matches nothing —
+        # loud, not a second strip down to `mini`
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("gpt-codex-mini", CATALOG)
+
+    def test_a_query_that_normalizes_to_nothing_matches_nothing(self):
+        # "" is inside every string; a query of pure punctuation must fail
+        # loudly rather than resolve to whatever sorts first
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("...", CATALOG)
 
 
 class TestLoadCatalog:

--- a/tests/test_modelcat.py
+++ b/tests/test_modelcat.py
@@ -37,6 +37,17 @@ CATALOG_WITH_LITERAL_GPT_TERRA = CATALOG + [
     {"slug": "gpt-terra", "display_name": "Terra Classic", "visibility": "list"},
 ]
 
+# One visible model — the shape that turns a missing empty-query guard into
+# a *silent* wrong answer instead of a loud ambiguity. "" is inside every
+# name, so an unguarded empty query hits every visible model; with three of
+# them that raises anyway and proves nothing, with one it resolves. Every
+# no-match assertion that exists to pin a guard runs against this.
+CATALOG_ONE_VISIBLE = [
+    {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "list"},
+    {"slug": "codex-auto-review", "display_name": "Codex Auto Review",
+     "visibility": "hide"},
+]
+
 
 class TestSplitModelHeader:
     def test_header_is_stripped_and_returned(self):
@@ -205,7 +216,11 @@ class TestGenericNameStandins:
             assert modelcat.resolve(name, CATALOG) == "", name
 
     def test_standin_is_exact_not_a_prefix_rule(self):
-        # "gpt-5.4-mini" resolves as itself; "gpt 5" is still ambiguous
+        # The standin arm matches `gpt`/`codex` whole: a longer name is a
+        # request to resolve, never a request for the default. Since 0.1.10
+        # the two failures below get one more chance at the family-prefix
+        # strip and still fail on their own merits — `5` hits every model
+        # here, `x` hits none — so neither quietly becomes "codex default".
         assert modelcat.resolve("gpt-5.4-mini", CATALOG) == "gpt-5.4-mini"
         with pytest.raises(modelcat.UnknownModel):
             modelcat.resolve("gpt 5", CATALOG)
@@ -284,9 +299,19 @@ class TestFamilyPrefixStripping:
         with pytest.raises(modelcat.UnknownModel):
             modelcat.resolve("gpt-codex-mini", CATALOG)
 
+    def test_an_unprefixed_miss_is_never_retried_as_an_empty_query(self):
+        # `banana` has no family token to strip, so the retry query would
+        # be "" — which is inside every name. Against a one-model catalog
+        # an unguarded retry resolves *silently* to that model instead of
+        # raising, so this is the assertion that pins the guard.
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("banana", CATALOG_ONE_VISIBLE)
+
     def test_a_query_that_normalizes_to_nothing_matches_nothing(self):
-        # "" is inside every string; a query of pure punctuation must fail
-        # loudly rather than resolve to whatever sorts first
+        # same hole one pass earlier: pure punctuation normalizes to "",
+        # which the full-query pass must not treat as a match either
+        with pytest.raises(modelcat.UnknownModel):
+            modelcat.resolve("...", CATALOG_ONE_VISIBLE)
         with pytest.raises(modelcat.UnknownModel):
             modelcat.resolve("...", CATALOG)
 

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -517,6 +517,8 @@ class TestSubModelHeader:
         p.write_text(json.dumps({"models": [
             {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol",
              "visibility": "list"},
+            {"slug": "gpt-5.6-terra", "display_name": "GPT-5.6-Terra",
+             "visibility": "list"},
             {"slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini",
              "visibility": "list"},
         ]}))
@@ -728,6 +730,22 @@ class TestSubModelHeader:
         assert r.exit_code == 0
         assert calls["kw"]["model"] == ""
         assert r.output.rstrip().endswith("[tandem-sub model: codex default]")
+
+    def test_family_prefixed_header_resolves(self, env_factory, monkeypatch):
+        # live-observed wording: an agent asked for "gpt terra" emits
+        # `tandem-model: gpt-terra`, which failed resolution before 0.1.10
+        import click.testing
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"],
+            input="tandem-model: gpt-terra\ndo the thing\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "do the thing"
+        assert calls["kw"]["model"] == "gpt-5.6-terra"
+        assert r.output.rstrip().endswith("[tandem-sub model: gpt-5.6-terra]")
 
     def test_family_name_still_fails_loudly(self, env_factory, monkeypatch):
         # the standin is exactly `gpt`/`codex`, not a prefix rule

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Follow-up to #25, prompted by live use: agents asked for "gpt terra" emit `tandem-model: gpt-terra`, which failed resolution — normalization keeps the query contiguous (`gptterra` can't sit inside `gpt56terra`) even though the intent is unambiguous.

Resolution gains one final pass: after the full-query substring match fails, strip a single leading `gpt`/`codex` token from the *normalized* query (longest-prefix, order-independent) and retry the unique visible-substring match.

- `gpt-terra` / `gpt terra` / `GPT.Terra` → `gpt-5.6-terra`; `gpt-mini` / `codex-mini` → `gpt-5.4-mini`.
- Ordering keeps every existing guarantee: exact slug/display match → standin (`gpt` alone still means "default") → full substring → **stripped substring** → loud `unknown model` listing.
- Ambiguity stays loud: `gpt-5` strips to `5`, hits several models, still fails with the slug menu. An empty stripped remainder is never retried (explicit call-site guard). Hidden catalog entries stay excluded from the stripped pass.
- Pure widening: the new pass is structurally unreachable for any query that resolved before.
- Version 0.1.10 in `pyproject.toml`/`plugin.json` lockstep, `uv.lock` synced. `plugin/agents/gpt.md` unchanged.

Spec: "Addendum 2" at the end of `docs/specs/2026-08-03-manual-default-model-passthrough-design.md`.

## Test plan

- 348 tests passing (13 new/rewritten: strip behavior across phrasings, ordering pins that flip under reimplementation, hidden-entry exclusion in the stripped pass, one-token-only stripping, and mutation-verified guards for the empty-remainder case against a single-visible-model catalog — the only shape where the unguarded variant fails silently).
- Live-verified against the real `~/.codex/models_cache.json`: `gpt-terra` → `gpt-5.6-terra`, `gpt-mini`/`codex-mini` → `gpt-5.4-mini`, `gpt` → default, `gpt-5`/`banana` → loud listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
