### PR TITLE
Model-pin recovery: survive the relay dropping the tandem-model header

### DIFF
--- a/docs/specs/2026-08-09-model-pin-recovery-design.md
+++ b/docs/specs/2026-08-09-model-pin-recovery-design.md
@@ -1,0 +1,140 @@
+# Model-pin recovery — design
+
+2026-08-09. Companion to the manual-routing model pass-through
+([2026-08-03](2026-08-03-manual-default-model-passthrough-design.md)):
+that spec gave briefs a `tandem-model:` first line; this one makes the
+line's delivery survive the relay that carries it.
+
+## Why
+
+A transcript audit (2026-08-08, all thirteen relay dispatches recorded
+under `~/.claude/projects/…/subagents/`) split the pass-through pipeline
+into its three hops and measured each:
+
+- **Parent → relay: lossless.** Every dispatch where the user named a
+  model (6/6) reached the relay with `tandem-model: …` intact as the
+  first line of its task message. Selection and header-authoring are not
+  the problem.
+- **Relay → `tandem sub`: lossy.** The haiku relay dropped the header
+  line from the heredoc it echoed in 5 of those 6 dispatches. The relay
+  prompt demanded the task be copied "byte-for-byte", but never mentioned
+  the header — and `tandem-model: sol` reads exactly like envelope
+  metadata addressed to the relay layer, so haiku treated it as already
+  consumed and started "the task" at line 2.
+- **`tandem sub` → codex: deterministic.** When the header arrives, it
+  resolves and pins correctly; when it does not arrive, nothing errs —
+  the brief is still a valid brief, so the worker silently runs the
+  config default. This silence is the whole severity of the bug: "runs
+  on luna" stays true even when you asked for sol, and only the missing
+  trailer hints at it.
+
+First layer of the fix: the relay bodies now name the header explicitly
+("that line is part of the task message … copy it exactly like every
+other line"). Live re-test (nine probes pinned to terra): in-band
+retention rose from ~1/6 to 5/7. Better, but a prompt can only make a
+small model *likelier* to copy a line; ~2/7 still arrived headerless.
+This spec is the second layer: make the pin survive even when the copy
+fails.
+
+## The shape of the problem
+
+The pin must travel parent → relay → `tandem sub`, and the middle hop is
+the unreliable one. Any scheme that keeps the pin *inside* the brief — a
+first line, a trailing line, a `-m` flag the relay is told to write —
+still depends on haiku reproducing it. The only two channels that do not
+pass through haiku at all:
+
+- the **parent prompt → hook**: `tandem hook-route` already runs on every
+  Agent/Task PreToolUse and receives `tool_input.prompt` pristine;
+- the **filesystem → `tandem sub`**: both processes share `$TANDEM_HOME`.
+
+The sandbox-consent stamp already rides exactly this road, and for the
+stated reason ("it cannot ride the dispatch itself, since the relay's
+only channel to the worker is the untrusted brief"). The pin follows it,
+with one difference: consent is a property of the *session*, so a single
+last-write-wins stamp file suffices; a pin is a property of *one
+dispatch*, and parallel dispatches with different pins are routine
+(mix-and-match is manual mode's selling point). The pin therefore needs
+a per-dispatch key, and the brief body is the only identifier both ends
+can see.
+
+## Design
+
+Two halves plus a small module (`pinstash.py`), all best-effort.
+
+**Capture (hook side).** `hookroute.relay_pin(payload)` returns
+`(requested, body)` when the dispatch both targets a relay
+(`gpt`/`codex-worker`, scope-insensitive like the loop guard) and opens
+with a well-formed `tandem-model:` header; `None` otherwise. The CLI
+then writes the stash entry:
+
+    ~/.tandem/model-pins/<sha256(body.strip())>   ← file name: body fingerprint
+    contents: sol                                 ← the requested name, unresolved
+
+Relay-only on purpose: a native agent's brief never reaches `tandem sub`
+under manual routing, and the `route="all"` rewrite prepends agent
+instructions, so a body captured pre-rewrite would not match what that
+relay echoes. Malformed headers are not stashed — if the relay preserves
+one, `sub` fails loudly on its own, and the stash must not launder a name
+the header parser rejects. The name is stored *unresolved* so that
+resolution (and its loud unknown-model failure listing real slugs)
+happens in `tandem sub`, identically to the in-band path.
+
+**Recovery (sub side).** When `tandem sub`'s stdin arrives with no
+header and no `-m` flag was given, it fingerprints its (stripped) task
+text and consults the stash. A hit rejoins the normal header path —
+catalog resolution, `worker model:` announcement, `[tandem-sub model: …]`
+trailer — so a recovered pin is indistinguishable from a preserved one.
+A miss changes nothing. Precedence, strongest first:
+
+    -m flag  >  in-band header  >  stashed pin  >  config default
+
+`-m` callers skip the lookup entirely: they never rode the header
+protocol, and a stale pin must not be able to abort their dispatch.
+
+**Stash contract** (`pinstash.py`):
+
+- **Exact match only.** The key is `sha256(body.strip())`; both writers
+  normalize edge whitespace and nothing else. No fuzzy matching: if the
+  relay ever mangles the body too (never observed — the drop is always
+  exactly the header line), the hash misses and the dispatch degrades to
+  today's behavior. Fail-open, never fail-worse.
+- **Entries expire, TTL one hour.** Long enough for a slow codex run
+  plus the relay's one sanctioned retry; short enough that an identical
+  brief re-dispatched much later does not inherit a stale pin. Expired
+  entries are pruned opportunistically on each stash.
+- **Lookups do not consume.** The sanctioned `--sandbox workspace-write`
+  rerun re-sends the same brief and must re-match the same pin.
+- **Every failure is silent.** A stash write error never reaches the
+  dispatch (mirror of `_stamp_sandbox`); a corrupt or implausible entry
+  reads as "no pin" — a recovered name is re-validated through the
+  header parser before it may reach `resolve()`, because aborting a
+  dispatch over stash bookkeeping would be worse than the silent default
+  the stash exists to improve on.
+
+## Rejected alternatives
+
+- **Prompt fix alone.** Shipped as layer one, measurably insufficient
+  (5/7). A prompt can raise a small model's copy fidelity, not guarantee
+  it.
+- **Single per-session stamp file** (the sandbox pattern verbatim).
+  ~15 lines, but last-write-wins misroutes under parallelism: a
+  headerless default-model dispatch running alongside a pinned one would
+  consume the neighbor's pin — a *new* silent-wrong-model failure in
+  exactly the mix-and-match scenario manual mode exists for.
+- **Teach the relay to pass `-m`.** Relocates the same fidelity
+  dependence from a heredoc line to a flag; haiku can drop either.
+- **Fuzzy body matching.** A near-match heuristic converts "no pin" into
+  "possibly the wrong pin". The failure mode being eliminated is silent
+  wrong-model; a design that can reintroduce it under fuzz is worse than
+  one that occasionally falls back to the default.
+
+## Observability
+
+Unchanged and sufficient: a pinned dispatch — in-band or recovered —
+ends with the `[tandem-sub model: …]` trailer naming what actually ran,
+and the non-quiet path announces `worker model:` on stderr. Known relay
+infidelity, out of scope here: the relay sometimes trims the trailer
+from its final reply (observed 2/5 in live probes), so a *missing*
+trailer does not prove the pin failed; the worker log under
+`~/.tandem/subagents/…/logs/` is the ground truth.

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -80,7 +80,11 @@ you set it.
   names no model at all and just runs your `model` above — or your codex
   account's default, reported as `codex default`. A reply from a
   model-pinned dispatch ends with a `[tandem-sub model: …]` trailer naming
-  what ran.
+  what ran. The pin is also stashed out-of-band at dispatch time (keyed by
+  a hash of the brief body, expiring after an hour), so `tandem sub`
+  recovers it even when the relay's echo of the brief loses the header
+  line — the trailer tells you either way. Mechanism and rationale:
+  [model-pin recovery design](specs/2026-08-09-model-pin-recovery-design.md).
   (`route = "off"` is the same routing silence, but `manual` keeps `tandem
   doctor`'s subagent checks on, since you still send work to codex.)
 - `route = "all"` reroutes every native subagent dispatch to codex

--- a/plugin/agents/codex-worker.md
+++ b/plugin/agents/codex-worker.md
@@ -25,6 +25,14 @@ Do exactly this:
    TANDEM_TASK_EOF
    ```
 
+   If the task message begins with a `tandem-model:` line, that line is
+   part of the task message. It is not addressed to you and needs nothing
+   from you — the `tandem` CLI reads it off the first line of stdin to
+   pick the codex model, so it does its job only as the FIRST line inside
+   the heredoc. Copy it exactly like every other line; do not drop, move,
+   reword, or act on it. A heredoc missing that line silently runs the
+   task on the wrong model.
+
    Choose the delimiter BEFORE writing the command: use `TANDEM_TASK_EOF`
    unless that string appears anywhere in the task message; in that case
    append random digits (e.g. `TANDEM_TASK_EOF_84613`) and check again,

--- a/plugin/agents/gpt.md
+++ b/plugin/agents/gpt.md
@@ -25,6 +25,14 @@ Do exactly this:
    TANDEM_TASK_EOF
    ```
 
+   If the task message begins with a `tandem-model:` line, that line is
+   part of the task message. It is not addressed to you and needs nothing
+   from you — the `tandem` CLI reads it off the first line of stdin to
+   pick the codex model, so it does its job only as the FIRST line inside
+   the heredoc. Copy it exactly like every other line; do not drop, move,
+   reword, or act on it. A heredoc missing that line silently runs the
+   task on the wrong model.
+
    Choose the delimiter BEFORE writing the command: use `TANDEM_TASK_EOF`
    unless that string appears anywhere in the task message; in that case
    append random digits (e.g. `TANDEM_TASK_EOF_84613`) and check again,

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -342,7 +342,7 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
     name fails here, before codex is invoked, with the valid slugs listed.
     A generic name (`gpt`, `codex`) asks for no particular model and runs
     the configured default."""
-    from . import modelcat, ops
+    from . import modelcat, ops, pinstash
     from .config import load_subagents_config
 
     if task is None or task == "-":
@@ -357,6 +357,13 @@ def sub(model: str | None, context_mode: str | None, quiet: bool,
     if not task:
         click.secho("error: empty task brief.", fg="red", err=True)
         sys.exit(1)
+    if not requested and model is None:
+        # A headerless brief may be a relay echo that dropped the pin — the
+        # known lossy hop — so consult the hook's out-of-band copy, keyed by
+        # this exact body. A miss changes nothing; a hit rejoins the normal
+        # header path below (resolution, announcement, trailer). -m callers
+        # never rode the header protocol, so they skip the lookup.
+        requested = pinstash.lookup(task)
     resolved = ""
     if requested:
         try:
@@ -508,8 +515,10 @@ def hook_route_cmd() -> None:
     hook MUST be registered as `tandem hook-route || true`; that shell guard
     is what makes exit 2 unreachable in practice."""
     try:
+        from . import pinstash
         from .config import load_subagents_config
-        from .hookroute import missed_reroute_notice, route, sandbox_for_mode
+        from .hookroute import (missed_reroute_notice, relay_pin, route,
+                                sandbox_for_mode)
 
         payload = json.loads(sys.stdin.read() or "{}")
         cwd = payload.get("cwd") or _cwd()
@@ -523,6 +532,15 @@ def hook_route_cmd() -> None:
         if session is not None and payload.get("tool_name") in ("Agent", "Task"):
             _stamp_sandbox(session.tandem_id,
                            sandbox_for_mode(payload.get("permission_mode")))
+        # The model pin travels the same out-of-band road as the consent
+        # stamp, for the same reason: it rides the brief, and the relay's
+        # echo of the brief is lossy (live transcripts show the
+        # `tandem-model:` line dropped from the heredoc). Stash it while
+        # the prompt is still pristine; `tandem sub` recovers it when its
+        # stdin arrives headerless.
+        pin = relay_pin(payload)
+        if pin is not None:
+            pinstash.stash(body=pin[1], requested=pin[0])
         codex_ok = False
         if session is not None:
             adapter = get_adapter("codex")

--- a/src/tandem/hookroute.py
+++ b/src/tandem/hookroute.py
@@ -36,6 +36,42 @@ RELAY_NAMES = frozenset({BRIDGE_NAME, ALIAS_NAME})
 WRITE_MODES = frozenset({"acceptEdits", "bypassPermissions"})
 
 
+def relay_pin(payload: dict) -> tuple[str, str] | None:
+    """(requested model, brief body) when this dispatch both targets a relay
+    and opens with a well-formed `tandem-model:` header; None otherwise.
+
+    The pin rides the brief, and the relay's echo of the brief into
+    `tandem sub` is lossy — live transcripts show the header line dropped
+    from the heredoc. This hook is the last place the prompt is pristine,
+    so the CLI stashes the pair (pinstash) for the relay's `tandem sub` to
+    recover. Relay-only on purpose: a native agent's brief never reaches
+    `tandem sub` under manual routing, and the route="all" rewrite prepends
+    agent instructions, so a body captured here would not match what that
+    relay echoes anyway. A malformed header is not stashed — if the relay
+    preserves it, `tandem sub` fails loudly on its own, and the stash must
+    not launder a name the header parser rejects."""
+    from . import modelcat
+
+    if payload.get("tool_name") not in ("Agent", "Task"):
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    subagent_type = tool_input.get("subagent_type") or ""
+    if subagent_type.rsplit(":", 1)[-1] not in RELAY_NAMES:
+        return None
+    prompt = tool_input.get("prompt")
+    if not isinstance(prompt, str):
+        return None
+    try:
+        requested, body = modelcat.split_model_header(prompt.strip())
+    except modelcat.MalformedHeader:
+        return None
+    if not requested:
+        return None
+    return requested, body
+
+
 def sandbox_for_mode(permission_mode) -> str:
     """The codex --sandbox value a dispatch from this claude permission
     mode has consented to, or "" for 'pass no flag'."""

--- a/src/tandem/pinstash.py
+++ b/src/tandem/pinstash.py
@@ -1,0 +1,97 @@
+"""Out-of-band model-pin stash: hook-route writes, `tandem sub` recovers.
+
+A `tandem-model:` first line pins the codex model for one dispatch, but it
+travels inside the brief, and the haiku relay that echoes the brief into
+`tandem sub` drops that line from its heredoc in a substantial fraction of
+dispatches (live transcripts, 2026-08-08 audit) — the worker then silently
+runs the config default. At PreToolUse time the parent prompt is still
+pristine, so hook-route stashes the requested name here, keyed by a hash of
+the brief body, and `tandem sub` consults the stash when its stdin arrives
+with no header.
+
+Contract: best-effort on both sides, mirroring the sandbox stamp. A stash
+write failure must never reach the dispatch, and a lookup returns the pinned
+name only on an exact (edge-whitespace-normalized) body match — anything
+else is "" and the dispatch behaves exactly as if this module did not exist.
+Entries are not consumed on read, because the relay's one sanctioned retry
+re-sends the same brief with --sandbox workspace-write; they expire by
+mtime instead."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from pathlib import Path
+
+from . import paths
+
+# Long enough to cover a slow codex run plus the relay's sanctioned retry;
+# short enough that an identical brief re-dispatched much later does not
+# inherit a stale pin.
+PIN_TTL = 3600
+
+
+def _pins_dir() -> Path:
+    return paths.tandem_home() / "model-pins"
+
+
+def _key(body: str) -> str:
+    # both writers normalize edge whitespace: the hook hashes the body split
+    # off the parent prompt, sub hashes its stripped stdin
+    return hashlib.sha256(
+        body.strip().encode("utf-8", errors="replace")).hexdigest()
+
+
+def stash(body: str, requested: str) -> None:
+    """Record the requested model for a brief with exactly this body."""
+    try:
+        d = _pins_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        _prune(d)
+        # write-then-rename so a concurrent lookup never reads a torn entry
+        tmp = d / f".{_key(body)}.tmp"
+        tmp.write_text(requested)
+        os.replace(tmp, d / _key(body))
+    except OSError:
+        pass
+
+
+def lookup(body: str) -> str:
+    """The pinned name for this exact brief body, or "" for any miss —
+    absent, expired, unreadable, or implausible as a header name."""
+    try:
+        p = _pins_dir() / _key(body)
+        if time.time() - p.stat().st_mtime > PIN_TTL:
+            return ""
+        name = p.read_text().strip()
+    # ValueError covers the UnicodeDecodeError of a corrupt entry
+    except (OSError, ValueError):
+        return ""
+    return name if _plausible(name) else ""
+
+
+def _plausible(name: str) -> bool:
+    """Would this name have survived the header parser? A corrupt entry that
+    reached resolve() would abort the dispatch loudly, which is worse than
+    the silent default this stash exists to improve on."""
+    from . import modelcat
+    try:
+        parsed, _ = modelcat.split_model_header(f"tandem-model: {name}\nx")
+    except modelcat.MalformedHeader:
+        return False
+    return parsed == name
+
+
+def _prune(d: Path) -> None:
+    cutoff = time.time() - PIN_TTL
+    try:
+        entries = list(d.iterdir())
+    except OSError:
+        return
+    for p in entries:
+        try:
+            if p.stat().st_mtime < cutoff:
+                p.unlink()
+        except OSError:
+            pass

--- a/tests/test_hookroute.py
+++ b/tests/test_hookroute.py
@@ -16,6 +16,7 @@ from tandem.hookroute import (
     NOTICE_NO_SESSION,
     find_agent_body,
     missed_reroute_notice,
+    relay_pin,
     route,
     sandbox_for_mode,
 )
@@ -213,6 +214,70 @@ class TestManualRoute:
         assert r.output == ""            # no rewrite, no notice
         assert (paths.tandem_home() / "sandbox"
                 / env.session.tandem_id).read_text() == "workspace-write"
+
+
+class TestRelayPin:
+    """relay_pin: which dispatches get their model pin stashed.
+
+    The pin rides the brief as a `tandem-model:` first line, but the haiku
+    relay drops that line from the heredoc it echoes into `tandem sub`
+    (live transcripts, 2026-08-08 audit). The hook sees the pristine parent
+    prompt, so it captures the pin here for `tandem sub` to recover."""
+
+    def test_relay_dispatch_with_header_is_pinned(self):
+        p = _payload(subagent_type="tandem:gpt",
+                     prompt="tandem-model: sol\ndo the thing")
+        assert relay_pin(p) == ("sol", "do the thing")
+
+    def test_bare_relay_name_is_pinned(self):
+        # same scope-insensitivity as the loop guard: the model can dispatch
+        # a relay by bare name or plugin-scoped id
+        p = _payload(subagent_type="gpt", prompt="tandem-model: sol\ntask")
+        assert relay_pin(p) == ("sol", "task")
+
+    def test_bridge_door_is_pinned_too(self):
+        p = _payload(subagent_type="tandem:codex-worker",
+                     prompt="tandem-model: terra\ntask")
+        assert relay_pin(p) == ("terra", "task")
+
+    def test_non_relay_dispatch_is_not_pinned(self):
+        # a native agent's brief starting with the header is not a relay
+        # dispatch; stashing it would leak pins into unrelated `tandem sub`
+        # runs that happen to share a body
+        p = _payload(prompt="tandem-model: sol\ntask")   # Explore
+        assert relay_pin(p) is None
+
+    def test_headerless_relay_dispatch_is_not_pinned(self):
+        p = _payload(subagent_type="tandem:gpt", prompt="just a task")
+        assert relay_pin(p) is None
+
+    def test_malformed_header_is_not_pinned(self):
+        # sub fails loudly on a malformed header IF the relay preserves it;
+        # the stash must not launder a name the header parser rejects
+        p = _payload(subagent_type="tandem:gpt",
+                     prompt="tandem-model: <sol>\ntask")
+        assert relay_pin(p) is None
+
+    def test_other_tools_and_garbage_are_not_pinned(self):
+        assert relay_pin({"tool_name": "Bash"}) is None
+        assert relay_pin({"tool_name": "Agent", "tool_input": "nope"}) is None
+        assert relay_pin({}) is None
+
+    def test_cli_stashes_pin_for_manual_gpt_dispatch(self, env_factory):
+        # mirrors test_manual_still_stamps_sandbox: manual mode never
+        # rewrites, but the pin must still be written before the relay
+        # spawns, or a dropped header is unrecoverable
+        from tandem import pinstash
+        env = env_factory(active="claude")
+        (paths.tandem_home() / "config.toml").write_text(
+            '[subagents]\nroute = "manual"\n')
+        payload = _payload(subagent_type="tandem:gpt",
+                           prompt="tandem-model: sol\ndo the thing")
+        payload["cwd"] = env.cwd
+        r = _run_hook(payload)
+        assert r.exit_code == 0
+        assert r.output == ""            # no rewrite, no notice
+        assert pinstash.lookup("do the thing") == "sol"
 
 
 class TestFindAgentBody:

--- a/tests/test_pinstash.py
+++ b/tests/test_pinstash.py
@@ -1,0 +1,94 @@
+"""pinstash: out-of-band model-pin recovery for relay-degraded briefs.
+
+The haiku relay drops a `tandem-model:` first line from the brief it echoes
+into `tandem sub` (live transcripts, 2026-08-08 audit: 5 of 6 pinned
+dispatches before the prompt fix; still ~2 of 7 after). The hook sees the
+pristine parent prompt, so it stashes the pin keyed by a hash of the brief
+body; `tandem sub` recovers the pin when its stdin arrives headerless.
+Everything here is best-effort: a stash problem must never break a dispatch,
+and a miss degrades to today's behavior (config default)."""
+
+import os
+import time
+
+import pytest
+
+from tandem import paths, pinstash
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+
+
+def _backdate_all(seconds: float) -> None:
+    past = time.time() - seconds
+    for p in (paths.tandem_home() / "model-pins").iterdir():
+        os.utime(p, (past, past))
+
+
+class TestStashLookup:
+    def test_roundtrip_returns_requested_name(self):
+        pinstash.stash("do the thing", "sol")
+        assert pinstash.lookup("do the thing") == "sol"
+
+    def test_unknown_body_is_empty(self):
+        assert pinstash.lookup("never stashed") == ""
+
+    def test_different_body_does_not_match(self):
+        pinstash.stash("task one", "sol")
+        assert pinstash.lookup("task two") == ""
+
+    def test_lookup_is_idempotent_for_sandbox_reruns(self):
+        # the relay's one sanctioned retry re-sends the SAME brief with
+        # --sandbox workspace-write; the pin must survive the first read
+        pinstash.stash("task", "sol")
+        assert pinstash.lookup("task") == "sol"
+        assert pinstash.lookup("task") == "sol"
+
+    def test_key_tolerates_edge_whitespace(self):
+        # the hook hashes the body split off the parent prompt; sub hashes
+        # its stripped stdin — both sides normalize edge whitespace
+        pinstash.stash("task\n", "sol")
+        assert pinstash.lookup("\ntask") == "sol"
+
+    def test_parallel_pins_keep_distinct_models(self):
+        pinstash.stash("review the docs", "sol")
+        pinstash.stash("fix the tests", "terra")
+        assert pinstash.lookup("review the docs") == "sol"
+        assert pinstash.lookup("fix the tests") == "terra"
+
+
+class TestExpiry:
+    def test_expired_pin_is_ignored(self):
+        pinstash.stash("task", "sol")
+        _backdate_all(pinstash.PIN_TTL + 60)
+        assert pinstash.lookup("task") == ""
+
+    def test_stash_prunes_expired_entries(self):
+        pinstash.stash("old", "sol")
+        _backdate_all(pinstash.PIN_TTL + 60)
+        pinstash.stash("new", "terra")
+        assert pinstash.lookup("new") == "terra"
+        # the expired entry is gone from disk, not merely ignored
+        assert len(list((paths.tandem_home() / "model-pins").iterdir())) == 1
+
+
+class TestRobustness:
+    def test_stash_failure_is_silent(self):
+        # a file squatting on the pins dir makes mkdir fail; the hook must
+        # never crash a dispatch over stash bookkeeping
+        home = paths.tandem_home()
+        home.mkdir(parents=True)
+        (home / "model-pins").write_text("squatter")
+        pinstash.stash("task", "sol")
+        assert pinstash.lookup("task") == ""
+
+    def test_corrupt_entry_is_empty_not_loud(self):
+        # a mangled entry must degrade to "no pin" — recovering garbage
+        # would abort the dispatch with an unknown-model error, which is
+        # worse than the silent default the stash exists to improve on
+        pinstash.stash("task", "sol")
+        [p] = (paths.tandem_home() / "model-pins").iterdir()
+        p.write_bytes(b"\xff\xfegarbage\xff")
+        assert pinstash.lookup("task") == ""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -116,6 +116,12 @@ def test_bridge_agent_definition():
     # a fixed heredoc delimiter is a shell-injection hazard: a task message
     # containing that line truncates the brief and runs the rest as shell
     assert "TANDEM_TASK_EOF_" in body
+    # live transcripts (2026-08-08 audit): with no explicit rule, the haiku
+    # relay dropped a `tandem-model:` first line from the heredoc in 5 of 6
+    # dispatches — it reads the header as envelope metadata already consumed,
+    # not as task content. The explicit first-line rule is the fix.
+    assert re.search(r"tandem-model.*\n.*part of the task message", body)
+    assert re.search(r"FIRST line inside\s+the heredoc", body)
     assert re.search(r"unless .*appears|appears .*in the task", body)
     assert "[tandem-sub blocked: write]" in body
     assert "--sandbox workspace-write" in body
@@ -136,7 +142,8 @@ def test_gpt_alias_agent_definition():
     # same relay contract as codex-worker
     body = text.split("---", 2)[2]
     for marker in ("tandem sub -q", "TANDEM_TASK_EOF_", "verbatim",
-                   "[tandem-sub failed]", "[tandem-sub blocked: write]",
+                   "tandem-model", "[tandem-sub failed]",
+                   "[tandem-sub blocked: write]",
                    "--sandbox workspace-write"):
         assert marker in body, marker
     assert re.search(r"never do the task yourself", body, re.I)

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -660,6 +660,93 @@ class TestSubModelHeader:
         assert "empty task brief" in r.output
         assert calls == {}
 
+    # --- stashed-pin recovery: the hook's out-of-band copy of the header ---
+
+    def test_stashed_pin_recovers_dropped_header(self, env_factory,
+                                                 monkeypatch):
+        # the haiku relay drops the `tandem-model:` first line from the
+        # heredoc it echoes (live transcripts, 2026-08-08 audit); the hook
+        # stashed the pin off the pristine parent prompt, and a headerless
+        # brief recovers it here
+        import click.testing
+
+        from tandem import pinstash
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        pinstash.stash("do the thing", "sol")
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="do the thing\n")
+        assert r.exit_code == 0
+        assert calls["task"] == "do the thing"
+        assert calls["kw"]["model"] == "gpt-5.6-sol"
+
+    def test_recovered_pin_appends_quiet_footer(self, env_factory,
+                                                monkeypatch):
+        # recovery must be visible exactly like an in-band pin: the trailer
+        # is the dispatching session's only proof of which model ran
+        import click.testing
+
+        from tandem import pinstash
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        self._capture(monkeypatch)
+        pinstash.stash("task", "sol")
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-q"], input="task\n")
+        assert r.output.rstrip().endswith("[tandem-sub model: gpt-5.6-sol]")
+
+    def test_inband_header_beats_stashed_pin(self, env_factory, monkeypatch):
+        # a preserved header is the fresher signal; the stash is only the
+        # fallback for briefs that arrive without one
+        import click.testing
+
+        from tandem import pinstash
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        pinstash.stash("task", "terra")
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="tandem-model: sol\ntask\n")
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "gpt-5.6-sol"
+
+    def test_explicit_flag_skips_stash_lookup(self, env_factory, monkeypatch):
+        # -m callers never rode the header protocol; a stale pin must not
+        # abort their dispatch (an unresolvable recovered name would)
+        import click.testing
+
+        from tandem import pinstash
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        pinstash.stash("task", "mystery-model")
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub", "-m", "flag-model"], input="task\n")
+        assert r.exit_code == 0
+        assert calls["kw"]["model"] == "flag-model"
+
+    def test_unknown_recovered_pin_fails_loud(self, env_factory, monkeypatch):
+        # same contract as an in-band header: resolution failures are loud
+        # and land before codex is invoked
+        import click.testing
+
+        from tandem import pinstash
+        env = env_factory(active="claude")
+        cli = self._cli_env(env, monkeypatch)
+        self._catalog()
+        calls = self._capture(monkeypatch)
+        pinstash.stash("task", "o3")
+        r = click.testing.CliRunner().invoke(
+            cli.main, ["sub"], input="task\n")
+        assert r.exit_code == 1
+        assert "unknown model 'o3'" in r.output
+        assert calls == {}
+
     # --- generic-name standins: "gpt"/"codex" mean "no preference" ---
 
     def test_standin_header_runs_the_codex_default(


### PR DESCRIPTION
## Problem

A transcript audit of all 13 recorded relay dispatches found the model pass-through failing at exactly one hop: the parent session writes the `tandem-model:` first line reliably (6/6), but the haiku relay **dropped that line from the heredoc it echoes into `tandem sub` in 5 of 6 pinned dispatches** — it reads the header as envelope metadata rather than task content. `tandem sub` then sees a perfectly valid headerless brief and silently runs the config default: "ask sol" quietly becomes luna, with only a missing trailer as a hint.

## Fix, two layers

1. **Relay prompt** (`plugin/agents/gpt.md` + `codex-worker.md`, bodies kept byte-identical per the existing test): explicitly name the header as part of the task message that must stay the first heredoc line. Live re-test (9 probes pinned to terra): in-band retention rose from ~1/6 to **5/7**.
2. **Deterministic backstop** (new `pinstash.py`): the pin also travels the sandbox-stamp road, outside the lossy relay. `hook-route` captures it off the pristine parent prompt (`hookroute.relay_pin`) and stashes it under `~/.tandem/model-pins/<sha256(brief body)>`; a headerless, flagless `tandem sub` fingerprints its stdin and recovers the pin, rejoining the normal header path (resolution, announcement, trailer). Precedence: `-m` flag > in-band header > stashed pin > config default. Exact-match only, 1h TTL, reads don't consume (the sanctioned `--sandbox` rerun re-matches), and every failure path degrades to today's behavior — the stash can miss, but never mispin.

Design rationale and rejected alternatives (single session stamp, relay `-m`, fuzzy matching): `docs/specs/2026-08-09-model-pin-recovery-design.md`.

## Test plan

- 23 new tests (TDD, watched fail first): stash roundtrip/expiry/corruption/parallel pins, `relay_pin` guards incl. the hook CLI writing the pin in manual mode, and `tandem sub` recovery/precedence/loud-unknown cases. Full suite: **380 passed**.
- Live E2E from this branch: `hook-route` payload carrying `tandem-model: terra` → headerless `tandem sub -q` → reply trailer `[tandem-sub model: gpt-5.6-terra]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
