### PR TITLE
docs: subagents guide split into basic/advanced; config.toml gets its own reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 ## 🆕 New in 0.2 — GPT subagents
 
-Ask for a second opinion without leaving Claude Code. Type "get the code
-reviewed by gpt" like you'd ask for anything else — tandem's plugin
-dispatches a codex worker with the full task brief, GPT's verdict lands
-back in your Claude session, and Claude applies the fixes. Name any model
-your codex account offers ("ask sol to review it"), or set a
-cheap default once and let every dispatch ride on it: Claude
-orchestrates, codex does the legwork, and your Claude quota stays on the
-main thread.
+Call another model family without leaving Claude Code. Type "get the
+code reviewed by gpt" and tandem's plugin hands the task to a local
+codex worker. GPT's verdict lands back in your Claude session, and
+Claude applies the fixes. Pin any model your codex account offers ("ask
+sol to review it") or set a cheap default once. Your Claude quota stays
+on the main thread.
 
 ![gpt subagent demo — ask for a GPT review in Claude Code, tandem dispatches a codex worker, the verdict comes back, fixes get committed](https://raw.githubusercontent.com/Bhavya6187/tandem/main/docs/gpt-subagent.gif)
 
@@ -76,20 +74,21 @@ text between terminals:
 tandem run --on codex "second opinion: why is this test flaky?"
 ```
 
-### 🐣 Subagents on the cheap model.
+### 🐣 Other model families, inside Claude Code.
 
-Load tandem's Claude Code plugin and GPT subagents are one ask away: "ask
-gpt to review this migration" runs the dispatch on a codex model instead
-of Claude's, with the task brief forwarded verbatim. Name a model to pin
-one, or set `route = "all"` to reroute every dispatch without asking.
-Claude orchestrates; codex does the legwork; your Claude quota stays on
-the main thread.
+Claude Code dispatches subagents on Claude models only. tandem's plugin
+lifts that limit: say "ask gpt to review this migration" and the task
+runs on a local codex worker instead, with the brief forwarded verbatim
+and the result returned through Claude's own machinery. Name a model to
+pin one, or set `route = "all"` to reroute every dispatch. Claude
+orchestrates; codex does the legwork; your Claude quota stays on the
+main thread.
 
 ```bash
 tandem plugin install
 ```
 
-Config reference, routing modes, and the sandbox rules:
+Basic setup, routing modes, and the sandbox rules:
 [GPT subagents guide](https://github.com/Bhavya6187/tandem/blob/main/docs/subagents.md).
 
 ### 🏠 Every model in its native harness.
@@ -158,9 +157,11 @@ between the tools).
 
 ## Docs
 
-- [GPT subagents — install, config & routing](https://github.com/Bhavya6187/tandem/blob/main/docs/subagents.md) —
-  plugin install, `config.toml` reference, routing modes, sandbox & trust
-  boundary
+- [GPT subagents — basic setup & routing](https://github.com/Bhavya6187/tandem/blob/main/docs/subagents.md) —
+  plugin install, worker model, routing modes, sandbox & trust boundary
+- [Configuration](https://github.com/Bhavya6187/tandem/blob/main/docs/configuration.md) —
+  the optional `~/.tandem/config.toml`: subagent worker settings,
+  per-harness startup args
 - [How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md) — sync engine, PTY
   passthrough, compatibility ranges, where your data lives
 - [Developing tandem](https://github.com/Bhavya6187/tandem/blob/main/docs/development.md) — dev setup and the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,40 @@
+# Configuration
+
+tandem reads one optional file: `~/.tandem/config.toml`. No file is
+required; every key has a working default. (Back to the
+[README](../README.md).)
+
+## [subagents] — GPT subagent workers
+
+Worker model, routing mode, and context handling for GPT subagent
+dispatches. Key semantics and the full routing story live in the
+[GPT subagents guide](subagents.md):
+
+```toml
+[subagents]
+model = "gpt-5.6-luna"  # worker default; unset = your codex account's default
+route = "manual"        # manual | all | off
+context = "match"       # match | task | full
+keep_forks = false      # keep each worker's rollout for debugging
+```
+
+## [claude] / [codex] — per-harness startup args
+
+Optional per-harness tables add flags to every interactive session tandem
+opens (`tandem`, `tandem resume`) — one-off relays (`tandem run`),
+subagent dispatch, and doctor probes are unaffected:
+
+```toml
+[claude]
+args = ["--dangerously-skip-permissions"]
+
+[codex]
+args = ["--dangerously-bypass-approvals-and-sandbox"]
+```
+
+The flags shown disable the harnesses' own permission prompts for
+sessions tandem launches — set them only if that is what you want.
+The list is passed to the harness raw: a flag that expects a value can
+swallow the settings tandem appends after it and break turn tracking.
+Malformed values (a non-list, empty or non-string elements) are
+silently ignored rather than failing the launch.

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -1,7 +1,7 @@
 # GPT subagents
 
-Dispatch delegated tasks from Claude Code to a GPT model — the full
-setup, configuration, and routing reference. (Back to the
+Dispatch delegated tasks from Claude Code to a GPT model. Basic setup
+first; the full configuration and routing reference after. (Back to the
 [README](../README.md).)
 
 Load tandem's Claude Code plugin and GPT subagents are one ask away: "ask
@@ -15,7 +15,10 @@ main thread. Two pieces: the `tandem` binary the hook shells out to, and
 the plugin that registers the hook — the plugin lives in this repo, not in
 the wheel, and without the binary on PATH it is inert.
 
-## Install the plugin
+## Basic setup
+
+No config file needed: routing is manual by default. All the basics need
+is the `codex` CLI installed and signed in, plus tandem and its plugin:
 
 ```bash
 uv tool install tandem-cli   # the binary the hook drives
@@ -30,14 +33,22 @@ tandem plugin install   # = claude plugin marketplace add Bhavya6187/tandem
                         #   + claude plugin install tandem@tandem
 ```
 
+That's it. In any tandem-paired Claude session, ask: "ask gpt to review
+this migration", or pin a model by name: "ask sol to review it". The
+worker runs on your codex account's default model, read-only, and its
+answer comes back like any subagent's. Everything below is optional
+tuning.
+
 The marketplace tracks this repo's default branch, but nothing updates
 behind your back: the first-launch offer asks before touching anything, and
 you pull new versions when you run `claude plugin marketplace update` (or
 `/plugin marketplace update` inside Claude).
 
-## Pick the worker model
+## Advanced
 
-Then create `~/.tandem/config.toml` and pick your plan's cheap model as the
+### Pick the worker model
+
+Create `~/.tandem/config.toml` and pick your plan's cheap model as the
 worker default — the ids your account can actually use are listed in
 `~/.codex/models_cache.json`, the same catalog a per-dispatch model request
 resolves against:
@@ -56,7 +67,7 @@ that one is not, and an explicitly asked-for gpt subagent bills that
 default just as automatic rerouting would, so `tandem doctor` warns until
 you set it.
 
-## Routing modes
+### Routing modes
 
 - `route = "manual"` (the default) keeps dispatches on Claude until you ask
   for codex — "use gpt subagents for this", "ask codex to review the
@@ -77,7 +88,7 @@ you set it.
   Claude and GPT both review this" comes back as codex twice — `manual` is
   the mode where mix-and-match works.
 
-## Write access and the sandbox
+### Write access and the sandbox
 
 - Write access follows your Claude permission mode. Dispatch while you're in
   `acceptEdits` or `bypassPermissions` and the codex worker runs with
@@ -96,27 +107,6 @@ you set it.
   loop guard matches on the last segment of the agent name in any scope — so
   a local `.claude/agents/gpt.md` of yours keeps dispatching natively.
 
-## Per-harness startup args
-
-Optional per-harness tables add flags to every interactive session tandem
-opens (`tandem`, `tandem resume`) — one-off relays (`tandem run`),
-subagent dispatch, and doctor probes are unaffected:
-
-```toml
-[claude]
-args = ["--dangerously-skip-permissions"]
-
-[codex]
-args = ["--dangerously-bypass-approvals-and-sandbox"]
-```
-
-The flags shown disable the harnesses' own permission prompts for
-sessions tandem launches — set them only if that is what you want.
-The list is passed to the harness raw: a flag that expects a value can
-swallow the settings tandem appends after it and break turn tracking.
-Malformed values (a non-list, empty or non-string elements) are
-silently ignored rather than failing the launch.
-
 ## Day to day
 
 Fork dispatches stay on Claude even under `route = "all"`, each worker's
@@ -132,3 +122,7 @@ remove tandem` to also unregister the marketplace.
 
 Hacking on the plugin itself? Skip the marketplace and point Claude at your
 clone: `claude --plugin-dir /path/to/tandem/plugin`.
+
+Startup flags for the harnesses themselves (`[claude]` / `[codex]` args)
+are not a subagent setting; they live in the
+[configuration reference](configuration.md).


### PR DESCRIPTION
Basic setup now needs only codex + the plugin (routing is manual by
default, worker falls back to the codex account default, read-only).
Worker model, routing modes, and sandbox rules move under Advanced.
Per-harness startup args were never a subagent setting; they move to a
new docs/configuration.md that documents ~/.tandem/config.toml, linked
from the README Docs section. README: the New-in-0.2 blurb is tightened
(local codex worker, no em dashes) and the value prop is reframed as
'Other model families, inside Claude Code'.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
