### PR TITLE
docs: model-pin example is now 'ask sol to review it' + heading spacing nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ask for a second opinion without leaving Claude Code. Type "get the code
 reviewed by gpt" like you'd ask for anything else — tandem's plugin
 dispatches a codex worker with the full task brief, GPT's verdict lands
 back in your Claude session, and Claude applies the fixes. Name any model
-your codex account offers ("ask gpt-5.4-mini to review it"), or set a
+your codex account offers ("ask sol to review it"), or set a
 cheap default once and let every dispatch ride on it: Claude
 orchestrates, codex does the legwork, and your Claude quota stays on the
 main thread.

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -7,7 +7,7 @@ setup, configuration, and routing reference. (Back to the
 Load tandem's Claude Code plugin and GPT subagents are one ask away: "ask
 gpt to review this migration" runs the dispatch on a codex model instead of
 Claude's, with the task brief forwarded verbatim. Name a model — "ask
-gpt-5.4-mini to review it" — and the worker runs on exactly that one. Want
+sol to review it" — and the worker runs on exactly that one. Want
 every dispatch rerouted without asking each time? Set `route = "all"`.
 Either way the result comes back through Claude's own machinery. Claude
 orchestrates; codex does the legwork; your Claude quota stays on the
@@ -76,6 +76,7 @@ you set it.
   automatically, no asking. It's all or nothing, though: under `all`, "have
   Claude and GPT both review this" comes back as codex twice — `manual` is
   the mode where mix-and-match works.
+
 ## Write access and the sandbox
 
 - Write access follows your Claude permission mode. Dispatch while you're in


### PR DESCRIPTION
Swaps the gpt-5.4-mini example for sol in the README and subagents guide
(also shows the loose name matching), and adds the missing blank line
before '## Write access and the sandbox' flagged in review.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
