### PR TITLE
feat: the tandem frame — Ctrl-] flips between native harnesses, bottom-row tab bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 dist/
 build/
 .pytest_cache/
+
+# superpowers brainstorm mockups
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and
 [OpenAI Codex CLI](https://github.com/openai/codex) as a single paired
 session — each model in its own native harness. Work in either one,
-switch at any moment, and pick up exactly where you left off. Only one
-model runs per turn; the other stays in sync through pure local file
-translation.
+flip to the other with **Ctrl-]**, and pick up exactly where you left
+off. Only one model runs per turn; the other stays in sync through pure
+local file translation.
 
 [![CI](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml/badge.svg)](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tandem-cli)](https://pypi.org/project/tandem-cli/)
@@ -36,11 +36,24 @@ cd your-project
 tandem                       # fresh paired session; drops you into claude
 ```
 
-Work normally. When you exit the agent, you land at tandem's prompt
-instead of your shell:
+Work normally — that's the real Claude Code TUI. When you want the other
+model, press **Ctrl-]**: tandem closes out the harness at the turn
+boundary and reopens the same conversation in Codex a couple of seconds
+later. Press it again to come back. The bottom row tracks who you're
+facing:
 
 ```
-tandem (claude)> switch      # continue instantly in codex
+claude ● │ codex ○   ^] flips
+```
+
+Pressed mid-turn, the flip arms and fires the moment the model finishes
+(the bar says so; press again to cancel).
+
+Exit the harness the usual way and you land at tandem's prompt instead of
+your shell:
+
+```
+tandem (claude)> switch      # the same flip, from the prompt
 tandem (codex)> exit
 to continue this session: tandem resume a1b2c3d4e5f6
 ```
@@ -53,6 +66,14 @@ tandem resume a1b2c3d4e5f6   # a specific one (id from the exit hint)
 ```
 
 ## Why tandem?
+
+### 🖥️ One CLI, two harnesses, zero ceremony.
+
+`tandem` is the terminal you live in. It fronts the real Claude Code or
+Codex TUI — pixel-for-pixel native — and **Ctrl-]** flips to the other
+one in a couple of seconds, same conversation, same files, same history.
+A one-line tab bar on the bottom row shows which model you're facing;
+everything above it is the untouched native UI.
 
 ### 🆕 0.2 — GPT subagents inside Claude Code
 
@@ -67,14 +88,14 @@ once. Setup and routing:
 
 ### ⏳ Hit a usage limit? Just keep going.
 
-Claude runs out of its usage window mid-refactor? Type `switch` and
+Claude runs out of its usage window mid-refactor? Press **Ctrl-]** and
 Codex continues the **same conversation** a second later — same files,
 same history, same plan. Two subscriptions become one long runway.
 
 ### 🌩️ Immune to outages.
 
-An Anthropic or OpenAI outage doesn't stop your work: `switch`, keep
-going in the other harness, and switch back whenever it clears.
+An Anthropic or OpenAI outage doesn't stop your work: **Ctrl-]**, keep
+going in the other harness, and flip back whenever it clears.
 
 Five more reasons — subscriptions not API bills, two model families on
 one problem, native harnesses, instant switching, privacy:
@@ -88,7 +109,11 @@ one problem, native harnesses, instant switching, privacy:
   CLI's native session format — pure local file I/O, no model calls —
   so the other side is always resume-ready.
 - Each CLI is the real thing running on a PTY: your keybindings, slash
-  commands, and MCP servers all work exactly as they do today.
+  commands, and MCP servers all work exactly as they do today — tandem
+  reserves exactly one key (Ctrl-]) and one terminal row (the tab bar).
+- A flip waits for the turn boundary, exits the fronted CLI gracefully,
+  lets the sync settle, and resumes the other side — no prompt in
+  between.
 - Everything stays local: the CLIs' own session files plus a small
   SQLite database in `~/.tandem`. No cloud sync, no telemetry.
 - Uninstall tandem tomorrow and both sessions still resume natively
@@ -102,6 +127,7 @@ Full mechanics — sync engine, crash safety, compatibility ranges:
 | Command | What it does |
 | --- | --- |
 | `tandem` | Start a fresh paired session (Claude active; `--active codex` to flip) |
+| `Ctrl-]` | Flip to the other harness from inside a running session, without stopping at a prompt (rebindable in `[frame]`) |
 | `switch` | Flip active/shadow and enter the other agent — at the tandem prompt, or one-shot from your shell (one-shot only flips, it doesn't enter) |
 | `tandem resume [id]` | Continue the most recent (or a specific) session |
 | `tandem run --on codex "…"` | One-off prompt to the *other* agent, with full context |
@@ -121,7 +147,7 @@ sync-mcp` (share MCP server configs between the tools).
   the full pitch, all eight reasons
 - [Configuration](https://github.com/Bhavya6187/tandem/blob/main/docs/configuration.md) —
   the optional `~/.tandem/config.toml`: subagent workers, per-harness
-  startup args
+  startup args, the flip key and tab bar
 - [How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md) —
   sync engine, PTY passthrough, compatibility, where your data lives
 - [Developing tandem](https://github.com/Bhavya6187/tandem/blob/main/docs/development.md) —

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,11 +53,14 @@ bar = true
 
 | key | default | meaning |
 | --- | --- | --- |
-| `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). |
+| `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). The bar relabels itself to match (`ctrl-t` shows `^T flips`). |
 | `bar` | `true` | The one-line tab bar on the bottom terminal row. `false` hides it; the flip still works. |
 
 An unparseable value falls back to the default rather than failing the
 launch. If a terminal can't sustain the bar, tandem drops it for the rest
 of that session — the flip is unaffected — and `tandem doctor` warns
 about it until you delete the marker file it names; set `bar = false` if
-you'd rather keep the bar off for good.
+you'd rather keep the bar off for good. Shrinking the window below the
+bar's row floor also drops it for the session, but that is tandem's own
+policy rather than a conflict, so nothing is recorded and `doctor` stays
+quiet.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,3 +38,26 @@ The list is passed to the harness raw: a flag that expects a value can
 swallow the settings tandem appends after it and break turn tracking.
 Malformed values (a non-list, empty or non-string elements) are
 silently ignored rather than failing the launch.
+
+## [frame] — the flip key and the tab bar
+
+The frame is tandem's own surface inside a running session: one reserved
+keybind that flips to the other harness, and the one-line tab bar on the
+bottom terminal row.
+
+```toml
+[frame]
+flip_key = "ctrl-]"
+bar = true
+```
+
+| key | default | meaning |
+| --- | --- | --- |
+| `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). |
+| `bar` | `true` | The one-line tab bar on the bottom terminal row. `false` hides it; the flip still works. |
+
+An unparseable value falls back to the default rather than failing the
+launch. If a terminal can't sustain the bar, tandem drops it for the rest
+of that session — the flip is unaffected — and `tandem doctor` warns
+about it until you delete the marker file it names; set `bar = false` if
+you'd rather keep the bar off for good.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -26,13 +26,16 @@ compatibility ranges, and where your data lives. (Back to the
   and resumes the other side — with no stop at the prompt in between.
   Where no marker could be wired (codex with a `notify` handler of your
   own, which tandem won't clobber) ~2s of transcript quiescence stands in;
-  where one was wired, a 30s valve covers a marker that never arrives. The
+  where one was wired, a 120s valve covers a marker that never arrives —
+  far above any plausible tool-call silence, because firing early kills a
+  live turn while firing late only costs a wait (and Ctrl-] cancels). The
   bottom terminal row is tandem's one drawn pixel: the child is told the
   terminal is a row shorter, a scroll region keeps output above the bar,
   and a targeted watcher reasserts it after child screen resets. If a
   terminal can't sustain the bar it drops for the session (the flip keeps
   working) and `tandem doctor` says so until you delete the marker file it
-  names.
+  names; shrinking the window below the bar's row floor drops it just as
+  permanently, but silently — that one isn't a conflict to fix.
 - **PTY passthrough.** tandem launches the real CLI on a pty (raw mode,
   resize forwarding, signals through the line discipline) and never
   scrapes terminal output — the transcript files are the source of truth.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -9,13 +9,30 @@ compatibility ranges, and where your data lives. (Back to the
   local file I/O: tandem tails the active transcript, translates each
   entry, and appends it to the shadow's session file. The shadow's model
   is never called to "catch up".
-- **A persistent prompt, not the OS shell.** Leaving the harness lands you
-  at `tandem (claude)>`. There, `switch` flips roles and drops you
-  straight into the other tool, Enter re-enters the current one, and
+- **A persistent prompt, not the OS shell.** Exiting the harness — as
+  opposed to flipping out of it — lands you at `tandem (claude)>`. There,
+  `switch` flips roles and drops you straight into the other tool, Enter
+  re-enters the current one, and
   `status` / `sync` / `doctor` / `run --on` / `sync-mcp` all run against
   this session. `exit` (or Ctrl-D) returns to your shell and prints the
   resume hint. Every command also works one-shot from your shell,
   targeting the directory's most recently used session.
+- **The frame: flip without leaving.** Ctrl-] (configurable, consumed at
+  the PTY layer, ignored inside bracketed paste) flips the screen to the
+  other harness: pressed mid-turn it arms and fires at the turn-complete
+  marker (press again to cancel — the bar shows the armed state), then
+  tandem exits the fronted CLI gracefully (quit keystrokes, then SIGTERM,
+  then a bounded SIGKILL), lets the incremental sync settle, flips roles,
+  and resumes the other side — with no stop at the prompt in between.
+  Where no marker could be wired (codex with a `notify` handler of your
+  own, which tandem won't clobber) ~2s of transcript quiescence stands in;
+  where one was wired, a 30s valve covers a marker that never arrives. The
+  bottom terminal row is tandem's one drawn pixel: the child is told the
+  terminal is a row shorter, a scroll region keeps output above the bar,
+  and a targeted watcher reasserts it after child screen resets. If a
+  terminal can't sustain the bar it drops for the session (the flip keeps
+  working) and `tandem doctor` says so until you delete the marker file it
+  names.
 - **PTY passthrough.** tandem launches the real CLI on a pty (raw mode,
   resize forwarding, signals through the line discipline) and never
   scrapes terminal output — the transcript files are the source of truth.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -19,16 +19,22 @@ compatibility ranges, and where your data lives. (Back to the
   targeting the directory's most recently used session.
 - **The frame: flip without leaving.** Ctrl-] (configurable, consumed at
   the PTY layer, ignored inside bracketed paste) flips the screen to the
-  other harness: pressed mid-turn it arms and fires at the turn-complete
-  marker (press again to cancel — the bar shows the armed state), then
+  other harness: pressed mid-turn it arms and fires at the turn boundary
+  (press again to cancel — the bar shows the armed state), then
   tandem exits the fronted CLI gracefully (quit keystrokes, then SIGTERM,
   then a bounded SIGKILL), lets the incremental sync settle, flips roles,
   and resumes the other side — with no stop at the prompt in between.
-  Where no marker could be wired (codex with a `notify` handler of your
-  own, which tandem won't clobber) ~2s of transcript quiescence stands in;
-  where one was wired, a 120s valve covers a marker that never arrives —
-  far above any plausible tool-call silence, because firing early kills a
-  live turn while firing late only costs a wait (and Ctrl-] cancels). The
+  With claude fronted, the boundary comes from claude's own session
+  registry (`~/.claude/sessions/<pid>.json`, the data `claude agents
+  --json` prints): `busy` holds the flip, anything else fires it — so an
+  idle prompt flips instantly even though claude keeps appending
+  housekeeping to its transcript between turns. With codex fronted the
+  transcript-marker rules stand: where no marker could be wired (codex
+  with a `notify` handler of your own, which tandem won't clobber) ~2s of
+  transcript quiescence stands in; where one was wired, a 120s valve
+  covers a marker that never arrives — far above any plausible tool-call
+  silence, because firing early kills a live turn while firing late only
+  costs a wait (and Ctrl-] cancels). The
   bottom terminal row is tandem's one drawn pixel: the child is told the
   terminal is a row shorter, a scroll region keeps output above the bar,
   and a targeted watcher reasserts it after child screen resets. If a

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -28,7 +28,11 @@ compatibility ranges, and where your data lives. (Back to the
   registry (`~/.claude/sessions/<pid>.json`, the data `claude agents
   --json` prints): `busy` holds the flip, anything else fires it — so an
   idle prompt flips instantly even though claude keeps appending
-  housekeeping to its transcript between turns. With codex fronted the
+  housekeeping to its transcript between turns.
+  (The registry appeared in claude 2.1.226; on older claudes the probe
+  finds nothing and every armed flip fires at once, mid-turn included —
+  the deliberate single-tier trade: no silent valve, breakage is loud.)
+  With codex fronted the
   transcript-marker rules stand: where no marker could be wired (codex
   with a `notify` handler of your own, which tandem won't clobber) ~2s of
   transcript quiescence stands in; where one was wired, a 120s valve

--- a/docs/plans/2026-08-09-meta-harness-frame.md
+++ b/docs/plans/2026-08-09-meta-harness-frame.md
@@ -1804,3 +1804,25 @@ Record results (terminal app + CLI versions tested) in the PR description.
 - **Spec coverage:** frame behavior (Tasks 6, 8–10), detector edges incl. paste + config override (Tasks 1, 2), bar + reserved row + guard + auto-drop (Tasks 3, 4, 6), termination ladder (Tasks 5, 7), turn-boundary + cancel toggle (Task 8), never-lose-the-session (Task 10 failure test), doctor note (Task 11), README/docs reframe (Task 12), live validation incl. emulator matrix and quit-recipe pinning (Task 13). Unpaired/plain sessions need no code: the detector only exists under the wrapper.
 - **Placeholder scan:** the two named-fixture stand-ins (`shell_env`, `doctor_env`) are explicit instructions to reuse the file's existing setup idiom, not TBDs; all code blocks are complete.
 - **Type consistency:** `FrameIO` fields match between Tasks 6 and 9; `terminate(soft=list[bytes])` matches `quit_keystrokes() -> list[bytes]`; `_enter`/`_switch` tuple returns consistent across Task 10's call sites; marker-file path identical in Tasks 9 and 11.
+
+---
+
+## Task 13 addendum — items added by the final whole-branch review
+
+Run these in addition to the checklist above:
+
+- [ ] **Does the bar survive first contact? (MERGE BLOCKER if not)** Launch, wait 60s, use both TUIs normally. If the bar vanishes immediately, capture output (`script`/asciinema) and check for a startup full-height DECSTBM — that decides whether the "parameterized DECSTBM ⇒ drop" rule survives.
+- [ ] **DECSC/DECRC collision:** watch for cursor misplacement during heavy streaming and drag-resize (one save slot per screen buffer; tandem and the child share it).
+- [ ] **Mid-turn flip during a >60s silent tool call** (arm at t+5s of a long test run) — must wait for turn completion, not fire at the 120s valve unless the hook actually died.
+- [ ] **Ctrl-] mid-turn in a fresh `tandem --active codex` session** — must show the armed indicator and wait (rollout-discovery publishing path).
+- [ ] **Sync-error visibility across a flip** — force a truncated transcript, flip, confirm the `sync error` line is readable after the screen clear.
+- [ ] **Quit-recipe verification:** confirm a normal flip reports a graceful exit (`soft`, not SIGTERM) in both directions, per pinned CLI versions.
+- [ ] **Shrink below 5 rows, then restore:** bar drops silently (no doctor marker — that's the shrink path), child gets full winsize back.
+- [ ] **Terminal hangup mid-session** (close window / drop SSH): no orphaned harness child.
+- [ ] **ESC pressed while the model is streaming** reaches the child (~200ms keyboard-idle flush) — test while streaming, not while idle.
+- [ ] Marker-less fresh codex (user-owned `notify`): flip armed in the first second of the session may fire early until the rollout is discovered — confirm the window is imperceptible in practice.
+- [ ] Note: the pump loop below the tty check has no automated coverage by design (pytest has no tty) — live validation is this code's only integration test.
+
+## Post-merge follow-ups (from review triage; none block merge)
+
+flip_key denylist for Tab/Enter/Esc collisions; pin the `bar_row` writable contract and the config→FrameIO seam with tests; carry-truncation test filler byte; `\x1b[0m` prefix before the bar's SGR; `time.monotonic()` in `_wait_dead`; EIO guard on the pump's stdin read; post-wait armed re-check (cancel TOCTOU); bound the flip-loop test fakes; extract `paths.bar_drop_marker()`; tail-join timeout vs `switch_session` drain lock (pre-existing); `docs/formats.md` cross-check next release.

--- a/docs/plans/2026-08-09-meta-harness-frame.md
+++ b/docs/plans/2026-08-09-meta-harness-frame.md
@@ -1,0 +1,1806 @@
+# Meta-Harness Frame Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Launch `tandem` once and never leave it: Ctrl-] flips the screen between the native Claude Code and Codex TUIs (~1–3 s, history intact via the existing sync engine), with a one-row status bar on the terminal's bottom line.
+
+**Architecture:** Three layers, none of which render conversation UI. `frame.py` (new) holds pure bytes-in/bytes-out state machines: flip-key detection on the input stream, a reset-watching guard on the output stream, and the bar's byte composition. `ptyrun.py` grows optional frame wiring (reserved bottom row via a `rows-1` winsize lie, scroll-region protection) and a `PtyControl` cross-thread termination handle. `runner.py` adds a `FlipMonitor` thread (armed flag → turn-boundary wait → termination ladder) and `shell.py` re-enters the other harness on flip without stopping at the tandem prompt. Spec: `docs/specs/2026-08-09-meta-harness-frame-design.md`.
+
+**Tech Stack:** Python 3.11+, ptyprocess, click, pytest. No new dependencies.
+
+## Global Constraints
+
+- No new dependencies; stdlib + existing deps only.
+- Config errors never break a launch: any malformed `[frame]` value falls back to its default (house rule from `src/tandem/config.py` module docstring).
+- tandem never parses meaning from terminal bytes except the exact sequences enumerated in `frame.py` (flip byte, bracketed-paste markers, SGR mouse, RIS/DECSTBM/alt-screen/ED). Everything else relays verbatim.
+- The bar activates only when: stdin is a tty AND `[frame] bar` is true AND terminal rows ≥ 5. The flip works with or without the bar.
+- The session must never be lost: every failure path lands at the tandem prompt with the resume hint (existing `shell.run_shell` finally-guarantee — do not disturb it).
+- Test seams: `shell.run_shell(input_fn=, run_harness=)` and monkeypatched `runner.run_in_pty` are the established patterns — reuse them, don't invent new ones.
+- Existing behavior is regression-scope: plain exits still reach the tandem prompt, `switch` typed at the prompt still works, non-tty `run_in_pty` fallback unchanged.
+- Commit messages follow the repo style (`feat:` / `docs:` prefixes, imperative, lowercase) and end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Run tests with `uv run pytest <path> -v` from the repo root (`/Users/bhavya/git/tandem`).
+
+---
+
+### Task 1: `[frame]` config table
+
+**Files:**
+- Modify: `src/tandem/config.py` (append after `load_harness_args`, ~line 81)
+- Test: `tests/test_config.py` (append)
+
+**Interfaces:**
+- Produces: `FrameConfig` frozen dataclass with `flip_byte: int = 0x1D`, `bar: bool = True`; `load_frame_config() -> FrameConfig`. Task 9 imports both from `tandem.config`.
+- Consumes: existing `_read_config()` in the same file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_config.py` (it already has `paths`/`tmp` fixtures in scope via `monkeypatch.setenv("TANDEM_HOME", ...)` — follow the file's existing pattern for writing `config.toml`; look at its first test for the exact fixture idiom and reuse it):
+
+```python
+from tandem.config import FrameConfig, load_frame_config
+
+
+def _write_config(tmp_path, monkeypatch, text):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path))
+    (tmp_path / "config.toml").write_text(text)
+
+
+def test_frame_defaults_without_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path))
+    cfg = load_frame_config()
+    assert cfg == FrameConfig(flip_byte=0x1D, bar=True)
+
+
+def test_frame_flip_key_ctrl_name(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "ctrl-t"\n')
+    assert load_frame_config().flip_byte == 0x14
+
+
+def test_frame_flip_key_hex(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "0x1e"\n')
+    assert load_frame_config().flip_byte == 0x1E
+
+
+def test_frame_flip_key_printable_rejected(tmp_path, monkeypatch):
+    # a printable key would swallow real typing — fall back to default
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "a"\n')
+    assert load_frame_config().flip_byte == 0x1D
+
+
+def test_frame_bar_off(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nbar = false\n')
+    assert load_frame_config().bar is False
+
+
+def test_frame_malformed_values_fall_back(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = 29\nbar = "yes"\n')
+    assert load_frame_config() == FrameConfig()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -v -k frame`
+Expected: FAIL — `ImportError: cannot import name 'FrameConfig'`
+
+- [ ] **Step 3: Implement**
+
+Append to `src/tandem/config.py`:
+
+```python
+@dataclass(frozen=True)
+class FrameConfig:
+    flip_byte: int = 0x1D   # Ctrl-]
+    bar: bool = True
+
+
+def _parse_flip_key(value: str) -> int | None:
+    """'ctrl-]' / 'ctrl-t' / '0x1d' -> byte value. None when unparseable or
+    not a control byte (a printable key would swallow real typing)."""
+    v = value.strip().lower()
+    if v.startswith("ctrl-") and len(v) == 6:
+        code = ord(v[5].upper()) & 0x1F
+    elif v.startswith("0x"):
+        try:
+            code = int(v, 16)
+        except ValueError:
+            return None
+    else:
+        return None
+    return code if 0 < code < 0x20 else None
+
+
+def load_frame_config() -> FrameConfig:
+    """[frame] table: the flip keybind and the status bar toggle."""
+    raw = _read_config().get("frame")
+    if not isinstance(raw, dict):
+        return FrameConfig()
+    d = FrameConfig()
+    key = raw.get("flip_key")
+    byte = _parse_flip_key(key) if isinstance(key, str) else None
+    bar = raw.get("bar")
+    return FrameConfig(
+        flip_byte=byte if byte is not None else d.flip_byte,
+        bar=bar if isinstance(bar, bool) else d.bar,
+    )
+```
+
+Also extend the module docstring's first paragraph to mention `[frame]`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: all PASS (new and pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/config.py tests/test_config.py
+git commit -m "feat: [frame] config table — flip_key and bar toggle"
+```
+
+---
+
+### Task 2: FlipDetector (input-side state machine)
+
+**Files:**
+- Create: `src/tandem/frame.py`
+- Test: `tests/test_frame.py` (create)
+
+**Interfaces:**
+- Produces: `FlipDetector(flip_byte: int, bar_row: int | None = None)` with `feed(data: bytes) -> tuple[bytes, int]` returning (bytes to forward to the child, count of flip presses). Task 6 consumes it in `ptyrun`.
+- Consumes: nothing tandem-internal (pure module — keep it that way; `ptyrun` imports `frame`, never the reverse).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_frame.py`:
+
+```python
+"""Frame state machines: pure bytes-in/bytes-out, no PTY, no threads."""
+
+from tandem.frame import FlipDetector
+
+FLIP = 0x1D  # Ctrl-]
+
+
+def test_flip_byte_consumed_and_counted():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"hello\x1dworld")
+    assert out == b"helloworld"
+    assert flips == 1
+
+
+def test_plain_bytes_pass_through_untouched():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"ls -la\r")
+    assert out == b"ls -la\r"
+    assert flips == 0
+
+
+def test_flip_byte_inside_bracketed_paste_passes_through():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"\x1b[200~abc\x1ddef\x1b[201~")
+    assert out == b"\x1b[200~abc\x1ddef\x1b[201~"
+    assert flips == 0
+
+
+def test_flip_after_paste_end_fires():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"\x1b[200~x\x1b[201~\x1d")
+    assert out == b"\x1b[200~x\x1b[201~"
+    assert flips == 1
+
+
+def test_paste_marker_split_across_feeds():
+    d = FlipDetector(FLIP)
+    out1, f1 = d.feed(b"\x1b[20")          # partial paste-begin marker
+    out2, f2 = d.feed(b"0~\x1d\x1b[201~")  # completes it; 0x1D is pasted
+    assert out1 + out2 == b"\x1b[200~\x1d\x1b[201~"
+    assert f1 == 0 and f2 == 0
+
+
+def test_paste_state_persists_across_feeds():
+    d = FlipDetector(FLIP)
+    d.feed(b"\x1b[200~abc")
+    out, flips = d.feed(b"\x1ddef")        # still inside the paste
+    assert out == b"\x1ddef"
+    assert flips == 0
+
+
+def test_mouse_click_on_bar_row_swallowed():
+    d = FlipDetector(FLIP, bar_row=40)
+    out, flips = d.feed(b"\x1b[<0;12;40M")
+    assert out == b""
+    assert flips == 0
+
+
+def test_mouse_click_elsewhere_passes_through():
+    d = FlipDetector(FLIP, bar_row=40)
+    out, _ = d.feed(b"\x1b[<0;12;39M")
+    assert out == b"\x1b[<0;12;39M"
+
+
+def test_mouse_ignored_when_no_bar():
+    d = FlipDetector(FLIP, bar_row=None)
+    out, _ = d.feed(b"\x1b[<0;12;40M")
+    assert out == b"\x1b[<0;12;40M"
+
+
+def test_lone_esc_not_swallowed():
+    # a bare ESC keypress must reach the child promptly-ish: it is carried
+    # only while it could still become a tracked sequence, and flushed as
+    # soon as following bytes rule that out
+    d = FlipDetector(FLIP)
+    out1, _ = d.feed(b"\x1b")
+    out2, _ = d.feed(b"q")
+    assert out1 + out2 == b"\x1bq"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_frame.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tandem.frame'`
+
+- [ ] **Step 3: Implement**
+
+Create `src/tandem/frame.py`:
+
+```python
+"""Frame machinery: flip-key detection, output guard, and the status bar.
+
+The frame is tandem's one visible surface — a reserved bottom row and one
+reserved keybind. Everything here is a pure bytes-in/bytes-out state
+machine so `ptyrun` stays a dumb pump: nothing in this module touches the
+terminal, the PTY, or threads, and `ptyrun` imports `frame`, never the
+reverse.
+"""
+
+from __future__ import annotations
+
+import re
+
+PASTE_BEGIN = b"\x1b[200~"
+PASTE_END = b"\x1b[201~"
+
+_MOUSE_RE = re.compile(rb"\x1b\[<(\d{1,4});(\d{1,4});(\d{1,4})([Mm])")
+# a trailing fragment that could still become a paste marker or mouse event
+_PARTIAL_RE = re.compile(rb"\x1b(\[(<(\d{0,4}(;\d{0,4}){0,2};?)?|20[01]?)?)?\Z")
+
+
+def _split_partial(buf: bytes) -> tuple[bytes, bytes]:
+    """Split off a trailing fragment of a tracked escape sequence, to be
+    retried on the next feed. Anything that cannot become one is not held
+    back (a lone ESC keypress must reach the child)."""
+    i = buf.rfind(b"\x1b", max(0, len(buf) - 11))
+    if i == -1:
+        return buf, b""
+    m = _PARTIAL_RE.match(buf, i)
+    if m and m.group(0) != b"":
+        return buf[:i], buf[i:]
+    return buf, b""
+
+
+class FlipDetector:
+    """Input-side filter: consume the flip byte (outside bracketed paste),
+    swallow SGR mouse events aimed at the bar row, forward everything else
+    byte-for-byte."""
+
+    def __init__(self, flip_byte: int, bar_row: int | None = None):
+        self.flip_byte = flip_byte
+        self.bar_row = bar_row
+        self._in_paste = False
+        self._carry = b""
+
+    def feed(self, data: bytes) -> tuple[bytes, int]:
+        buf = self._carry + data
+        buf, self._carry = _split_partial(buf)
+        out = bytearray()
+        flips = 0
+        i = 0
+        while i < len(buf):
+            if not self._in_paste and buf.startswith(PASTE_BEGIN, i):
+                self._in_paste = True
+                out += PASTE_BEGIN
+                i += len(PASTE_BEGIN)
+                continue
+            if self._in_paste and buf.startswith(PASTE_END, i):
+                self._in_paste = False
+                out += PASTE_END
+                i += len(PASTE_END)
+                continue
+            if not self._in_paste:
+                m = _MOUSE_RE.match(buf, i)
+                if m:
+                    if self.bar_row is not None and int(m.group(3)) == self.bar_row:
+                        i = m.end()  # click landed on tandem's row
+                        continue
+                    out += m.group(0)
+                    i = m.end()
+                    continue
+                if buf[i] == self.flip_byte:
+                    flips += 1
+                    i += 1
+                    continue
+            out.append(buf[i])
+            i += 1
+        return bytes(out), flips
+```
+
+Note on `test_lone_esc_not_swallowed`: `_PARTIAL_RE` matches a bare `\x1b` at end-of-buffer, so `\x1b` alone is carried; the next feed makes the buffer `\x1bq`, which no longer matches, so both bytes flush. If the regex needs adjusting to satisfy the test, adjust the regex — the test states the contract.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_frame.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/frame.py tests/test_frame.py
+git commit -m "feat: FlipDetector — flip keybind on the PTY input stream, paste-safe"
+```
+
+---
+
+### Task 3: OutputGuard (output-side watcher)
+
+**Files:**
+- Modify: `src/tandem/frame.py` (append)
+- Test: `tests/test_frame.py` (append)
+
+**Interfaces:**
+- Produces: `OutputGuard()` with `feed(data: bytes) -> str` returning `""` (nothing), `"reassert"` (repaint bar + scroll region), or `"drop"` (child manages its own scroll regions — bar cannot coexist). Never alters bytes. Task 6 consumes it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_frame.py`:
+
+```python
+from tandem.frame import OutputGuard
+
+
+def test_guard_plain_output_no_verdict():
+    assert OutputGuard().feed(b"hello \x1b[31mred\x1b[0m") == ""
+
+
+def test_guard_clear_screen_triggers_reassert():
+    assert OutputGuard().feed(b"\x1b[2J") == "reassert"
+
+
+def test_guard_alt_screen_enter_and_leave_trigger_reassert():
+    g = OutputGuard()
+    assert g.feed(b"\x1b[?1049h") == "reassert"
+    assert g.feed(b"\x1b[?1049l") == "reassert"
+
+
+def test_guard_ris_triggers_reassert():
+    assert OutputGuard().feed(b"\x1bc") == "reassert"
+
+
+def test_guard_bare_region_reset_triggers_reassert():
+    assert OutputGuard().feed(b"\x1b[r") == "reassert"
+
+
+def test_guard_parameterized_region_triggers_drop():
+    # the child drives its own scroll regions: the bar cannot coexist
+    assert OutputGuard().feed(b"\x1b[5;40r") == "drop"
+
+
+def test_guard_drop_wins_over_reassert():
+    assert OutputGuard().feed(b"\x1b[2J\x1b[5;40r") == "drop"
+
+
+def test_guard_sequence_split_across_feeds():
+    g = OutputGuard()
+    assert g.feed(b"text\x1b[?10") == ""
+    assert g.feed(b"49h more") == "reassert"
+
+
+def test_guard_does_not_double_count_carry():
+    g = OutputGuard()
+    assert g.feed(b"\x1b[2J") == "reassert"
+    # the sequence sits inside the carry window now; a new feed with no
+    # fresh trigger must not re-fire it
+    assert g.feed(b"quiet") == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_frame.py -v -k guard`
+Expected: FAIL — `ImportError: cannot import name 'OutputGuard'`
+
+- [ ] **Step 3: Implement**
+
+Append to `src/tandem/frame.py`:
+
+```python
+_DROP_RE = re.compile(rb"\x1b\[\d{1,4}(;\d{1,4})?r")     # child's own DECSTBM
+_REASSERT_RE = re.compile(rb"\x1bc|\x1b\[\?1049[hl]|\x1b\[[23]J|\x1b\[r(?!\d)")
+
+
+class OutputGuard:
+    """Output-side watcher for the handful of sequences that clobber the
+    reserved row or scroll region. Returns a verdict; never alters bytes.
+    A small carry window handles sequences split across read chunks; only
+    matches ending beyond the carry count (earlier ones fired last feed)."""
+
+    CARRY = 15
+
+    def __init__(self):
+        self._carry = b""
+
+    def feed(self, data: bytes) -> str:
+        buf = self._carry + data
+        base = len(self._carry)
+        self._carry = buf[max(0, len(buf) - self.CARRY):]
+        for m in _DROP_RE.finditer(buf):
+            if m.end() > base:
+                return "drop"
+        for m in _REASSERT_RE.finditer(buf):
+            if m.end() > base:
+                return "reassert"
+        return ""
+```
+
+Note: `\x1b\[r(?!\d)` keeps the bare-reset pattern from half-matching the front of a parameterized one; `_DROP_RE` is checked first regardless.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_frame.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/frame.py tests/test_frame.py
+git commit -m "feat: OutputGuard — watch child output for bar-clobbering resets"
+```
+
+---
+
+### Task 4: StatusBar (byte composition)
+
+**Files:**
+- Modify: `src/tandem/frame.py` (append)
+- Test: `tests/test_frame.py` (append)
+
+**Interfaces:**
+- Produces: `StatusBar(rows: int, cols: int, active: str, other: str)` with `resize(rows, cols)`, `line(armed: bool) -> str`, `paint(armed: bool) -> bytes`, `region() -> bytes`, `clear() -> bytes`. Pure composition — the pump writes what this returns. Task 6 consumes it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_frame.py`:
+
+```python
+from tandem.frame import StatusBar
+
+
+def test_bar_line_shows_active_and_other():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    line = bar.line(armed=False)
+    assert "claude ●" in line and "codex ○" in line and "^] flips" in line
+    assert len(line) == 60
+
+
+def test_bar_line_armed_state():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    line = bar.line(armed=True)
+    assert "flipping at turn end" in line and "^] cancels" in line
+
+
+def test_bar_line_truncates_to_width():
+    bar = StatusBar(rows=40, cols=12, active="claude", other="codex")
+    assert len(bar.line(armed=False)) == 12
+
+
+def test_bar_paint_targets_real_bottom_row_and_restores_cursor():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    b = bar.paint(armed=False)
+    assert b.startswith(b"\x1b7")        # DECSC save cursor
+    assert b"\x1b[40;1H" in b            # jump to the real bottom row
+    assert b"\x1b[7m" in b               # inverse video
+    assert b.endswith(b"\x1b[0m\x1b8")   # reset attrs, DECRC restore
+
+
+def test_bar_region_reserves_all_but_last_row():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    b = bar.region()
+    assert b == b"\x1b7\x1b[1;39r\x1b8"  # DECSTBM homes the cursor: save/restore
+
+
+def test_bar_clear_restores_full_region_and_wipes_row():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    b = bar.clear()
+    assert b"\x1b[r" in b                # full-screen scroll region back
+    assert b"\x1b[40;1H" in b and b"\x1b[2K" in b
+
+
+def test_bar_resize_recomputes():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    bar.resize(rows=30, cols=50)
+    assert b"\x1b[30;1H" in bar.paint(armed=False)
+    assert len(bar.line(armed=False)) == 50
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_frame.py -v -k bar`
+Expected: FAIL — `ImportError: cannot import name 'StatusBar'`
+
+- [ ] **Step 3: Implement**
+
+Append to `src/tandem/frame.py`:
+
+```python
+class StatusBar:
+    """Composes the bar's paint/region/clear byte strings for the real
+    bottom terminal row. The child is told the terminal is one row shorter
+    (identity row mapping for everything it can address); DECSTBM keeps
+    normal-buffer scrolling above the bar."""
+
+    def __init__(self, rows: int, cols: int, active: str, other: str):
+        self.rows = rows
+        self.cols = cols
+        self.active = active
+        self.other = other
+
+    def resize(self, rows: int, cols: int) -> None:
+        self.rows = rows
+        self.cols = cols
+
+    def line(self, armed: bool) -> str:
+        if armed:
+            text = f" {self.active} ⏳ flipping at turn end…  ^] cancels"
+        else:
+            text = f" {self.active} ● │ {self.other} ○   ^] flips"
+        return text[: self.cols].ljust(self.cols)
+
+    def paint(self, armed: bool) -> bytes:
+        return (
+            b"\x1b7"
+            + f"\x1b[{self.rows};1H".encode()
+            + b"\x1b[7m"
+            + self.line(armed).encode()
+            + b"\x1b[0m\x1b8"
+        )
+
+    def region(self) -> bytes:
+        # DECSTBM homes the cursor, so save/restore around it
+        return b"\x1b7" + f"\x1b[1;{self.rows - 1}r".encode() + b"\x1b8"
+
+    def clear(self) -> bytes:
+        return (
+            b"\x1b7\x1b[r"
+            + f"\x1b[{self.rows};1H".encode()
+            + b"\x1b[2K\x1b8"
+        )
+```
+
+(`line()` counts characters, not display cells — `●`/`│`/`⏳` are one cell each in practice; exact-width invariants are on `len(str)`, which is what the tests pin.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_frame.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/frame.py tests/test_frame.py
+git commit -m "feat: StatusBar — bottom-row tab bar byte composition"
+```
+
+---
+
+### Task 5: PtyControl and the termination ladder
+
+**Files:**
+- Modify: `src/tandem/ptyrun.py` (add imports `threading`, `time`, `dataclasses`; add classes above `run_in_pty`)
+- Test: `tests/test_ptyrun.py` (append)
+
+**Interfaces:**
+- Produces: `PtyControl()` with `attach(child) -> None` (called by `run_in_pty` once the child exists) and `terminate(soft: list[bytes], soft_timeout: float = 3.0, term_timeout: float = 2.0) -> str` returning `"dead" | "soft" | "term" | "kill"` — safe to call from another thread. Tasks 6 and 9 consume it.
+- Consumes: `os.killpg`, `signal`, ptyprocess child API (`.write`, `.isalive()`, `.pid`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_ptyrun.py`:
+
+```python
+import time
+
+from tandem.ptyrun import PtyControl
+
+
+class _StubChild:
+    """Stands in for a PtyProcess: records writes, dies on command."""
+
+    def __init__(self, dies_after_writes=None, dies_on_signal=None):
+        self.pid = 99999999  # killpg will fail -> ladder must survive that
+        self.writes = []
+        self._alive = True
+        self._dies_after_writes = dies_after_writes
+        self._dies_on_signal = dies_on_signal
+
+    def write(self, data):
+        self.writes.append(data)
+        if self._dies_after_writes and len(self.writes) >= self._dies_after_writes:
+            self._alive = False
+
+    def isalive(self):
+        return self._alive
+
+    def kill_externally(self):
+        self._alive = False
+
+
+def test_terminate_soft_exit():
+    c = PtyControl()
+    child = _StubChild(dies_after_writes=2)
+    c.attach(child)
+    how = c.terminate([b"\x03", b"\x04"], soft_timeout=1.0, term_timeout=0.2)
+    assert how == "soft"
+    assert child.writes == [b"\x03", b"\x04"]
+
+
+def test_terminate_already_dead():
+    c = PtyControl()
+    child = _StubChild()
+    child.kill_externally()
+    c.attach(child)
+    assert c.terminate([b"\x04"], soft_timeout=0.2) == "dead"
+
+
+def test_terminate_never_attached_returns_dead():
+    c = PtyControl()
+    assert c.terminate([b"\x04"], soft_timeout=0.1, attach_timeout=0.1) == "dead"
+
+
+def test_terminate_escalates_past_failing_killpg(monkeypatch):
+    # killpg raising (fake pid) must not break the ladder; the child dying
+    # during the term wait is still detected
+    c = PtyControl()
+    child = _StubChild()
+    c.attach(child)
+
+    import tandem.ptyrun as ptyrun
+
+    def fake_killpg(pgid, sig):
+        child.kill_externally()
+
+    monkeypatch.setattr(ptyrun.os, "killpg", fake_killpg)
+    how = c.terminate([b"\x03"], soft_timeout=0.3, term_timeout=1.0)
+    assert how == "term"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_ptyrun.py -v`
+Expected: FAIL — `ImportError: cannot import name 'PtyControl'`
+
+- [ ] **Step 3: Implement**
+
+Add to `src/tandem/ptyrun.py` (new imports at top: `import threading`, `import time`):
+
+```python
+def _wait_dead(child, timeout: float) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not child.isalive():
+            return True
+        time.sleep(0.05)
+    return not child.isalive()
+
+
+class PtyControl:
+    """Cross-thread termination handle. run_in_pty attaches the live child;
+    terminate() runs the escalation ladder from any other thread: soft quit
+    keystrokes (the CLI finalizes its own transcript), SIGTERM to the
+    process group, SIGKILL. Every rung tolerates a child that is already
+    gone."""
+
+    def __init__(self):
+        self._child = None
+        self._attached = threading.Event()
+
+    def attach(self, child) -> None:
+        self._child = child
+        self._attached.set()
+
+    def terminate(
+        self,
+        soft: list[bytes],
+        soft_timeout: float = 3.0,
+        term_timeout: float = 2.0,
+        attach_timeout: float = 5.0,
+    ) -> str:
+        self._attached.wait(timeout=attach_timeout)
+        child = self._child
+        if child is None or not child.isalive():
+            return "dead"
+        for chunk in soft:
+            try:
+                child.write(chunk)
+            except Exception:
+                break
+            time.sleep(0.25)
+        if _wait_dead(child, soft_timeout):
+            return "soft"
+        try:
+            os.killpg(child.pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        if _wait_dead(child, term_timeout):
+            return "term"
+        try:
+            os.killpg(child.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        _wait_dead(child, 1.0)
+        return "kill"
+```
+
+(ptyprocess spawns the child with `setsid`, so the child's pid is its process-group id — `killpg(child.pid, …)` takes the harness's tool children down with it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_ptyrun.py -v`
+Expected: all PASS. The soft test writes both chunks with 0.25 s pauses — runtime under a second.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/ptyrun.py tests/test_ptyrun.py
+git commit -m "feat: PtyControl — cross-thread termination ladder for the pty child"
+```
+
+---
+
+### Task 6: Frame wiring in run_in_pty
+
+**Files:**
+- Modify: `src/tandem/ptyrun.py` (extend `run_in_pty`, add `FrameIO`; new import `from .frame import FlipDetector, OutputGuard, StatusBar`)
+- Test: `tests/test_ptyrun.py` (append)
+
+**Interfaces:**
+- Produces: `FrameIO` dataclass — fields `flip_byte: int`, `on_flip: Callable[[], None]`, `armed: Callable[[], bool]`, `bar: bool = True`, `active: str = ""`, `other: str = ""`, `bar_dropped: bool = False` (set by the pump when the bar had to go). New `run_in_pty(argv, cwd=None, env=None, frame: FrameIO | None = None, control: PtyControl | None = None) -> int`; both new params default to None = today's behavior, byte-for-byte. Also produces `_child_dims(rows: int, cols: int, bar_on: bool) -> tuple[int, int]` (unit-testable winsize lie). Task 9 constructs `FrameIO` and passes both.
+- Consumes: Task 2 `FlipDetector`, Task 3 `OutputGuard`, Task 4 `StatusBar`, Task 5 `PtyControl`.
+
+- [ ] **Step 1: Write the failing tests**
+
+The interactive pump needs a real tty, which pytest doesn't have — the integrated path is covered by live validation (Task 11). What is unit-testable: the winsize lie, bar-activation policy, and that the non-tty fallback still ignores frame/control safely. Append to `tests/test_ptyrun.py`:
+
+```python
+import sys
+
+from tandem.ptyrun import FrameIO, _bar_on, _child_dims, run_in_pty
+
+
+def test_child_dims_reserves_bottom_row_when_bar_on():
+    assert _child_dims(40, 120, bar_on=True) == (39, 120)
+    assert _child_dims(40, 120, bar_on=False) == (40, 120)
+
+
+def test_bar_activation_policy():
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
+    assert _bar_on(frame, rows=40) is True
+    assert _bar_on(frame, rows=4) is False      # too small
+    assert _bar_on(None, rows=40) is False      # no frame wiring
+    frame_off = FrameIO(
+        flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False, bar=False
+    )
+    assert _bar_on(frame_off, rows=40) is False  # [frame] bar = false
+
+
+def test_non_tty_fallback_ignores_frame_and_control(capfd):
+    from tandem.ptyrun import PtyControl
+
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
+    code = run_in_pty(
+        [sys.executable, "-c", "print('fallback-ok')"],
+        frame=frame,
+        control=PtyControl(),
+    )
+    assert code == 0
+    assert "fallback-ok" in capfd.readouterr().out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_ptyrun.py -v`
+Expected: FAIL — `ImportError: cannot import name 'FrameIO'`
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/ptyrun.py`, add near the top (after `PtyControl`):
+
+```python
+from dataclasses import dataclass
+from typing import Callable
+
+from .frame import FlipDetector, OutputGuard, StatusBar
+
+
+@dataclass
+class FrameIO:
+    """Frame wiring for run_in_pty, built by the runner. The pump
+    constructs the detector/guard/bar internally from these fields;
+    `bar_dropped` reports back that the bar had to be disabled."""
+
+    flip_byte: int
+    on_flip: Callable[[], None]
+    armed: Callable[[], bool]
+    bar: bool = True
+    active: str = ""
+    other: str = ""
+    bar_dropped: bool = False
+
+
+def _child_dims(rows: int, cols: int, bar_on: bool) -> tuple[int, int]:
+    """The winsize lie: with the bar on, the child gets one row fewer and
+    tandem owns the real bottom row."""
+    return (rows - 1 if bar_on else rows, cols)
+
+
+def _bar_on(frame: FrameIO | None, rows: int) -> bool:
+    return frame is not None and frame.bar and rows >= 5
+```
+
+Then rewrite `run_in_pty` — same skeleton, frame-aware. Full replacement body:
+
+```python
+def run_in_pty(
+    argv: list[str],
+    cwd: str | None = None,
+    env: dict | None = None,
+    frame: FrameIO | None = None,
+    control: PtyControl | None = None,
+) -> int:
+    """Run argv on a pty, mirroring the controlling terminal. Returns the
+    child's exit status. Falls back to a plain subprocess when stdin is not
+    a tty (tests, pipes). With `frame`, tandem reserves the bottom row for
+    the status bar and watches for the flip keybind; with `control`, the
+    child is attached for cross-thread termination."""
+    try:
+        stdin_fd = sys.stdin.fileno()
+        is_tty = os.isatty(stdin_fd)
+    except (ValueError, OSError, io.UnsupportedOperation):
+        is_tty = False
+    if not is_tty:
+        return subprocess.run(argv, cwd=cwd, env=env).returncode
+
+    rows, cols = _winsize(stdin_fd)
+    bar_on = _bar_on(frame, rows)
+    detector = FlipDetector(
+        frame.flip_byte, bar_row=rows if bar_on else None
+    ) if frame else None
+    guard = OutputGuard() if bar_on else None
+    bar = StatusBar(rows, cols, frame.active, frame.other) if bar_on else None
+
+    child = PtyProcess.spawn(
+        argv, cwd=cwd, env=env or dict(os.environ),
+        dimensions=_child_dims(rows, cols, bar_on),
+    )
+    if control is not None:
+        control.attach(child)
+
+    out_fd = sys.stdout.fileno()
+
+    def paint() -> None:
+        if bar is not None:
+            os.write(out_fd, bar.region() + bar.paint(frame.armed()))
+
+    def drop_bar() -> None:
+        nonlocal bar_on, guard, bar
+        if bar is None:
+            return
+        os.write(out_fd, bar.clear())
+        r, c = _winsize(stdin_fd)
+        try:
+            child.setwinsize(r, c)
+        except Exception:
+            pass
+        if detector is not None:
+            detector.bar_row = None
+        bar_on, guard, bar = False, None, None
+        frame.bar_dropped = True
+
+    def on_winch(signum, frm):
+        r, c = _winsize(stdin_fd)
+        if bar is not None:
+            bar.resize(r, c)
+            detector.bar_row = r
+        try:
+            child.setwinsize(*_child_dims(r, c, bar_on))
+        except Exception:
+            pass
+        paint()
+
+    def on_term(signum, frm):
+        try:
+            child.kill(signal.SIGTERM)
+        except Exception:
+            pass
+
+    old_winch = signal.signal(signal.SIGWINCH, on_winch)
+    old_term = signal.signal(signal.SIGTERM, on_term)
+    old_attrs = termios.tcgetattr(stdin_fd)
+    last_armed = False
+    try:
+        tty.setraw(stdin_fd)
+        paint()
+        stdin_open = True
+        while child.isalive():
+            rlist = [child.fd] + ([stdin_fd] if stdin_open else [])
+            try:
+                ready, _, _ = select.select(rlist, [], [], 0.2)
+            except InterruptedError:
+                continue  # signal (e.g. SIGWINCH) — loop again
+            if child.fd in ready:
+                try:
+                    data = child.read(65536)
+                except EOFError:
+                    break
+                if not data:
+                    break
+                os.write(out_fd, data)
+                if guard is not None:
+                    verdict = guard.feed(data)
+                    if verdict == "drop":
+                        drop_bar()
+                    elif verdict == "reassert":
+                        paint()
+            if stdin_open and stdin_fd in ready:
+                data = os.read(stdin_fd, 65536)
+                if data:
+                    if detector is not None:
+                        data, flips = detector.feed(data)
+                        for _ in range(flips):
+                            frame.on_flip()
+                    if data:
+                        child.write(data)
+                else:
+                    child.sendeof()
+                    stdin_open = False
+            if bar is not None and frame.armed() != last_armed:
+                last_armed = frame.armed()
+                paint()
+    finally:
+        if bar is not None:
+            os.write(out_fd, bar.clear())
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)
+        signal.signal(signal.SIGWINCH, old_winch)
+        signal.signal(signal.SIGTERM, old_term)
+    try:
+        child.wait()
+    except Exception:
+        pass
+    return child.exitstatus if child.exitstatus is not None else 1
+```
+
+Also update the module docstring: the "never reads meaning from the terminal stream" sentence gains "— except the frame's enumerated sequences (flip byte, paste markers, mouse, and the output guard's reset set)".
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_ptyrun.py tests/test_frame.py -v`
+Expected: all PASS (including the two pre-existing fallback tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/ptyrun.py tests/test_ptyrun.py
+git commit -m "feat: run_in_pty frame wiring — reserved bar row, flip detection, output guard"
+```
+
+---
+
+### Task 7: Adapter quit recipes
+
+**Files:**
+- Modify: `src/tandem/harness/base.py` (add method to `HarnessAdapter`)
+- Modify: `src/tandem/harness/claude_code.py`, `src/tandem/harness/codex.py`
+- Test: `tests/test_frame.py` (append — small, keeps frame concerns together)
+
+**Interfaces:**
+- Produces: `HarnessAdapter.quit_keystrokes(self) -> list[bytes]` — byte chunks sent in order (0.25 s apart, by `PtyControl.terminate`) to cleanly exit the interactive CLI: clear the composer, then quit. Task 9 consumes via `adapter.quit_keystrokes()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_frame.py`:
+
+```python
+from tandem.harness import get_adapter
+
+
+def test_claude_quit_recipe():
+    # Ctrl-C clears the composer / interrupts, Ctrl-D on the empty
+    # composer exits
+    assert get_adapter("claude").quit_keystrokes() == [b"\x03", b"\x04"]
+
+
+def test_codex_quit_recipe():
+    # Ctrl-C clears/interrupts, second Ctrl-C quits ("press again"),
+    # Ctrl-D backstops older builds
+    assert get_adapter("codex").quit_keystrokes() == [b"\x03", b"\x03", b"\x04"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_frame.py -v -k quit`
+Expected: FAIL — `AttributeError: ... has no attribute 'quit_keystrokes'`
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/harness/base.py`, add to `HarnessAdapter` (near `hook_argv_extra`, ~line 65):
+
+```python
+    def quit_keystrokes(self) -> list[bytes]:
+        """Byte chunks that cleanly exit the interactive CLI — clear the
+        composer, then quit — sent in order with a short pause between.
+        Pinned per harness version; live-verified at release (the ladder's
+        SIGTERM rung backstops a recipe the CLI stops honoring)."""
+        return []
+```
+
+In `ClaudeCodeAdapter`:
+
+```python
+    def quit_keystrokes(self) -> list[bytes]:
+        return [b"\x03", b"\x04"]
+```
+
+In `CodexAdapter`:
+
+```python
+    def quit_keystrokes(self) -> list[bytes]:
+        return [b"\x03", b"\x03", b"\x04"]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_frame.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/harness/base.py src/tandem/harness/claude_code.py src/tandem/harness/codex.py tests/test_frame.py
+git commit -m "feat: per-harness quit keystroke recipes for the soft-exit rung"
+```
+
+---
+
+### Task 8: wait_until_safe + FlipMonitor
+
+**Files:**
+- Modify: `src/tandem/runner.py` (add after `ctx_to_cursor`, before `TailLoop`)
+- Test: `tests/test_runner.py` (append)
+
+**Interfaces:**
+- Produces: `wait_until_safe(transcript: Path | None, sentinel: Path | None, cancelled: Callable[[], bool], quiesce: float = 2.0, poll: float = 0.2) -> bool` (False = cancelled). `FlipMonitor(control, quit_bytes: list[bytes], transcript: Path | None, sentinel: Path)` with `start()`, `stop()`, `flip_pressed()` (thread-safe arm/cancel toggle), `armed() -> bool`, and attributes `flip_requested: bool`, `how: str`. Task 9 wires it into `InteractiveRunner`.
+- Consumes: Task 5 `PtyControl.terminate(soft=...)` (called with `quit_bytes`).
+
+The turn-boundary rule (from the spec): the transcript's last append happens before the Stop hook / notify touches the sentinel, so **idle ⇔ sentinel mtime ≥ transcript mtime**. Mid-turn, wait for the marker touch or ~2 s of transcript quiescence (the fallback where the marker is unavailable — e.g. codex with a user-configured notify handler tandem refuses to clobber). A missing file reads as mtime 0, which makes a fresh session (no files) idle and a marker-less mid-turn session take the quiescence path.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_runner.py`:
+
+```python
+import os
+import threading
+import time
+
+from tandem.runner import FlipMonitor, wait_until_safe
+
+
+def _touch(path, mtime):
+    path.write_text("x")
+    os.utime(path, (mtime, mtime))
+
+
+def test_wait_idle_when_sentinel_newer_than_transcript(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    now = time.time()
+    _touch(t, now - 10)
+    _touch(s, now - 5)   # marker closed the last turn
+    assert wait_until_safe(t, s, cancelled=lambda: False) is True
+
+
+def test_wait_idle_when_no_files(tmp_path):
+    assert (
+        wait_until_safe(tmp_path / "none", tmp_path / "none2",
+                        cancelled=lambda: False)
+        is True
+    )
+
+
+def test_wait_quiescence_fallback(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    now = time.time()
+    _touch(t, now - 3)   # transcript quiet for 3s, no marker since
+    _touch(s, now - 10)
+    assert (
+        wait_until_safe(t, s, cancelled=lambda: False, quiesce=2.0) is True
+    )
+
+
+def test_wait_blocks_midturn_then_marker_releases(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())          # a line just landed: turn in flight
+    _touch(s, time.time() - 30)
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       quiesce=30.0, poll=0.05)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    time.sleep(0.2)
+    assert not done.is_set()        # still waiting
+    _touch(s, time.time() + 1)      # marker fires
+    assert done.wait(timeout=2)
+    assert result["ok"] is True
+
+
+def test_wait_cancelled(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    assert (
+        wait_until_safe(t, s, cancelled=lambda: True, quiesce=30.0) is False
+    )
+
+
+class _StubControl:
+    def __init__(self):
+        self.calls = []
+
+    def terminate(self, soft, **kw):
+        self.calls.append(soft)
+        return "soft"
+
+
+def test_monitor_arm_wait_terminate(tmp_path):
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=None,
+                    sentinel=tmp_path / "s.turn")
+    m.start()
+    assert m.armed() is False
+    m.flip_pressed()                 # idle (no files) -> fires immediately
+    deadline = time.time() + 3
+    while not m.flip_requested and time.time() < deadline:
+        time.sleep(0.05)
+    m.stop()
+    assert m.flip_requested is True
+    assert m.how == "soft"
+    assert control.calls == [[b"\x04"]]
+
+
+def test_monitor_toggle_cancels(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())           # mid-turn: monitor will block
+    _touch(s, time.time() - 30)
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=t, sentinel=s)
+    m.start()
+    m.flip_pressed()
+    time.sleep(0.1)
+    assert m.armed() is True
+    m.flip_pressed()                 # toggle: cancel
+    time.sleep(0.3)
+    assert m.armed() is False
+    assert m.flip_requested is False
+    m.stop()
+    assert control.calls == []
+
+
+def test_monitor_stop_unblocks_cleanly(tmp_path):
+    m = FlipMonitor(_StubControl(), [b"\x04"], transcript=None,
+                    sentinel=tmp_path / "s.turn")
+    m.start()
+    m.stop()                         # never armed: must not hang or fire
+    assert m.flip_requested is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_runner.py -v -k "wait or monitor"`
+Expected: FAIL — `ImportError: cannot import name 'FlipMonitor'`
+
+- [ ] **Step 3: Implement**
+
+Add to `src/tandem/runner.py` (after `ctx_to_cursor`; `time`, `threading`, `Path` already imported):
+
+```python
+def _mtime(path: Path | None) -> float:
+    if path is None:
+        return 0.0
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def wait_until_safe(
+    transcript: Path | None,
+    sentinel: Path | None,
+    cancelled,
+    quiesce: float = 2.0,
+    poll: float = 0.2,
+) -> bool:
+    """Block until the turn boundary. The transcript's last append lands
+    before the Stop hook / notify touches the sentinel, so idle means the
+    sentinel is at least as new as the transcript; otherwise wait for the
+    marker touch, with transcript quiescence as the marker-less fallback.
+    Returns False if `cancelled()` turned true first."""
+    while True:
+        if cancelled():
+            return False
+        t, s = _mtime(transcript), _mtime(sentinel)
+        if s >= t:
+            return True
+        if time.time() - t >= quiesce:
+            return True
+        time.sleep(poll)
+
+
+class FlipMonitor:
+    """Owns the flip lifecycle: the armed flag (toggle to cancel), the
+    turn-boundary wait, and the termination ladder through the PtyControl.
+    One background thread; all public methods are thread-safe."""
+
+    def __init__(self, control, quit_bytes: list[bytes],
+                 transcript: Path | None, sentinel: Path):
+        self.control = control
+        self.quit_bytes = quit_bytes
+        self.transcript = transcript
+        self.sentinel = sentinel
+        self.flip_requested = False
+        self.how = ""
+        self._armed = threading.Event()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name="tandem-flip", daemon=True
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._armed.set()  # unblock the wait
+        self._thread.join(timeout=15)
+
+    def flip_pressed(self) -> None:
+        if self._armed.is_set():
+            self._armed.clear()  # toggle: cancel a pending flip
+        else:
+            self._armed.set()
+
+    def armed(self) -> bool:
+        return self._armed.is_set() and not self.flip_requested
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._armed.wait()
+            if self._stop.is_set():
+                return
+            ok = wait_until_safe(
+                self.transcript,
+                self.sentinel,
+                cancelled=lambda: (
+                    not self._armed.is_set() or self._stop.is_set()
+                ),
+            )
+            if self._stop.is_set():
+                return
+            if not ok:
+                continue  # cancelled: back to waiting for the next arm
+            self.flip_requested = True
+            self.how = self.control.terminate(self.quit_bytes)
+            return
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_runner.py -v`
+Expected: all PASS (the mid-turn test takes ~1 s by design).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/runner.py tests/test_runner.py
+git commit -m "feat: FlipMonitor — armed flag, turn-boundary wait, termination ladder"
+```
+
+---
+
+### Task 9: Wire the frame into InteractiveRunner
+
+**Files:**
+- Modify: `src/tandem/runner.py` (`InteractiveRunner.run`, ~lines 176–261; new imports `load_frame_config` from `.config`, `FrameIO`, `PtyControl` from `.ptyrun`)
+- Test: `tests/test_runner.py` (append)
+
+**Interfaces:**
+- Consumes: Task 1 `load_frame_config()`, Task 6 `FrameIO`/`run_in_pty(frame=, control=)`, Task 5 `PtyControl`, Task 7 `adapter.quit_keystrokes()`, Task 8 `FlipMonitor`.
+- Produces: `InteractiveRunner.run() -> int` unchanged in return type, plus a new attribute set before returning: `self.flip_requested: bool`. On bar drop, a marker file `paths.tandem_home() / "tmp" / f"{tandem_id}-bar-dropped"` and a stderr-style note after exit. Task 10 consumes `flip_requested`; Task 11 (doctor) consumes the marker file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_runner.py` (reusing the file's `_Sink` and `env_factory`; note the existing `_run_capturing_argv` monkeypatches `run_in_pty` with `lambda argv, cwd=None: ...` — those tests keep passing because the new params have defaults and `InteractiveRunner` passes them by keyword; update that lambda to `lambda argv, cwd=None, **kw: ...` only if the run below shows otherwise):
+
+```python
+def test_runner_passes_frame_and_control(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+    seen = {}
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        seen.update(frame=frame, control=control)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    r = runner.InteractiveRunner(env.session, lambda st, se, so: _Sink())
+    code = r.run()
+    assert code == 0
+    assert seen["control"] is not None
+    frame = seen["frame"]
+    assert frame is not None
+    assert frame.flip_byte == 0x1D
+    assert frame.active == "claude" and frame.other == "codex"
+    assert r.flip_requested is False
+
+
+def test_runner_reports_flip_requested(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        frame.on_flip()  # user pressed the keybind; idle -> fires
+        deadline = time.time() + 3
+        while not frame.armed() and time.time() < deadline:
+            time.sleep(0.02)
+        # the monitor's ladder finds no real child: control.terminate
+        # returns "dead", flip_requested still set
+        deadline = time.time() + 3
+        while frame.armed() and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    r = runner.InteractiveRunner(env.session, lambda st, se, so: _Sink())
+    r.run()
+    assert r.flip_requested is True
+
+
+def test_runner_writes_bar_drop_marker(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        frame.bar_dropped = True
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    marker = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-bar-dropped"
+    assert marker.exists()
+```
+
+Add `import time` to the test file's imports if Task 8 didn't already.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_runner.py -v`
+Expected: the three new tests FAIL (`run_in_pty` called without `frame=`/`control=` kwargs → `seen` empty / no `flip_requested` attribute). Pre-existing tests must still pass; if any fail on the changed call signature, fix them per the note in Step 1.
+
+- [ ] **Step 3: Implement**
+
+In `InteractiveRunner.run()`:
+
+Imports at module top: `from .config import load_frame_config, load_harness_args` (extend the existing import), `from .ptyrun import FrameIO, PtyControl, run_in_pty` (extend).
+
+After the `argv` lines (`argv += adapter.hook_argv_extra(sentinel)`) and before `stop = threading.Event()`:
+
+```python
+        frame_cfg = load_frame_config()
+        control = PtyControl()
+        monitor = FlipMonitor(
+            control, adapter.quit_keystrokes(), transcript, sentinel
+        )
+        frame = FrameIO(
+            flip_byte=frame_cfg.flip_byte,
+            on_flip=monitor.flip_pressed,
+            armed=monitor.armed,
+            bar=frame_cfg.bar,
+            active=active,
+            other=session.shadow,
+        )
+        self.flip_requested = False
+```
+
+Change the `run_in_pty` call and the `finally`:
+
+```python
+        thread = threading.Thread(target=tail_thread, name="tandem-tail", daemon=True)
+        thread.start()
+        monitor.start()
+        try:
+            code = run_in_pty(argv, cwd=session.cwd, frame=frame, control=control)
+        finally:
+            stop.set()
+            monitor.stop()
+            thread.join(timeout=10)
+            sentinel.unlink(missing_ok=True)
+            self.flip_requested = monitor.flip_requested
+        if frame.bar_dropped:
+            marker = paths.tandem_home() / "tmp" / f"{session.tandem_id}-bar-dropped"
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch()
+            errors.append(
+                "status bar disabled for this session (terminal conflict);"
+                " set [frame] bar = false to silence"
+            )
+        for err in errors:
+            print(f"tandem: sync error: {err}")
+        return code
+```
+
+(The existing `for err in errors:` block moves after the bar-drop check; the message prefix stays as-is — one shared reporting path.)
+
+Also set `self.flip_requested = False` in `__init__` so the attribute exists even if `run()` raises early.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_runner.py -v`
+Expected: all PASS, including the pre-existing argv tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/runner.py tests/test_runner.py
+git commit -m "feat: InteractiveRunner wires the frame — flip monitor, control, bar-drop marker"
+```
+
+---
+
+### Task 10: Auto-flip in shell.run_shell
+
+**Files:**
+- Modify: `src/tandem/shell.py` (`run_shell`, `_switch`, `_enter`; add `_flip_loop`, `_norm`, `_clear_screen`; add `import sys`)
+- Test: `tests/test_shell.py` (append)
+
+**Interfaces:**
+- Consumes: `run_harness(session)` now returns `int` **or** `(code: int, flip: bool)`. The real closure (built inside `run_shell` when `run_harness is None`) returns `(runner.run(), runner.flip_requested)`. Test seams passing plain ints keep working via `_norm`.
+- Produces: `_enter(...) -> tuple[int, bool]` and `_switch(...) -> tuple[int, bool]` (both previously returned `int`); `_flip_loop(tandem_id, run_harness, first: tuple[int, bool]) -> int` — flips repeatedly, no prompt stop, screen cleared between; `run_shell` signature unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_shell.py` (mirror the file's existing fake-`run_harness`/`input_fn` idiom — read its first test and reuse the same session/store setup helper it uses):
+
+```python
+from tandem import shell
+
+
+def test_flip_reenters_other_harness_without_prompt(shell_env):
+    # shell_env: use the same fixture/helper the file's existing tests use
+    # to get (tandem_id, store) with a paired session; adapt the name.
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        if len(calls) == 1:
+            return (0, True)     # user pressed Ctrl-]
+        return (0, False)        # then exited normally
+
+    prompts = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        raise EOFError           # leave the shell at the first prompt
+
+    code = shell.run_shell(
+        shell_env.tandem_id, sink_factory=None,
+        input_fn=input_fn, run_harness=run_harness,
+    )
+    assert code == 0
+    assert calls == ["claude", "codex"]      # flip switched roles, no prompt between
+    assert len(prompts) == 1                 # prompt only after the plain exit
+
+
+def test_flip_failure_falls_back_to_prompt(shell_env, monkeypatch):
+    # ops.switch_session raising must not lose the session: back to prompt
+    def run_harness(session):
+        return (0, True)
+
+    def boom(store, session):
+        raise RuntimeError("no flip for you")
+
+    monkeypatch.setattr(shell.ops, "switch_session", boom)
+
+    def input_fn(prompt):
+        raise EOFError
+
+    code = shell.run_shell(
+        shell_env.tandem_id, sink_factory=None,
+        input_fn=input_fn, run_harness=run_harness,
+    )
+    assert code == 0             # carried through; session intact at prompt
+
+
+def test_int_returning_run_harness_still_works(shell_env):
+    # legacy seam: plain int means no flip
+    def run_harness(session):
+        return 7
+
+    def input_fn(prompt):
+        raise EOFError
+
+    code = shell.run_shell(
+        shell_env.tandem_id, sink_factory=None,
+        input_fn=input_fn, run_harness=run_harness,
+    )
+    assert code == 7
+```
+
+`shell_env` above is a stand-in name: `tests/test_shell.py` already constructs paired sessions for `run_shell` tests — use its existing fixture or setup helper verbatim. Do not invent a new fixture if one exists.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_shell.py -v -k flip`
+Expected: FAIL — with a tuple return, current `run_shell` treats `(0, True)` as the exit code (type error or wrong assertion), and no re-enter happens.
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/shell.py` (add `import sys` at top):
+
+```python
+def _norm(res) -> tuple[int, bool]:
+    """run_harness returns int (legacy and test seams) or (code, flip)."""
+    return res if isinstance(res, tuple) else (res, False)
+
+
+def _clear_screen() -> None:
+    if sys.stdout.isatty():  # pragma: no cover - interactive only
+        sys.stdout.write("\x1b[2J\x1b[H")
+        sys.stdout.flush()
+
+
+def _flip_loop(tandem_id: str, run_harness, first: tuple[int, bool]) -> int:
+    """Keep flipping (Ctrl-]) until a session ends without requesting one.
+    No prompt stop between flips — this is the frame's tab feel."""
+    code, flip = first
+    while flip:
+        _clear_screen()
+        code, flip = _switch(tandem_id, run_harness, code)
+    return code
+```
+
+Change `_enter` to return `(code, flip)`:
+
+```python
+def _enter(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
+    """Run the active harness; returns (exit code, flip requested). A
+    failed launch (or a vanished session row) is reported and `code` is
+    carried forward with no flip, so the caller returns to the prompt
+    instead of losing the session."""
+    try:
+        with StateStore() as store:
+            session = store.get_session(tandem_id)
+            if session is None:
+                raise LookupError(f"session {tandem_id} is not in the state store")
+            store.touch_used(tandem_id)
+        return _norm(run_harness(session))
+    except Exception as exc:
+        click.secho(
+            f"could not run the harness: {type(exc).__name__}: {exc}",
+            fg="red",
+            err=True,
+        )
+        return code, False
+```
+
+Change `_switch` the same way — its failure paths become `return code, False`, and its success tail becomes `return _enter(tandem_id, run_harness, code)` (unchanged text, now propagating the tuple).
+
+In `run_shell`, update the three call sites:
+
+- initial entry: `code = _flip_loop(tandem_id, run_harness, _enter(tandem_id, run_harness, code))`
+- the `"" | "resume"` branch: same `_flip_loop(...)` form
+- the `["switch"]` branch: `code = _flip_loop(tandem_id, run_harness, _switch(tandem_id, run_harness, code))`
+
+Update the default `run_harness` closure at the top of `run_shell`:
+
+```python
+        def run_harness(session):
+            from .runner import InteractiveRunner
+
+            r = InteractiveRunner(session, sink_factory=sink_factory)
+            return r.run(), r.flip_requested
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_shell.py -v`
+Expected: all PASS — the new flip tests and every pre-existing `run_shell` test (they pass ints through the seam; `_norm` keeps their meaning).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/shell.py tests/test_shell.py
+git commit -m "feat: shell auto-flip — Ctrl-] re-enters the other harness without a prompt stop"
+```
+
+---
+
+### Task 11: Doctor surfaces bar drops
+
+**Files:**
+- Modify: `src/tandem/doctor.py` (inside `run_doctor`, with the other per-session checks)
+- Test: `tests/test_memory_doctor.py` (append — doctor tests live here)
+
+**Interfaces:**
+- Consumes: the marker file Task 9 writes: `paths.tandem_home() / "tmp" / f"{session.tandem_id}-bar-dropped"`.
+- Produces: a `report.warn(...)` when the marker exists.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_memory_doctor.py` (reuse the file's existing doctor-report fixture/setup idiom for a paired session):
+
+```python
+def test_doctor_warns_on_bar_drop_marker(doctor_env):
+    # doctor_env: whatever existing fixture yields (store, session) for
+    # run_doctor tests in this file — reuse it verbatim.
+    from tandem import paths
+    from tandem.doctor import run_doctor
+
+    store, session = doctor_env
+    marker = paths.tandem_home() / "tmp" / f"{session.tandem_id}-bar-dropped"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.touch()
+    report = run_doctor(store, session)
+    assert any(
+        c.status == "warn" and "status bar" in c.msg for c in report.checks
+    )
+
+
+def test_doctor_quiet_without_bar_drop_marker(doctor_env):
+    from tandem.doctor import run_doctor
+
+    store, session = doctor_env
+    report = run_doctor(store, session)
+    assert not any("status bar" in c.msg for c in report.checks)
+```
+
+(Check the actual `Check` field name for the message — `msg` vs `message` — in `doctor.py` ~line 130 and match it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_memory_doctor.py -v -k bar_drop`
+Expected: FAIL — no such warning is produced.
+
+- [ ] **Step 3: Implement**
+
+In `run_doctor` (with the other session-scoped checks), add:
+
+```python
+    marker = paths.tandem_home() / "tmp" / f"{session.tandem_id}-bar-dropped"
+    if marker.exists():
+        report.warn(
+            "the status bar was auto-disabled in a previous session"
+            " (terminal conflict) — set [frame] bar = false to keep it off,"
+            " or delete the marker to retry: " + str(marker)
+        )
+```
+
+Import `paths` if `doctor.py` doesn't already.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_memory_doctor.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/doctor.py tests/test_memory_doctor.py
+git commit -m "feat: doctor warns when the status bar was auto-disabled"
+```
+
+---
+
+### Task 12: Docs — the inverted story
+
+**Files:**
+- Modify: `README.md` (Why tandem / quick-start area)
+- Modify: `docs/how-it-works.md` (new "The frame" bullet in the mechanics list)
+- Modify: `docs/configuration.md` (new `[frame]` section)
+
+**Interfaces:** none — prose only. Match each file's existing voice (short bullets, bold leads, no marketing fluff beyond the README's established tone).
+
+- [ ] **Step 1: README**
+
+Add a frame-led bullet to the "Why tandem?" section (place it first) and update the quick-start to lead with the frame experience:
+
+```markdown
+### 🖥️ One CLI, two harnesses, zero ceremony.
+
+`tandem` is the terminal you live in. It fronts the real Claude Code or
+Codex TUI — pixel-for-pixel native — and **Ctrl-]** flips to the other
+one in a couple of seconds, same conversation, same files, same history.
+A one-line tab bar on the bottom row shows which model you're facing;
+everything above it is the untouched native UI.
+```
+
+And in the how-you-use-it flow, replace the exit-then-`switch` framing with: work → `Ctrl-]` → keep working, noting that the tandem prompt still exists on plain exit and `switch` still works there.
+
+- [ ] **Step 2: docs/how-it-works.md**
+
+Add one bullet to the top mechanics list, after "A persistent prompt, not the OS shell":
+
+```markdown
+- **The frame: flip without leaving.** Ctrl-] (configurable, consumed at
+  the PTY layer, ignored inside bracketed paste) flips the screen to the
+  other harness: pressed mid-turn it arms and fires at the turn-complete
+  marker (press again to cancel — the bar shows the armed state), then
+  tandem exits the fronted CLI gracefully (quit keystrokes, then SIGTERM,
+  then a bounded SIGKILL), lets the incremental sync settle, flips roles,
+  and resumes the other side. The bottom terminal row is tandem's one
+  drawn pixel: the child is told the terminal is a row shorter, a scroll
+  region keeps output above the bar, and a targeted watcher reasserts it
+  after child screen resets. If a terminal can't sustain the bar it drops
+  for the session (the flip keeps working) and `tandem doctor` says so.
+```
+
+- [ ] **Step 3: docs/configuration.md**
+
+Add:
+
+```markdown
+## [frame]
+
+| key | default | meaning |
+| --- | --- | --- |
+| `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). |
+| `bar` | `true` | The one-line tab bar on the bottom terminal row. `false` hides it; the flip still works. |
+```
+
+- [ ] **Step 4: Proofread render**
+
+Run: `uv run python -c "print(open('README.md').read()[:2000])"` — or just re-read the three diffs. Check: no stale exit-then-switch instructions contradicting the frame story anywhere in the three files (`grep -n "switch" README.md docs/how-it-works.md docs/configuration.md`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/how-it-works.md docs/configuration.md
+git commit -m "docs: the frame — tandem as the CLI you launch, Ctrl-] flips models"
+```
+
+---
+
+### Task 13: Live validation (operator-run)
+
+**Files:** none (manual checklist; fixes discovered here become new commits on this branch)
+
+This is the release gate. Run in a scratch repo with a real paired session (`tandem` in a fresh directory), on at least two of: Terminal.app, iTerm2, VS Code terminal.
+
+- [ ] Flip claude → codex while idle: lands in codex within ~3 s, history present, bar shows `codex ●`.
+- [ ] Flip codex → claude while idle: same, reversed.
+- [ ] Press Ctrl-] mid-turn (while the model is generating): bar shows `⏳ flipping at turn end…`; flip fires only after the turn completes; the completed turn is present on the other side.
+- [ ] Press Ctrl-] mid-turn, then Ctrl-] again: armed indicator clears, no flip happens.
+- [ ] Paste a text blob containing a literal Ctrl-] byte (e.g. `printf 'a\x1db' | pbcopy`, then paste in the composer): no flip, the paste arrives intact.
+- [ ] Quit-recipe verification (spec: pinned per harness version): confirm the soft rung actually exits each CLI — flip and check the runner reports/behaves as a graceful exit (no SIGTERM needed). If a recipe fails, fix `quit_keystrokes()` for that adapter and note the CLI version in the commit message.
+- [ ] Bar under stress: resize the window (bar repaints, no child misrender), scroll a long output (bar stays pinned), open something alt-screen from inside the harness if available (bar survives or drops gracefully).
+- [ ] `[frame] bar = false`: no bar, flip still works.
+- [ ] `[frame] flip_key = "ctrl-t"`: Ctrl-T flips, Ctrl-] types through.
+- [ ] Resume-failure fallback: temporarily break the shadow CLI (`PATH` without codex), flip — tandem relaunches the harness you left and reports the problem; session intact.
+- [ ] Plain exit (Ctrl-D at empty composer): still lands at the `tandem (active)>` prompt; `switch`, `status`, `exit` all behave as before.
+- [ ] Non-frame surfaces unaffected: `tandem run --on codex "..."` one-shot works; a plain `claude` launched outside tandem is untouched by any of this.
+
+Record results (terminal app + CLI versions tested) in the PR description.
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** frame behavior (Tasks 6, 8–10), detector edges incl. paste + config override (Tasks 1, 2), bar + reserved row + guard + auto-drop (Tasks 3, 4, 6), termination ladder (Tasks 5, 7), turn-boundary + cancel toggle (Task 8), never-lose-the-session (Task 10 failure test), doctor note (Task 11), README/docs reframe (Task 12), live validation incl. emulator matrix and quit-recipe pinning (Task 13). Unpaired/plain sessions need no code: the detector only exists under the wrapper.
+- **Placeholder scan:** the two named-fixture stand-ins (`shell_env`, `doctor_env`) are explicit instructions to reuse the file's existing setup idiom, not TBDs; all code blocks are complete.
+- **Type consistency:** `FrameIO` fields match between Tasks 6 and 9; `terminate(soft=list[bytes])` matches `quit_keystrokes() -> list[bytes]`; `_enter`/`_switch` tuple returns consistent across Task 10's call sites; marker-file path identical in Tasks 9 and 11.

--- a/docs/plans/2026-08-09-meta-harness-frame.md
+++ b/docs/plans/2026-08-09-meta-harness-frame.md
@@ -1823,6 +1823,38 @@ Run these in addition to the checklist above:
 - [ ] Marker-less fresh codex (user-owned `notify`): flip armed in the first second of the session may fire early until the rollout is discovered — confirm the window is imperceptible in practice.
 - [ ] Note: the pump loop below the tty check has no automated coverage by design (pytest has no tty) — live validation is this code's only integration test.
 
+## Task 13 live-validation results — 2026-08-09, Cursor terminal, codex 0.147.0
+
+The merge-blocker item fired on first contact, and root-caused to two frame
+bugs plus one compat break (session `dbce59329de6`/`05bec5f70889` forensics):
+
+- **Flip key dead under codex (fixed).** codex's TUI queries the kitty
+  keyboard protocol (`\x1b[?u`) and pushes enhancement flags (`\x1b[>7u`)
+  when the terminal supports them — the Cursor terminal does. From then on
+  Ctrl-] arrives as CSI-u (`\x1b[93;5u`), never as the raw 0x1D byte, so the
+  detector never saw it: flips *out of claude* worked, flips *out of codex*
+  were silently dead. `FlipDetector` now recognizes the CSI-u spelling of
+  the configured flip key (press + repeat count, release swallowed, lock
+  modifiers tolerated, other chords on the same key forwarded).
+- **Bar killed by a benign scroll region (fixed).** codex asserts
+  `\x1b[1;<rows-2>r` at TUI startup to guard its composer rows. The
+  "parameterized DECSTBM ⇒ drop" rule read that as a terminal conflict and
+  tore the bar down instantly — the bar could never survive a codex phase.
+  `OutputGuard` now judges a region by its bottom edge against the real
+  terminal height: above the bar row is benign (`child_owns_region` keeps
+  repaints from stomping the child's region), reaching the bar row or
+  defaulting to full height still drops.
+- **codex 0.147 stores sessions in sqlite (OPEN compat break).** The live
+  codex holds no rollout JSONL open; threads live in
+  `~/.codex/state_5.sqlite` (`thread_sections` et al.) and a fresh 0.147
+  session writes no rollout file at all. Tandem's codex tailer/sync is
+  blind against it, and turn-boundary quiescence on a never-touched rollout
+  is trivially "idle" (a flip can fire mid-turn on marker-less codex
+  sessions). Needs its own design pass; not a frame bug.
+- Also observed: `codex resume <id>` of a tandem-seeded JSONL rollout still
+  launches and runs on 0.147 (the model_provider seed field holds up), but
+  nothing is appended back to the rollout.
+
 ## Post-merge follow-ups (from review triage; none block merge)
 
 flip_key denylist for Tab/Enter/Esc collisions; pin the `bar_row` writable contract and the config→FrameIO seam with tests; carry-truncation test filler byte; `\x1b[0m` prefix before the bar's SGR; `time.monotonic()` in `_wait_dead`; EIO guard on the pump's stdin read; post-wait armed re-check (cancel TOCTOU); bound the flip-loop test fakes; extract `paths.bar_drop_marker()`; tail-join timeout vs `switch_session` drain lock (pre-existing); `docs/formats.md` cross-check next release.

--- a/docs/plans/2026-08-10-idle-flip-status-probe.md
+++ b/docs/plans/2026-08-10-idle-flip-status-probe.md
@@ -1,0 +1,594 @@
+# Idle Flip via Claude Session-Status Probe — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pressing the flip key while claude sits idle flips immediately, by reading claude's own per-session status registry instead of inferring turn state from file mtimes.
+
+**Architecture:** Claude 2.1.226 maintains `~/.claude/sessions/<pid>.json` — one file per live session with `sessionId` and `status: "busy" | "waiting"`, rewritten on transitions (it is the data `claude agents --json` prints). A new adapter method scans that registry by session id (tandem mints claude session ids, so it always knows the key), skipping entries whose pid is dead. When claude is the active harness, `wait_until_safe` consults this probe as the **entire** turn-boundary test — replacing both the sentinel-vs-transcript mtime comparison and the 120s valve, which are broken for claude because modern claude appends housekeeping to the transcript between turns (`away_summary` minutes after Stop, mtime bumps on resume). Codex keeps the existing logic untouched.
+
+**Tech Stack:** Python 3.11+ stdlib only (json, os, pathlib). Tests: pytest via the repo venv.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-idle-flip-status-probe.md` (untracked — `docs/superpowers/` is gitignored).
+
+## Global Constraints
+
+- Work directly on branch `meta-harness-frame`. The working tree carries **unrelated uncommitted PR #36 fixes** in `src/tandem/frame.py`, `src/tandem/harness/codex.py`, `src/tandem/ptyrun.py`, `tests/test_frame.py`, `tests/test_ptyrun.py`, `docs/plans/2026-08-09-meta-harness-frame.md`. NEVER run `git add -A`, `git add .`, or `git commit -a`; stage only the explicit paths each commit step lists.
+- Single tier (operator decision): when the probe is wired, its verdict is final. `"busy"` waits; **anything else — `"waiting"`, no matching entry, unreadable file, unknown status — flips immediately.** No fallback to mtime logic, no valve. Eager failure on registry schema drift is accepted ("if it breaks we'll fix it later").
+- Codex flip behavior must be byte-identical: every existing test in `tests/test_runner.py` stays green unmodified.
+- The Stop hook / sentinel wiring is untouched — the transcript tailer uses the sentinel as its wake signal.
+- Run tests with `.venv/bin/python -m pytest` (system python lacks the project deps).
+
+## File Structure
+
+- `src/tandem/paths.py` — add `claude_sessions_dir()` (registry location, `CLAUDE_CONFIG_DIR`-aware like every other helper here).
+- `src/tandem/harness/claude_code.py` — add module-level `_pid_alive()` and `ClaudeCodeAdapter.session_status()`. Adapter owns format knowledge; the runner never parses registry JSON.
+- `src/tandem/runner.py` — `wait_until_safe` and `FlipMonitor` gain an optional `status_probe`; `InteractiveRunner.run()` wires it for claude only.
+- `tests/test_runner.py` — all new tests live here, beside the existing wait/monitor/wiring tests they imitate.
+- `docs/how-it-works.md` — the frame bullet describes the new claude boundary test.
+
+---
+
+### Task 1: Registry probe on the claude adapter
+
+**Files:**
+- Modify: `src/tandem/paths.py` (after `claude_installed_plugins_path`, ~line 56)
+- Modify: `src/tandem/harness/claude_code.py` (imports ~line 13; new code after `quit_keystrokes`, ~line 130)
+- Test: `tests/test_runner.py` (append at end)
+
+**Interfaces:**
+- Produces: `paths.claude_sessions_dir() -> Path`; `ClaudeCodeAdapter.session_status(session_id: str) -> str | None`; module function `claude_code._pid_alive(pid: int) -> bool` (monkeypatch seam for tests).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_runner.py`:
+
+```python
+# ---- claude session-status probe -------------------------------------------
+
+
+def _registry(tmp_path, monkeypatch, entries):
+    """Fake ~/.claude/sessions with the given {filename: dict-or-raw} files."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    d = tmp_path / ".claude" / "sessions"
+    d.mkdir(parents=True)
+    for name, entry in entries.items():
+        text = entry if isinstance(entry, str) else json.dumps(entry)
+        (d / name).write_text(text)
+    return d
+
+
+_SID = "11111111-1111-4111-8111-111111111111"
+
+
+def _claude_adapter():
+    from tandem.harness import get_adapter
+    return get_adapter("claude")
+
+
+def test_pid_alive_own_pid():
+    from tandem.harness.claude_code import _pid_alive
+    assert _pid_alive(os.getpid()) is True
+
+
+def test_session_status_reads_busy_and_waiting(tmp_path, monkeypatch):
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "busy"},
+    })
+    assert _claude_adapter().session_status(_SID) == "busy"
+    _registry(tmp_path.joinpath("b"), monkeypatch, {
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting",
+                       "waitingFor": "input needed"},
+    })
+    assert _claude_adapter().session_status(_SID) == "waiting"
+
+
+def test_session_status_none_when_no_match(tmp_path, monkeypatch):
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        f"{me}.json": {"pid": me, "sessionId": "someone-else", "status": "busy"},
+    })
+    assert _claude_adapter().session_status(_SID) is None
+
+
+def test_session_status_none_when_dir_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    assert _claude_adapter().session_status(_SID) is None
+
+
+def test_session_status_skips_stale_dead_pid_entry(tmp_path, monkeypatch):
+    # A crashed run of this same resumed session leaves a dead-pid file
+    # frozen at "busy"; the live entry must win.
+    from tandem.harness import claude_code
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        "99999.json": {"pid": 99999, "sessionId": _SID, "status": "busy"},
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting"},
+    })
+    monkeypatch.setattr(claude_code, "_pid_alive", lambda pid: pid == me)
+    assert claude_code.ClaudeCodeAdapter().session_status(_SID) == "waiting"
+    # dead-only: no live entry at all reads as no answer
+    monkeypatch.setattr(claude_code, "_pid_alive", lambda pid: False)
+    assert claude_code.ClaudeCodeAdapter().session_status(_SID) is None
+
+
+def test_session_status_busy_wins_among_live_matches(tmp_path, monkeypatch):
+    from tandem.harness import claude_code
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        "11.json": {"pid": 11, "sessionId": _SID, "status": "waiting"},
+        "22.json": {"pid": 22, "sessionId": _SID, "status": "busy"},
+    })
+    monkeypatch.setattr(claude_code, "_pid_alive", lambda pid: True)
+    assert claude_code.ClaudeCodeAdapter().session_status(_SID) == "busy"
+
+
+def test_session_status_tolerates_garbage_files(tmp_path, monkeypatch):
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        "junk.json": "not json{",
+        "list.json": '["not", "a", "dict"]',
+        "nopid.json": {"sessionId": _SID, "status": "busy"},
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting"},
+    })
+    assert _claude_adapter().session_status(_SID) == "waiting"
+```
+
+`tests/test_runner.py` already imports `os`, `time`, `threading`, `runner`, `paths`; add `import json` to its imports if not present.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_runner.py -k "session_status or pid_alive" -v`
+Expected: FAIL/ERROR with `AttributeError: ... no attribute 'session_status'` (and an ImportError on `_pid_alive`).
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/paths.py`, after `claude_installed_plugins_path()`:
+
+```python
+def claude_sessions_dir() -> Path:
+    """Per-live-session registry: <pid>.json with sessionId and
+    status "busy"|"waiting" — the data `claude agents --json` prints
+    (observed: claude 2.1.226). Rewritten by claude on state
+    transitions; stale files linger after a crash."""
+    return claude_home() / "sessions"
+```
+
+In `src/tandem/harness/claude_code.py`: add `import os` to the stdlib imports (alphabetical, before `import uuid as uuidlib`). Then, module-level, above the adapter class:
+
+```python
+def _pid_alive(pid: int) -> bool:
+    """A registry entry for a dead pid is a stale leftover (claude
+    cleans up on exit, not on crash). PermissionError means alive but
+    not ours — still alive; anything else unreadable counts as dead,
+    because trusting a stale entry can freeze the flip on a phantom
+    "busy"."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+```
+
+On `ClaudeCodeAdapter`, after `quit_keystrokes`:
+
+```python
+def session_status(self, session_id: str) -> str | None:
+    """Live turn state from claude's session registry: "busy" while a
+    turn runs, "waiting" at the prompt, None when no live entry
+    matches. The flip wait treats anything but "busy" as flippable
+    (single-tier by spec: eager on schema drift). Matched by
+    sessionId — tandem mints claude session ids — never by pid
+    filename, which a forking wrapper would break. Dead-pid entries
+    are skipped; among several live matches "busy" wins, because
+    flipping kills a live turn while waiting only costs a wait."""
+    try:
+        files = sorted(paths.claude_sessions_dir().glob("*.json"))
+    except OSError:
+        return None
+    statuses: list[str] = []
+    for p in files:
+        try:
+            entry = json.loads(p.read_text())
+        except (OSError, ValueError):
+            continue
+        if not isinstance(entry, dict) or entry.get("sessionId") != session_id:
+            continue
+        pid = entry.get("pid")
+        if not isinstance(pid, int) or not _pid_alive(pid):
+            continue
+        status = entry.get("status")
+        if isinstance(status, str):
+            statuses.append(status)
+    if "busy" in statuses:
+        return "busy"
+    return statuses[0] if statuses else None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_runner.py -k "session_status or pid_alive" -v`
+Expected: 7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/paths.py src/tandem/harness/claude_code.py tests/test_runner.py
+git commit -m "feat: claude session-status probe reads the live registry"
+```
+
+---
+
+### Task 2: The probe replaces the mtime test in the flip wait
+
+**Files:**
+- Modify: `src/tandem/runner.py` (`wait_until_safe` ~line 129; `FlipMonitor.__init__` ~line 221 and `_run` ~line 270)
+- Test: `tests/test_runner.py` (append)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (the probe arrives as a plain callable).
+- Produces: `wait_until_safe(..., status_probe: Callable[[], str | None] | None = None)` — keyword-only position at the end of the signature; `FlipMonitor(..., status_probe=None)` stored as `self.status_probe` and forwarded by `_run`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_runner.py`:
+
+```python
+# ---- status probe replaces the mtime rules ---------------------------------
+
+
+def test_wait_probe_waiting_overrides_busy_mtimes(tmp_path):
+    # transcript newer than sentinel: the mtime rules read mid-turn and
+    # would hold for the 120s valve. The probe says the session is at its
+    # prompt, and the probe is the whole test now.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    assert wait_until_safe(t, s, cancelled=lambda: False, marker_wired=True,
+                           status_probe=lambda: "waiting") is True
+
+
+def test_wait_probe_no_answer_flips_eagerly(tmp_path):
+    # single tier by spec: registry missing/unreadable -> flip now.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    assert wait_until_safe(t, s, cancelled=lambda: False, marker_wired=True,
+                           status_probe=lambda: None) is True
+
+
+def test_wait_probe_busy_blocks_then_releases(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(s, time.time())  # mtime rules would say idle (sentinel newest)
+    _touch(t, time.time() - 30)
+    state = {"status": "busy"}
+    result = {}
+    done = threading.Event()
+
+    def wait():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       marker_wired=True, poll=0.05,
+                                       status_probe=lambda: state["status"])
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    assert not done.wait(timeout=0.4)   # busy verdict outranks idle mtimes
+    state["status"] = "waiting"
+    assert done.wait(timeout=3)
+    assert result["ok"] is True
+
+
+def test_wait_probe_busy_suppresses_valve(tmp_path):
+    # A long-silent tool call: transcript ancient, quiesce tiny — the old
+    # valve would fire and kill the live turn. The probe's "busy" holds.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time() - 3600)
+    _touch(s, time.time() - 7200)
+    state = {"status": "busy"}
+    result = {}
+    done = threading.Event()
+
+    def wait():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       marker_wired=True, quiesce=0.1,
+                                       poll=0.05,
+                                       status_probe=lambda: state["status"])
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    assert not done.wait(timeout=0.5)   # outlives quiesce: no valve
+    state["status"] = "waiting"
+    assert done.wait(timeout=3)
+    assert result["ok"] is True
+
+
+def test_wait_probe_busy_cancel_honored(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    cancel = threading.Event()
+    result = {}
+    done = threading.Event()
+
+    def wait():
+        result["ok"] = wait_until_safe(t, s, cancelled=cancel.is_set,
+                                       marker_wired=True, poll=0.05,
+                                       status_probe=lambda: "busy")
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    assert not done.wait(timeout=0.3)
+    cancel.set()
+    assert done.wait(timeout=3)
+    assert result["ok"] is False
+
+
+def test_monitor_probe_waiting_fires_immediately(tmp_path):
+    # End-to-end through FlipMonitor: mtimes scream mid-turn, probe says
+    # waiting -> the ladder runs. Mirrors test_monitor_arm_wait_terminate.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=t, sentinel=s,
+                    marker_wired=True, poll=0.05,
+                    status_probe=lambda: "waiting")
+    m.start()
+    m.flip_pressed()
+    deadline = time.time() + 3
+    while not m.flip_requested and time.time() < deadline:
+        time.sleep(0.05)
+    m.stop()
+    assert m.flip_requested is True
+    assert m.how == "soft"
+    assert control.calls == [[b"\x04"]]
+```
+
+(`_touch` and `_StubControl` already exist in this file — `_StubControl.terminate` records `soft` in `self.calls` and returns `"soft"`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_runner.py -k probe -v`
+Expected: FAIL with `TypeError: wait_until_safe() got an unexpected keyword argument 'status_probe'`.
+
+- [ ] **Step 3: Implement**
+
+In `src/tandem/runner.py`, `wait_until_safe`: add the parameter after `provider`:
+
+```python
+def wait_until_safe(
+    transcript: Path | None,
+    sentinel: Path | None,
+    cancelled: Callable[[], bool],
+    quiesce: float | None = None,
+    poll: float = 0.2,
+    marker_wired: bool = False,
+    provider: Callable[[], Path | None] | None = None,
+    status_probe: Callable[[], str | None] | None = None,
+) -> bool:
+```
+
+Append to its docstring (after the wall-clock paragraph):
+
+```
+    With `status_probe` (claude sessions), the probe is the entire
+    boundary test and the marker/quiescence rules above never run: the
+    probe reads claude's own session registry, which distinguishes a
+    running turn ("busy") from an idle prompt ("waiting") directly.
+    Anything but "busy" — including no answer at all — flips
+    immediately: single-tier by spec, eager on registry schema drift.
+    The valve is deliberately absent here; it existed to cap a marker
+    that never arrives, and it killed genuinely long turns. The
+    transcript-noise problem this solves: modern claude appends
+    housekeeping (away_summary, last-prompt) minutes after Stop and
+    bumps the transcript mtime on resume, so sentinel >= transcript is
+    false while the session sits idle at its prompt.
+```
+
+Then, at the top of the `while True:` loop, immediately after the `cancelled()` check:
+
+```python
+        if status_probe is not None:
+            if status_probe() == "busy":
+                time.sleep(poll)
+                continue
+            return True
+```
+
+`FlipMonitor.__init__`: add `status_probe=None` after `poll` and store it:
+
+```python
+    def __init__(self, control, quit_bytes: list[bytes],
+                 transcript: Path | None, sentinel: Path,
+                 marker_wired: bool = False,
+                 quiesce: float | None = None, poll: float = 0.2,
+                 status_probe: Callable[[], str | None] | None = None):
+```
+
+with `self.status_probe = status_probe` beside the other assignments, and in `_run`, pass it through:
+
+```python
+            ok = wait_until_safe(
+                self.transcript,
+                self.sentinel,
+                cancelled=lambda: (
+                    not self._armed.is_set() or self._stop.is_set()
+                ),
+                quiesce=self.quiesce,
+                poll=self.poll,
+                marker_wired=self.marker_wired,
+                provider=lambda: self.transcript,
+                status_probe=self.status_probe,
+            )
+```
+
+Append one line to the `FlipMonitor` class docstring:
+
+```
+    `status_probe` (claude only) reads the harness's own session
+    registry and, when present, replaces the transcript/sentinel rules
+    entirely — see `wait_until_safe`.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_runner.py -v`
+Expected: all new `probe` tests PASS **and every pre-existing test still passes** (codex path untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tandem/runner.py tests/test_runner.py
+git commit -m "feat: status probe replaces the mtime idle test in the flip wait"
+```
+
+---
+
+### Task 3: Runner wiring and docs
+
+**Files:**
+- Modify: `src/tandem/runner.py` (`InteractiveRunner.run`, the `FlipMonitor(...)` construction, ~line 417)
+- Modify: `docs/how-it-works.md` (frame bullet, ~lines 20–33)
+- Test: `tests/test_runner.py` (append)
+
+**Interfaces:**
+- Consumes: `adapter.session_status(session_id)` (Task 1), `FlipMonitor(..., status_probe=...)` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_runner.py` (mirrors `test_runner_publishes_the_discovered_codex_rollout_to_the_monitor`; `_Sink` already exists in this file):
+
+```python
+def test_runner_wires_status_probe_for_claude(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["kw"] = kw
+        return real(*a, **kw)
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    probe = made["kw"]["status_probe"]
+    assert probe is not None
+    # the probe closes over the claude sid: feed the registry and ask it
+    me = os.getpid()
+    d = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "sessions"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{me}.json").write_text(json.dumps(
+        {"pid": me, "sessionId": env.session.claude_session_id,
+         "status": "busy"}))
+    assert probe() == "busy"
+
+
+def test_runner_wires_no_probe_for_codex(env_factory, monkeypatch):
+    env = env_factory(active="codex")
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["kw"] = kw
+        return real(*a, **kw)
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    assert made["kw"]["status_probe"] is None
+```
+
+`tests/test_runner.py` must import `Path` (`from pathlib import Path`) — add if absent.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_runner.py -k wires -v`
+Expected: FAIL with `KeyError: 'status_probe'` (runner never passes it yet).
+
+- [ ] **Step 3: Implement the wiring**
+
+In `InteractiveRunner.run()`, replace the `FlipMonitor(...)` construction:
+
+```python
+        monitor = FlipMonitor(
+            control, adapter.quit_keystrokes(), transcript, sentinel,
+            marker_wired=bool(hook_extra),
+            # claude only: codex has no session registry, and a probe that
+            # answers None would flip eagerly mid-turn — absence, not None
+            # answers, is how codex opts out.
+            status_probe=(
+                (lambda: adapter.session_status(active_sid))
+                if active == "claude" else None
+            ),
+        )
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `.venv/bin/python -m pytest`
+Expected: everything passes (the dirty PR #36 working-tree files pair with their own updated tests; do not touch them).
+
+- [ ] **Step 5: Update docs/how-it-works.md**
+
+Two edits in the frame bullet. First:
+
+old:
+```
+  other harness: pressed mid-turn it arms and fires at the turn-complete
+  marker (press again to cancel — the bar shows the armed state), then
+```
+new:
+```
+  other harness: pressed mid-turn it arms and fires at the turn boundary
+  (press again to cancel — the bar shows the armed state), then
+```
+
+Second:
+
+old:
+```
+  Where no marker could be wired (codex with a `notify` handler of your
+  own, which tandem won't clobber) ~2s of transcript quiescence stands in;
+  where one was wired, a 120s valve covers a marker that never arrives —
+  far above any plausible tool-call silence, because firing early kills a
+  live turn while firing late only costs a wait (and Ctrl-] cancels). The
+```
+new:
+```
+  With claude fronted, the boundary comes from claude's own session
+  registry (`~/.claude/sessions/<pid>.json`, the data `claude agents
+  --json` prints): `busy` holds the flip, anything else fires it — so an
+  idle prompt flips instantly even though claude keeps appending
+  housekeeping to its transcript between turns. With codex fronted the
+  transcript-marker rules stand: where no marker could be wired (codex
+  with a `notify` handler of your own, which tandem won't clobber) ~2s of
+  transcript quiescence stands in; where one was wired, a 120s valve
+  covers a marker that never arrives — far above any plausible tool-call
+  silence, because firing early kills a live turn while firing late only
+  costs a wait (and Ctrl-] cancels). The
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tandem/runner.py tests/test_runner.py docs/how-it-works.md
+git commit -m "feat: runner wires the claude status probe into the flip"
+```
+
+---
+
+## Live validation checklist (operator, real terminal — after implementation)
+
+- [ ] Flip while typing mid-session, minutes after a completed turn (the `away_summary` window): flips instantly.
+- [ ] Flip immediately after launch/resume with nothing submitted: flips instantly.
+- [ ] Flip mid-turn (model generating): bar shows armed state, flip fires at turn end.
+- [ ] Flip while a permission dialog is open: record observed `status`/`waitingFor` in the registry file and decide whether abandoning the in-flight tool call is acceptable.
+- [ ] Second flip-key press while armed still cancels.

--- a/docs/plans/2026-08-10-idle-flip-status-probe.md
+++ b/docs/plans/2026-08-10-idle-flip-status-probe.md
@@ -592,3 +592,4 @@ git commit -m "feat: runner wires the claude status probe into the flip"
 - [ ] Flip mid-turn (model generating): bar shows armed state, flip fires at turn end.
 - [ ] Flip while a permission dialog is open: record observed `status`/`waitingFor` in the registry file and decide whether abandoning the in-flight tool call is acceptable.
 - [ ] Second flip-key press while armed still cancels.
+- [ ] After an instant idle flip, the other side has the complete last turn. (The old sentinel rule was ordered-by-construction — Stop fired after the final transcript append; `status: "waiting"` carries no such ordering guarantee. The graceful quit plus the tail thread's final drain should cover it; confirm live.)

--- a/docs/plans/2026-08-10-idle-flip-status-probe.md
+++ b/docs/plans/2026-08-10-idle-flip-status-probe.md
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- Work directly on branch `meta-harness-frame`. The working tree carries **unrelated uncommitted PR #36 fixes** in `src/tandem/frame.py`, `src/tandem/harness/codex.py`, `src/tandem/ptyrun.py`, `tests/test_frame.py`, `tests/test_ptyrun.py`, `docs/plans/2026-08-09-meta-harness-frame.md`. NEVER run `git add -A`, `git add .`, or `git commit -a`; stage only the explicit paths each commit step lists.
+- Work directly on branch `meta-harness-frame` (the PR #36 live-validation fixes are committed as `cc0321a`/`1623e35`; the tree starts clean). Stage only the explicit paths each commit step lists — no `git add -A`/`git add .`/`git commit -a`.
 - Single tier (operator decision): when the probe is wired, its verdict is final. `"busy"` waits; **anything else — `"waiting"`, no matching entry, unreadable file, unknown status — flips immediately.** No fallback to mtime logic, no valve. Eager failure on registry schema drift is accepted ("if it breaks we'll fix it later").
 - Codex flip behavior must be byte-identical: every existing test in `tests/test_runner.py` stays green unmodified.
 - The Stop hook / sentinel wiring is untouched — the transcript tailer uses the sentinel as its wake signal.

--- a/docs/specs/2026-08-09-meta-harness-frame-design.md
+++ b/docs/specs/2026-08-09-meta-harness-frame-design.md
@@ -32,9 +32,12 @@ Decisions made during brainstorming:
 - **Subagents unchanged.** Quick cross-model consults remain the 0.2
   delegation path ("ask gpt to review this"); this feature only changes
   how you move your whole seat between harnesses.
-- **No chrome.** The flip is a screen clear plus the incoming TUI's own
-  redraw. No tab bar or status line; the tab feel comes from speed and
-  continuity, not decoration.
+- **One line of chrome: the tab bar.** tandem reserves the terminal's
+  bottom row for a status bar (`claude ● │ codex ○  ⌃] flips`) and
+  renders no other pixel — conversation UI stays entirely native. The
+  bar also surfaces armed-flip state (`⏳ flipping at turn end…`), which
+  is otherwise invisible. A `[frame] bar = false` kill-switch and
+  graceful auto-drop cap the risk.
 - **The escape hatch stays.** A plain exit (Ctrl-D) still lands at the
   tandem prompt; `exit` there returns to the OS shell with the resume
   hint. One-shot commands from the OS shell are untouched.
@@ -54,6 +57,12 @@ Decisions made during brainstorming:
   wrapper).
 - The flip key is configurable (`[frame] flip_key` in config.toml) for
   anyone who needs the raw byte in their TUI.
+- **The tab bar** sits on the bottom terminal row for the whole session:
+  active harness highlighted, the other dimmed, the flip hint, and —
+  while a mid-turn flip is armed — `⏳ flipping at turn end…`. It
+  repaints on resize and after child screen resets, disables via
+  `[frame] bar = false`, and auto-drops for the session (flip still
+  works) if the terminal can't sustain it.
 
 ## Implementation
 
@@ -88,6 +97,27 @@ SIGKILL after a bounded timeout. Whether the exit was graceful is
 recorded. Transcript appends are whole-line and durable, so even the
 forced path cannot corrupt history.
 
+### Status bar: a reserved bottom row
+
+The child is told the terminal is one row shorter (`rows-1` in the PTY
+winsize, on launch and on every resize), and tandem paints the bar on
+the real bottom row. Bottom — not top — is load-bearing: the child's
+rows 1..rows-1 map to real rows identically, so cursor-position
+reports, mouse coordinates, and absolute addressing all stay truthful
+with zero translation. A scroll region (DECSTBM rows 1..rows-1) keeps
+normal-buffer scrolling (Claude Code scrolls the real buffer) above the
+bar.
+
+The one new touch on the output path: a small state machine scans the
+child's output for the few sequences that would clobber the setup —
+RIS, `CSI r`, alt-screen enter/leave (`CSI ?1049h/l`), full-screen ED —
+and reasserts the scroll region and repaints the bar after each
+(handling sequences split across read chunks). It is a targeted filter,
+not a terminal emulator; all other bytes relay verbatim as today. Keys
+landing on the bar row (mouse reports with the bottom row's coordinate)
+are swallowed. If the filter encounters output it cannot reconcile, the
+bar drops for the session and the frame continues bar-less.
+
 ### Flip and re-enter
 
 The runner's existing exit path runs unchanged (stop and join the tail
@@ -112,6 +142,9 @@ No new sync logic anywhere.
   above.
 - **Marker unavailable or missed:** the quiescence fallback promotes the
   armed flag; worst case the flip lands ~2 s late.
+- **Bar can't be sustained** (irreconcilable child output, exotic
+  terminal): auto-drop the bar for the session, keep flipping; note it
+  in `tandem doctor`. `[frame] bar = false` disables it outright.
 
 ## Testing
 
@@ -125,9 +158,14 @@ No new sync logic anywhere.
   `run_harness` / `input_fn` seams — flip lands back in the loop without
   a prompt stop; plain exit still reaches the prompt.
 - `ops.switch_session` is unchanged and already covered.
+- **Bar:** winsize lie on launch/resize; scroll-region reassert after
+  each watched sequence (including sequences split across chunks); armed
+  state rendering; auto-drop path; kill-switch.
 - **Live validation** (manual, operator-run, as in prior releases):
   flips both directions in a scratch repo; mid-turn arm and cancel; a
-  paste containing 0x1D; resume-failure fallback; unpaired no-op.
+  paste containing 0x1D; resume-failure fallback; unpaired no-op; bar
+  behavior across Terminal.app, iTerm2, and the VS Code terminal
+  (scrollback, resize, alt-screen switches).
 
 ## Docs
 
@@ -142,6 +180,7 @@ becomes the implementation detail rather than the headline.
   deliberately dropped; no design is retained.
 - `/tandem:switch` or any in-session tandem commands (parked branch,
   untouched).
-- Tab-bar or status-line chrome.
+- Richer chrome than the one-row bar (menus, mouse interaction, per-turn
+  stats).
 - Any change to sync/translation, subagents, pairing, or the tandem
   prompt's plain-exit behavior.

--- a/docs/specs/2026-08-09-meta-harness-frame-design.md
+++ b/docs/specs/2026-08-09-meta-harness-frame-design.md
@@ -1,0 +1,147 @@
+# The tandem frame: Ctrl-] flips between native harnesses
+
+Date: 2026-08-09
+Status: approved (brainstorm)
+
+## Problem
+
+tandem's product story inverts: instead of an accessory you occasionally
+visit between sessions, tandem becomes the CLI you launch — a meta
+harness. Claude Code and Codex are faces inside it, and moving between
+them should feel like changing tabs, not like leaving one program to
+start another. Today that move is a ceremony: exit the harness, land at
+the `tandem (active)>` prompt, type `switch`, re-enter.
+
+The goal: launch `tandem` once and never leave it. One keybind flips the
+screen to the other native TUI a couple of seconds later, resumed with
+the same history (the sync engine has already kept the shadow transcript
+current). The native TUIs do all rendering — tandem builds no chat UI
+and scrapes no output; it stays the invisible terminal owner it already
+is.
+
+Decisions made during brainstorming:
+
+- **Native UIs only.** tandem renders no conversation UI in any mode.
+  PTY passthrough remains the only display path; transcripts remain the
+  only data path.
+- **Keybind only.** Ctrl-] (configurable) is the sole flip trigger. No
+  `/tandem:switch` slash command, no transcript command detection, no
+  plugin changes, no in-session tandem commands. (A separately parked
+  branch, `in-session-switch`, explored the slash-command route; it
+  stays parked and this design does not depend on it.)
+- **Subagents unchanged.** Quick cross-model consults remain the 0.2
+  delegation path ("ask gpt to review this"); this feature only changes
+  how you move your whole seat between harnesses.
+- **No chrome.** The flip is a screen clear plus the incoming TUI's own
+  redraw. No tab bar or status line; the tab feel comes from speed and
+  continuity, not decoration.
+- **The escape hatch stays.** A plain exit (Ctrl-D) still lands at the
+  tandem prompt; `exit` there returns to the OS shell with the resume
+  hint. One-shot commands from the OS shell are untouched.
+
+## Behavior
+
+- `tandem` / `tandem resume` enters the frame: the active harness runs
+  full-screen on its PTY, exactly as today.
+- **Ctrl-] while the harness is idle:** flip now. The fronted CLI is
+  exited gracefully, roles flip, the screen clears, and the other
+  harness resumes with the same history. End to end ~1–3 s.
+- **Ctrl-] mid-turn:** the flip arms and fires when the turn completes
+  (tandem's existing turn-complete marker; quiescence fallback). A
+  second Ctrl-] while armed cancels — the key is a toggle.
+- **Unpaired or plain sessions:** the keybind is a no-op. Sessions not
+  running under tandem are unaffected (there is no detector outside the
+  wrapper).
+- The flip key is configurable (`[frame] flip_key` in config.toml) for
+  anyone who needs the raw byte in their TUI.
+
+## Implementation
+
+### Detector: one byte in the PTY input relay
+
+`ptyrun`'s input relay watches the keyboard stream for the flip byte
+(0x1D default) and consumes it — it is never forwarded to the child.
+Bracketed-paste state is tracked (ESC `[200~` … ESC `[201~`) so a paste
+containing the byte cannot trigger a flip. Everything else passes
+through untouched, as today.
+
+### Arm, turn boundary, cancel
+
+The detector sets an in-memory armed flag on the runner — no shared
+state, no cross-process protocol. If the harness is idle the flip fires
+immediately (the tailer already distinguishes in-flight turns: a
+user-message event opens one, the marker touch closes it). Otherwise it fires on the next turn-complete signal: the
+marker file tandem already injects per-invocation (claude `--settings`
+Stop hook, codex `-c notify`) and the tailer already watches, with ~2 s
+of transcript quiescence as the fallback where the marker is
+unavailable. A second Ctrl-] while armed clears the flag.
+
+### Termination ladder
+
+`run_in_pty` grows a small control handle for cross-thread termination.
+Escalation: first a soft app-level exit — clear the composer, then the
+harness's own quit keystroke (adapter-owned recipes in
+`harness/claude_code.py` / `harness/codex.py`; exact keystrokes pinned
+at implementation per harness version), letting the CLI finalize
+its own transcript — then SIGTERM to the child's process group, then
+SIGKILL after a bounded timeout. Whether the exit was graceful is
+recorded. Transcript appends are whole-line and durable, so even the
+forced path cannot corrupt history.
+
+### Flip and re-enter
+
+The runner's existing exit path runs unchanged (stop and join the tail
+thread, final locked drain), surfacing "flip requested" alongside the
+exit code. `run_shell` sees it and reuses the existing `_switch` path
+verbatim — `ops.switch_session` (role flip in the state store, memory
+sync CLAUDE.md ⟷ AGENTS.md) — then clears the screen and immediately
+re-enters the newly active harness instead of stopping at the prompt.
+No new sync logic anywhere.
+
+## Error handling
+
+- **Resume failure** (version drift, missing binary, unhealthy rollout):
+  relaunch the harness the user just left — never strand them. If that
+  also fails, fall to the tandem prompt with the error shown; the resume
+  hint still prints from the existing `finally` (the session is never
+  lost). Post-flip rollout problems surface through the existing
+  "may not resume cleanly; run `tandem doctor`" advisory.
+- **Translation failure during the final drain:** the existing
+  quarantine path applies; the flip proceeds.
+- **Child ignores the soft quit:** SIGTERM, then bounded SIGKILL, as
+  above.
+- **Marker unavailable or missed:** the quiescence fallback promotes the
+  armed flag; worst case the flip lands ~2 s late.
+
+## Testing
+
+- **Detector** (extends `test_ptyrun.py`): flip-byte match,
+  bracketed-paste suppression, consume-not-forward, config override.
+- **Runner:** armed flag → marker → termination ordering; idle
+  fires immediately; cancel toggle; quiescence fallback; graceful vs
+  forced recorded; existing stop/join/final-drain ordering preserved
+  (seams already exist).
+- **Shell:** the auto-flip loop via the existing injected
+  `run_harness` / `input_fn` seams — flip lands back in the loop without
+  a prompt stop; plain exit still reaches the prompt.
+- `ops.switch_session` is unchanged and already covered.
+- **Live validation** (manual, operator-run, as in prior releases):
+  flips both directions in a scratch repo; mid-turn arm and cancel; a
+  paste containing 0x1D; resume-failure fallback; unpaired no-op.
+
+## Docs
+
+README reframe to match the inverted story: launch `tandem`, work in
+whichever native TUI is fronted, `Ctrl-]` to flip; the pairing engine
+becomes the implementation detail rather than the headline.
+
+## Out of scope
+
+- Peer-turn directive routing (`@gpt …` prefixes running whole turns on
+  the other model in-place) — discussed during brainstorming and
+  deliberately dropped; no design is retained.
+- `/tandem:switch` or any in-session tandem commands (parked branch,
+  untouched).
+- Tab-bar or status-line chrome.
+- Any change to sync/translation, subagents, pairing, or the tandem
+  prompt's plain-exit behavior.

--- a/docs/why.md
+++ b/docs/why.md
@@ -17,16 +17,17 @@ main thread. Setup and routing modes:
 
 ## ⏳ Hit a usage limit? Just keep going.
 
-Claude runs out of its usage window mid-refactor? Type `switch` and Codex
-continues the **same conversation** a second later — same files, same
-history, same plan. Your two subscriptions become one long runway instead
-of two separate walls.
+Claude runs out of its usage window mid-refactor? Press **Ctrl-]** and
+Codex continues the **same conversation** a second later — same files,
+same history, same plan. Your two subscriptions become one long runway
+instead of two separate walls.
 
 ## 🌩️ Immune to outages.
 
 An Anthropic or OpenAI outage doesn't stop your work. If the active
-model's API goes down, `switch` — the same session continues seamlessly
-in the other harness, and you can switch back whenever the outage clears.
+model's API goes down, press **Ctrl-]** — the same session continues
+seamlessly in the other harness, and you can flip back whenever the
+outage clears.
 
 ## 💳 Subscriptions, not API bills.
 

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -1,7 +1,8 @@
 """User configuration: $TANDEM_HOME/config.toml.
 
 [subagents] controls codex subagent routing; [claude] / [codex] hold an
-`args` list appended to every interactive launch of that harness.
+`args` list appended to every interactive launch of that harness; [frame]
+holds the meta-harness flip keybind and its status bar toggle.
 
 Unknown keys are ignored and every error yields defaults — configuration
 must never be the reason a launch breaks or subagent routing stops (the
@@ -79,3 +80,43 @@ def load_harness_args(harness: str) -> list[str]:
     ):
         return []
     return args
+
+
+@dataclass(frozen=True)
+class FrameConfig:
+    flip_byte: int = 0x1D   # Ctrl-]
+    bar: bool = True
+
+
+def _parse_flip_key(value: str) -> int | None:
+    """'ctrl-]' / 'ctrl-t' / '0x1d' -> byte value. None when unparseable or
+    not a control byte (a printable key would swallow real typing)."""
+    v = value.strip().lower()
+    if v.startswith("ctrl-") and len(v) == 6:
+        # No .upper() before ord(): & 0x1F already folds case across printable
+        # ASCII, and case-folding can expand one char into several ("ß" -> "SS"),
+        # which would raise TypeError out of a config read.
+        code = ord(v[5]) & 0x1F
+    elif v.startswith("0x"):
+        try:
+            code = int(v, 16)
+        except ValueError:
+            return None
+    else:
+        return None
+    return code if 0 < code < 0x20 else None
+
+
+def load_frame_config() -> FrameConfig:
+    """[frame] table: the flip keybind and the status bar toggle."""
+    raw = _read_config().get("frame")
+    if not isinstance(raw, dict):
+        return FrameConfig()
+    d = FrameConfig()
+    key = raw.get("flip_key")
+    byte = _parse_flip_key(key) if isinstance(key, str) else None
+    bar = raw.get("bar")
+    return FrameConfig(
+        flip_byte=byte if byte is not None else d.flip_byte,
+        bar=bar if isinstance(bar, bool) else d.bar,
+    )

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -219,6 +219,16 @@ def run_doctor(store, session, live: bool = False) -> DoctorReport:
                 f"(run `tandem sync`)"
             )
 
+    # Written best-effort by the runner when the frame gave up on the status
+    # bar; nothing deletes it, so the warning repeats until the user does.
+    bar_marker = paths.tandem_home() / "tmp" / f"{session.tandem_id}-bar-dropped"
+    if bar_marker.exists():
+        report.warn(
+            "the status bar was auto-disabled in a previous session"
+            " (terminal conflict) — set [frame] bar = false to keep it off,"
+            " or delete the marker to retry: " + str(bar_marker)
+        )
+
     qdir = paths.quarantine_dir(session.tandem_id)
     qfiles = sorted(qdir.iterdir()) if qdir.is_dir() else []
     if qfiles:

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -111,3 +111,55 @@ class OutputGuard:
             if m.end() > base:
                 return "reassert"
         return ""
+
+
+class StatusBar:
+    """Composes the bar's paint/region/clear byte strings for the real
+    bottom terminal row. The child is told the terminal is one row shorter
+    (identity row mapping for everything it can address); DECSTBM keeps
+    normal-buffer scrolling above the bar."""
+
+    def __init__(self, rows: int, cols: int, active: str, other: str):
+        self.rows = rows
+        self.cols = cols
+        self.active = active
+        self.other = other
+
+    def resize(self, rows: int, cols: int) -> None:
+        self.rows = rows
+        self.cols = cols
+
+    def line(self, armed: bool) -> str:
+        # padded and truncated by character count, so every glyph here must be
+        # one terminal cell wide: a two-cell glyph (any with East_Asian_Width
+        # W/F, e.g. ⏳ U+23F3) makes the painted row cols+1 cells and wraps off
+        # the last line. ● │ ○ ◐ are 'A' (ambiguous) — one cell outside
+        # CJK-wide terminal configs.
+        if armed:
+            text = f" {self.active} ◐ flipping at turn end…  ^] cancels"
+        else:
+            text = f" {self.active} ● │ {self.other} ○   ^] flips"
+        return text[: self.cols].ljust(self.cols)
+
+    def paint(self, armed: bool) -> bytes:
+        return (
+            b"\x1b7"
+            + f"\x1b[{self.rows};1H".encode()
+            + b"\x1b[7m"
+            + self.line(armed).encode()
+            + b"\x1b[0m\x1b8"
+        )
+
+    def region(self) -> bytes:
+        # DECSTBM homes the cursor, so save/restore around it. The bottom is
+        # floored at row 1: ioctl reports rows=0 when the size is unknown and
+        # 1-row panes exist, and `\x1b[1;0r` / `\x1b[1;-1r` would be ignored or
+        # malformed — leaving the previous region in force under the bar.
+        return b"\x1b7" + f"\x1b[1;{max(1, self.rows - 1)}r".encode() + b"\x1b8"
+
+    def clear(self) -> bytes:
+        return (
+            b"\x1b7\x1b[r"
+            + f"\x1b[{self.rows};1H".encode()
+            + b"\x1b[2K\x1b8"
+        )

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -20,30 +20,83 @@ _PARTIAL_RE = re.compile(rb"\x1b(\[(<(\d{0,4}(;\d{0,4}){0,2};?)?|2(0[01]?)?)?)?\
 # longest byte string _PARTIAL_RE can match: ESC [ < 1234 ;1234 ;1234 ;
 _MAX_PARTIAL = 18
 
+# kitty CSI-u modifier field is 1 + a bitmask; the flip chord is ctrl (4)
+# with nothing else held except the lock keys (capslock 64, numlock 128),
+# which real keyboards leave lit all the time
+_CSIU_CTRL = 4
+_CSIU_DISQUALIFIERS = 1 | 2 | 8 | 16 | 32   # shift, alt, super, hyper, meta
 
-def _split_partial(buf: bytes) -> tuple[bytes, bytes]:
-    """Split off a trailing fragment of a tracked escape sequence, to be
-    retried on the next feed. Anything that cannot become one is not held
-    back (a lone ESC keypress must reach the child)."""
-    i = buf.rfind(b"\x1b", max(0, len(buf) - _MAX_PARTIAL))
-    if i == -1:
-        return buf, b""
-    m = _PARTIAL_RE.match(buf, i)
-    if m and m.group(0) != b"":
-        return buf[:i], buf[i:]
-    return buf, b""
+
+def _csiu_codepoint(flip_byte: int) -> int | None:
+    """The codepoint a kitty-protocol terminal reports for the flip chord.
+
+    Once a child pushes kitty enhancement flags (codex's TUI does, on any
+    terminal that supports them), Ctrl-] arrives as ``\\x1b[93;5u`` and the
+    raw 0x1D byte never appears — so the detector must recognize this
+    spelling too, or the flip key is silently dead for that whole phase.
+
+    Letters report their lowercase codepoint; 0x1B-0x1D report the
+    unshifted punctuation key. 0x1E/0x1F need Shift on common layouts (the
+    modifier field would not be plain ctrl), so they keep legacy-byte
+    detection only."""
+    if 0x01 <= flip_byte <= 0x1A:
+        return flip_byte + 96
+    if flip_byte in (0x1B, 0x1C, 0x1D):
+        return flip_byte + 64
+    return None
 
 
 class FlipDetector:
-    """Input-side filter: consume the flip byte (outside bracketed paste),
-    swallow SGR mouse events aimed at the bar row, forward everything else
-    byte-for-byte."""
+    """Input-side filter: consume the flip key — as its raw control byte or
+    its kitty CSI-u spelling — outside bracketed paste, swallow SGR mouse
+    events aimed at the bar row, forward everything else byte-for-byte."""
 
     def __init__(self, flip_byte: int, bar_row: int | None = None):
         self.flip_byte = flip_byte
         self.bar_row = bar_row
         self._in_paste = False
         self._carry = b""
+        cp = _csiu_codepoint(flip_byte)
+        if cp is None:
+            self._csiu_re = None
+            self._partial_re = _PARTIAL_RE
+            self._max_partial = _MAX_PARTIAL
+        else:
+            digits = str(cp).encode()
+            # \x1b[<cp>(:shifted(:base)?)?;<mods>(:<event>)?u — alternates
+            # come from the "report alternate keys" flag, the event type
+            # (1 press, 2 repeat, 3 release) from "report event types";
+            # both are part of the >7u push codex uses.
+            self._csiu_re = re.compile(
+                rb"\x1b\[" + digits
+                + rb"(?::\d{1,7}(?::\d{1,7})?)?;(\d{1,3})(?::(\d{1,2}))?u"
+            )
+            # a trailing fragment that could still become the flip sequence
+            # must be carried like the mouse/paste fragments: nested
+            # optionals so every prefix of the digits (then of the
+            # alternates/mods tail) matches up to \Z
+            frag = rb"(?::\d{0,7}(?::\d{0,7})?)?(?:;\d{0,3}(?::\d{0,2})?)?"
+            for ch in reversed(digits[1:]):
+                frag = b"(?:" + bytes([ch]) + frag + b")?"
+            frag = digits[:1] + frag
+            self._partial_re = re.compile(
+                rb"\x1b(\[(<(\d{0,4}(;\d{0,4}){0,2};?)?|2(0[01]?)?|"
+                + frag + rb")?)?\Z"
+            )
+            # ESC [ + 3 digits + :1234567:1234567 + ;123 + :12
+            self._max_partial = 32
+
+    def _split_partial(self, buf: bytes) -> tuple[bytes, bytes]:
+        """Split off a trailing fragment of a tracked escape sequence, to be
+        retried on the next feed. Anything that cannot become one is not held
+        back (a lone ESC keypress must reach the child)."""
+        i = buf.rfind(b"\x1b", max(0, len(buf) - self._max_partial))
+        if i == -1:
+            return buf, b""
+        m = self._partial_re.match(buf, i)
+        if m and m.group(0) != b"":
+            return buf[:i], buf[i:]
+        return buf, b""
 
     def flush(self) -> bytes:
         """Release a stranded fragment verbatim. A carried prefix waits for
@@ -56,7 +109,7 @@ class FlipDetector:
 
     def feed(self, data: bytes) -> tuple[bytes, int]:
         buf = self._carry + data
-        buf, self._carry = _split_partial(buf)
+        buf, self._carry = self._split_partial(buf)
         out = bytearray()
         flips = 0
         i = 0
@@ -80,6 +133,24 @@ class FlipDetector:
                     out += m.group(0)
                     i = m.end()
                     continue
+                if self._csiu_re is not None:
+                    m = self._csiu_re.match(buf, i)
+                    if m:
+                        bits = int(m.group(1)) - 1
+                        if bits & _CSIU_CTRL and not bits & _CSIU_DISQUALIFIERS:
+                            # ours: count press (bare or :1) and repeat (:2,
+                            # matching legacy autorepeat), swallow the
+                            # release (:3) — the child never saw the press,
+                            # so it must not see the key come back up.
+                            if m.group(2) in (None, b"1", b"2"):
+                                flips += 1
+                            i = m.end()
+                            continue
+                        # same key, different chord (e.g. ctrl+shift):
+                        # not the flip — forward it whole
+                        out += m.group(0)
+                        i = m.end()
+                        continue
                 if buf[i] == self.flip_byte:
                     flips += 1
                     i += 1
@@ -89,37 +160,63 @@ class FlipDetector:
         return bytes(out), flips
 
 
-_DROP_RE = re.compile(rb"\x1b\[\d{1,4}(;\d{1,4})?r")     # child's own DECSTBM
-# bare `\x1b[r` needs no guard against half-matching a parameterized region:
-# that form spells its digits *before* the r, so the two can never share a
-# prefix. `_DROP_RE` is scanned first regardless, so drop still wins.
-_REASSERT_RE = re.compile(rb"\x1bc|\x1b\[\?1049[hl]|\x1b\[[23]J|\x1b\[r")
+# One union of everything watched, scanned in stream order. The
+# parameterized-DECSTBM branch (digits before the r) and the bare `\x1b[r`
+# branch can never share a prefix, so the alternation is unambiguous.
+_WATCH_RE = re.compile(
+    rb"\x1b\[(\d{1,4})(?:;(\d{1,4}))?r"     # child DECSTBM with parameters
+    rb"|\x1b\[r"                            # bare DECSTBM reset
+    rb"|\x1bc"                              # RIS: full reset
+    rb"|\x1b\[\?1049[hl]"                   # alt screen enter/leave
+    rb"|\x1b\[[23]J"                        # clear screen / scrollback
+)
 
 
 class OutputGuard:
     """Output-side watcher for the handful of sequences that clobber the
     reserved row or scroll region. Returns a verdict; never alters bytes.
     A small carry window handles sequences split across read chunks; only
-    matches ending beyond the carry count (earlier ones fired last feed)."""
+    matches ending beyond the carry count (earlier ones fired last feed).
+
+    A parameterized DECSTBM is judged by its bottom edge against `rows`
+    (the real terminal height — the bar row). A child that pins a region
+    *above* the bar (codex's TUI guards its composer rows this way at
+    startup) is not a conflict: the bar row is untouched, so the verdict is
+    a repaint, and `child_owns_region` flips on so the repaint knows not to
+    stomp the child's region with tandem's own. Only a region that reaches
+    the bar row — or one whose bottom is left to default to the last row —
+    is a real fight over the same rows and worth dropping the bar for.
+    With `rows` unknown (0), every parameterized region is assumed to cover
+    the bar. The pump keeps `rows` current across SIGWINCH."""
 
     # >= the longest watched sequence (12 bytes: ESC [ 1234 ;5678 r), so no
     # split point can hide one from both feeds it straddles
     CARRY = 15
 
-    def __init__(self):
+    def __init__(self, rows: int = 0):
+        self.rows = rows
+        self.child_owns_region = False
         self._carry = b""
 
     def feed(self, data: bytes) -> str:
         buf = self._carry + data
         base = len(self._carry)
         self._carry = buf[max(0, len(buf) - self.CARRY):]
-        for m in _DROP_RE.finditer(buf):
-            if m.end() > base:
+        verdict = ""
+        for m in _WATCH_RE.finditer(buf):
+            if m.end() <= base:
+                continue
+            if m.group(1) is not None:
+                bottom = m.group(2)
+                if bottom is not None and 0 < int(bottom) < self.rows:
+                    self.child_owns_region = True
+                    verdict = "reassert"
+                    continue
                 return "drop"
-        for m in _REASSERT_RE.finditer(buf):
-            if m.end() > base:
-                return "reassert"
-        return ""
+            if m.group(0) in (b"\x1b[r", b"\x1bc"):
+                self.child_owns_region = False
+            verdict = "reassert"
+        return verdict
 
 
 class StatusBar:

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -128,11 +128,17 @@ class StatusBar:
     (identity row mapping for everything it can address); DECSTBM keeps
     normal-buffer scrolling above the bar."""
 
-    def __init__(self, rows: int, cols: int, active: str, other: str):
+    def __init__(self, rows: int, cols: int, active: str, other: str,
+                 key_label: str = "^]"):
         self.rows = rows
         self.cols = cols
         self.active = active
         self.other = other
+        # The bar is the only place the keybind is advertised, so it has to
+        # name the key actually bound — `[frame] flip_key` rebinds it, and a
+        # bar still saying ^] would send the user pressing a key that goes
+        # straight through to the harness.
+        self.key_label = key_label
 
     def resize(self, rows: int, cols: int) -> None:
         self.rows = rows
@@ -145,9 +151,9 @@ class StatusBar:
         # the last line. ● │ ○ ◐ are 'A' (ambiguous) — one cell outside
         # CJK-wide terminal configs.
         if armed:
-            text = f" {self.active} ◐ flipping at turn end…  ^] cancels"
+            text = f" {self.active} ◐ flipping at turn end…  {self.key_label} cancels"
         else:
-            text = f" {self.active} ● │ {self.other} ○   ^] flips"
+            text = f" {self.active} ● │ {self.other} ○   {self.key_label} flips"
         return text[: self.cols].ljust(self.cols)
 
     def paint(self, armed: bool) -> bytes:

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -45,6 +45,15 @@ class FlipDetector:
         self._in_paste = False
         self._carry = b""
 
+    def flush(self) -> bytes:
+        """Release a stranded fragment verbatim. A carried prefix waits for
+        bytes that may never come — a lone ESC is the interrupt key in both
+        TUIs — so the pump flushes on an idle tick. Only the carry is
+        cleared: paste state is not carry state, and forgetting mid-paste
+        would re-arm the flip byte inside someone's pasted text."""
+        carry, self._carry = self._carry, b""
+        return carry
+
     def feed(self, data: bytes) -> tuple[bytes, int]:
         buf = self._carry + data
         buf, self._carry = _split_partial(buf)

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -1,0 +1,80 @@
+"""Frame machinery: flip-key detection, output guard, and the status bar.
+
+The frame is tandem's one visible surface — a reserved bottom row and one
+reserved keybind. Everything here is a pure bytes-in/bytes-out state
+machine so `ptyrun` stays a dumb pump: nothing in this module touches the
+terminal, the PTY, or threads, and `ptyrun` imports `frame`, never the
+reverse.
+"""
+
+from __future__ import annotations
+
+import re
+
+PASTE_BEGIN = b"\x1b[200~"
+PASTE_END = b"\x1b[201~"
+
+_MOUSE_RE = re.compile(rb"\x1b\[<(\d{1,4});(\d{1,4});(\d{1,4})([Mm])")
+# a trailing fragment that could still become a paste marker or mouse event
+_PARTIAL_RE = re.compile(rb"\x1b(\[(<(\d{0,4}(;\d{0,4}){0,2};?)?|2(0[01]?)?)?)?\Z")
+# longest byte string _PARTIAL_RE can match: ESC [ < 1234 ;1234 ;1234 ;
+_MAX_PARTIAL = 18
+
+
+def _split_partial(buf: bytes) -> tuple[bytes, bytes]:
+    """Split off a trailing fragment of a tracked escape sequence, to be
+    retried on the next feed. Anything that cannot become one is not held
+    back (a lone ESC keypress must reach the child)."""
+    i = buf.rfind(b"\x1b", max(0, len(buf) - _MAX_PARTIAL))
+    if i == -1:
+        return buf, b""
+    m = _PARTIAL_RE.match(buf, i)
+    if m and m.group(0) != b"":
+        return buf[:i], buf[i:]
+    return buf, b""
+
+
+class FlipDetector:
+    """Input-side filter: consume the flip byte (outside bracketed paste),
+    swallow SGR mouse events aimed at the bar row, forward everything else
+    byte-for-byte."""
+
+    def __init__(self, flip_byte: int, bar_row: int | None = None):
+        self.flip_byte = flip_byte
+        self.bar_row = bar_row
+        self._in_paste = False
+        self._carry = b""
+
+    def feed(self, data: bytes) -> tuple[bytes, int]:
+        buf = self._carry + data
+        buf, self._carry = _split_partial(buf)
+        out = bytearray()
+        flips = 0
+        i = 0
+        while i < len(buf):
+            if not self._in_paste and buf.startswith(PASTE_BEGIN, i):
+                self._in_paste = True
+                out += PASTE_BEGIN
+                i += len(PASTE_BEGIN)
+                continue
+            if self._in_paste and buf.startswith(PASTE_END, i):
+                self._in_paste = False
+                out += PASTE_END
+                i += len(PASTE_END)
+                continue
+            if not self._in_paste:
+                m = _MOUSE_RE.match(buf, i)
+                if m:
+                    if self.bar_row is not None and int(m.group(3)) == self.bar_row:
+                        i = m.end()  # click landed on tandem's row
+                        continue
+                    out += m.group(0)
+                    i = m.end()
+                    continue
+                if buf[i] == self.flip_byte:
+                    flips += 1
+                    i += 1
+                    continue
+            out.append(buf[i])
+            i += 1
+        return bytes(out), flips

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -78,3 +78,36 @@ class FlipDetector:
             out.append(buf[i])
             i += 1
         return bytes(out), flips
+
+
+_DROP_RE = re.compile(rb"\x1b\[\d{1,4}(;\d{1,4})?r")     # child's own DECSTBM
+# bare `\x1b[r` needs no guard against half-matching a parameterized region:
+# that form spells its digits *before* the r, so the two can never share a
+# prefix. `_DROP_RE` is scanned first regardless, so drop still wins.
+_REASSERT_RE = re.compile(rb"\x1bc|\x1b\[\?1049[hl]|\x1b\[[23]J|\x1b\[r")
+
+
+class OutputGuard:
+    """Output-side watcher for the handful of sequences that clobber the
+    reserved row or scroll region. Returns a verdict; never alters bytes.
+    A small carry window handles sequences split across read chunks; only
+    matches ending beyond the carry count (earlier ones fired last feed)."""
+
+    # >= the longest watched sequence (12 bytes: ESC [ 1234 ;5678 r), so no
+    # split point can hide one from both feeds it straddles
+    CARRY = 15
+
+    def __init__(self):
+        self._carry = b""
+
+    def feed(self, data: bytes) -> str:
+        buf = self._carry + data
+        base = len(self._carry)
+        self._carry = buf[max(0, len(buf) - self.CARRY):]
+        for m in _DROP_RE.finditer(buf):
+            if m.end() > base:
+                return "drop"
+        for m in _REASSERT_RE.finditer(buf):
+            if m.end() > base:
+                return "reassert"
+        return ""

--- a/src/tandem/harness/base.py
+++ b/src/tandem/harness/base.py
@@ -68,6 +68,13 @@ class HarnessAdapter(ABC):
         uses the sentinel as a flush signal; fs-watching remains the
         fallback."""
 
+    def quit_keystrokes(self) -> list[bytes]:
+        """Byte chunks that cleanly exit the interactive CLI — clear the
+        composer, then quit — sent in order with a short pause between.
+        Pinned per harness version; live-verified at release (the ladder's
+        SIGTERM rung backstops a recipe the CLI stops honoring)."""
+        return []
+
     # -- transcript parsing / rendering (the converter halves) ---------------
 
     @abstractmethod

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -126,6 +126,9 @@ class ClaudeCodeAdapter(HarnessAdapter):
         }
         return ["--settings", json.dumps(settings)]
 
+    def quit_keystrokes(self) -> list[bytes]:
+        return [b"\x03", b"\x04"]
+
     # -- parsing -------------------------------------------------------------
 
     def parse_entry(self, raw: dict[str, Any], ctx: SessionContext) -> list[NormalizedEvent]:

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -51,7 +51,8 @@ def _pid_alive(pid: int) -> bool:
     cleans up on exit, not on crash). PermissionError means alive but
     not ours — still alive; anything else unreadable counts as dead,
     because trusting a stale entry can freeze the flip on a phantom
-    "busy"."""
+    "busy". Callers must screen out pid <= 0 first: kill(0)/kill(-N)
+    probe process groups and would read as alive."""
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -169,7 +170,8 @@ class ClaudeCodeAdapter(HarnessAdapter):
             if not isinstance(entry, dict) or entry.get("sessionId") != session_id:
                 continue
             pid = entry.get("pid")
-            if not isinstance(pid, int) or not _pid_alive(pid):
+            if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0 \
+                or not _pid_alive(pid):
                 continue
             status = entry.get("status")
             if isinstance(status, str):

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -11,6 +11,7 @@ Session format observed on claude 2.1.220 (docs/formats.md):
 from __future__ import annotations
 
 import json
+import os
 import uuid as uuidlib
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,23 @@ def _stringify_block_content(content: Any) -> str:
                 parts.append(f"<{c.get('type', 'block')}>")
         return "\n".join(parts)
     return "" if content is None else str(content)
+
+
+def _pid_alive(pid: int) -> bool:
+    """A registry entry for a dead pid is a stale leftover (claude
+    cleans up on exit, not on crash). PermissionError means alive but
+    not ours — still alive; anything else unreadable counts as dead,
+    because trusting a stale entry can freeze the flip on a phantom
+    "busy"."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 class ClaudeCodeAdapter(HarnessAdapter):
@@ -128,6 +146,37 @@ class ClaudeCodeAdapter(HarnessAdapter):
 
     def quit_keystrokes(self) -> list[bytes]:
         return [b"\x03", b"\x04"]
+
+    def session_status(self, session_id: str) -> str | None:
+        """Live turn state from claude's session registry: "busy" while a
+        turn runs, "waiting" at the prompt, None when no live entry
+        matches. The flip wait treats anything but "busy" as flippable
+        (single-tier by spec: eager on schema drift). Matched by
+        sessionId — tandem mints claude session ids — never by pid
+        filename, which a forking wrapper would break. Dead-pid entries
+        are skipped; among several live matches "busy" wins, because
+        flipping kills a live turn while waiting only costs a wait."""
+        try:
+            files = sorted(paths.claude_sessions_dir().glob("*.json"))
+        except OSError:
+            return None
+        statuses: list[str] = []
+        for p in files:
+            try:
+                entry = json.loads(p.read_text())
+            except (OSError, ValueError):
+                continue
+            if not isinstance(entry, dict) or entry.get("sessionId") != session_id:
+                continue
+            pid = entry.get("pid")
+            if not isinstance(pid, int) or not _pid_alive(pid):
+                continue
+            status = entry.get("status")
+            if isinstance(status, str):
+                statuses.append(status)
+        if "busy" in statuses:
+            return "busy"
+        return statuses[0] if statuses else None
 
     # -- parsing -------------------------------------------------------------
 

--- a/src/tandem/harness/codex.py
+++ b/src/tandem/harness/codex.py
@@ -158,6 +158,9 @@ class CodexAdapter(HarnessAdapter):
         # lands in $0 and is ignored.
         return ["-c", f'notify=["/bin/sh","-c","touch \'{sentinel}\'"]']
 
+    def quit_keystrokes(self) -> list[bytes]:
+        return [b"\x03", b"\x03", b"\x04"]
+
     # -- parsing -------------------------------------------------------------
 
     def parse_entry(self, raw: dict[str, Any], ctx: SessionContext) -> list[NormalizedEvent]:

--- a/src/tandem/harness/codex.py
+++ b/src/tandem/harness/codex.py
@@ -5,6 +5,13 @@ Session format observed on codex-cli 0.145.0 (docs/formats.md):
 - each line {timestamp, type, payload}; model-facing history is the
   response_item lines, UI history is the event_msg lines
 - first line is session_meta; ~/.codex/session_index.jsonl indexes threads
+
+KNOWN BREAK — codex 0.147.0 moved session storage to sqlite
+(~/.codex/state_5.sqlite, thread_sections et al.): a live session holds no
+rollout JSONL open and a fresh session writes none, so the tailer/sync see
+nothing from codex. `codex resume` of a tandem-seeded rollout still
+launches (2026-08-09, live-validated), but appends nothing back. Needs a
+storage-aware adapter pass; tracked in the frame plan's validation results.
 """
 
 from __future__ import annotations

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -112,6 +112,20 @@ def switch_session(store: StateStore, session: PairedSession):
         _create_codex_shadow_late(store, session)
         session = store.get_session(session.tandem_id) or session
 
+    # If claude never ran, its file does not exist either: claude's CLI
+    # creates the transcript on the first turn, not at launch, so a flip
+    # away from a zero-turn claude leaves its recorded id with no file and
+    # the drain below no target to append to. Seed it now — but only when
+    # tandem has never consumed a byte of it; a consumed-then-missing file
+    # is data loss, and the drain's hard error is the right answer there.
+    if new_active == "claude" and session.claude_session_id:
+        expected = get_adapter("claude").expected_transcript_path(
+            session.cwd, session.claude_session_id
+        )
+        never_ran = store.get_cursor(session.tandem_id, "claude").byte_offset == 0
+        if not expected.exists() and never_ran:
+            _create_claude_shadow_late(store, session)
+
     drain_source(store, session, old_active, flush_dangling=True)
     fast_forward(store, session, new_active)
     store.set_active(session.tandem_id, new_active)
@@ -132,6 +146,24 @@ def switch_session(store: StateStore, session: PairedSession):
         problems = validate_transcript(new_active, transcript,
                                        getattr(session, f"{new_active}_session_id"))
     return new_active, problems, memory_report
+
+
+def _create_claude_shadow_late(store: StateStore, session: PairedSession) -> None:
+    from .constants import SEED_NOTE
+    from .runner import ctx_from_cursor
+
+    adapter = get_adapter("claude")
+    cursor = store.get_cursor(session.tandem_id, session.active)
+    ctx = ctx_from_cursor(session, session.active, cursor)
+    # Any leaf uuid the cursor still holds points into the missing file;
+    # the seed is the new file's root, so it must not chain onto it.
+    ctx.claude_leaf_uuid = None
+    note = SEED_NOTE.format(
+        tandem_id=session.tandem_id, other=get_adapter(session.active).display_name
+    )
+    adapter.create_shadow_transcript(session.cwd, session.claude_session_id, ctx, note)
+    cursor.pending["claude_leaf_uuid"] = ctx.claude_leaf_uuid
+    store.save_cursor(cursor)
 
 
 def _create_codex_shadow_late(store: StateStore, session: PairedSession) -> None:

--- a/src/tandem/paths.py
+++ b/src/tandem/paths.py
@@ -54,6 +54,14 @@ def claude_installed_plugins_path() -> Path:
     return claude_home() / "plugins" / "installed_plugins.json"
 
 
+def claude_sessions_dir() -> Path:
+    """Per-live-session registry: <pid>.json with sessionId and
+    status "busy"|"waiting" — the data `claude agents --json` prints
+    (observed: claude 2.1.226). Rewritten by claude on state
+    transitions; stale files linger after a crash."""
+    return claude_home() / "sessions"
+
+
 # --- Codex ------------------------------------------------------------------
 
 def codex_home() -> Path:

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -193,7 +193,7 @@ def run_in_pty(
         if frame
         else None
     )
-    guard = OutputGuard() if bar_on else None
+    guard = OutputGuard(rows) if bar_on else None
     bar = (
         StatusBar(rows, cols, frame.active, frame.other, frame.key_label)
         if bar_on
@@ -214,8 +214,16 @@ def run_in_pty(
     out_fd = sys.stdout.fileno()
 
     def paint() -> None:
-        if bar is not None:
-            _write_all(out_fd, bar.region() + bar.paint(frame.armed()))
+        # Local reads: drop_bar can null these out from under a repaint.
+        # While the child owns a benign scroll region (codex pinning its
+        # composer rows), only the row is repainted: re-emitting tandem's
+        # own region would widen the child's out from under it, and the
+        # armed-state repaint fires on every flip press.
+        b, g = bar, guard
+        if b is None:
+            return
+        region = b"" if (g is not None and g.child_owns_region) else b.region()
+        _write_all(out_fd, region + b.paint(frame.armed()))
 
     def drop_bar(reason: str) -> None:
         """Terminal state: the guard's drop verdict is not latched, so the
@@ -226,10 +234,12 @@ def run_in_pty(
         not come back when the window grows again; the drop is session-
         scoped by design).
 
-        - "conflict": the child asserted its own scroll region, so tandem and
-          the harness are fighting over the same rows. That is a real,
-          per-terminal incompatibility the user may want to settle with
-          `[frame] bar = false`, so it leaves the marker `doctor` reads.
+        - "conflict": the child asserted a scroll region that covers the
+          bar row (a region pinned above the bar is benign and never lands
+          here), so tandem and the harness really are fighting over the
+          same rows. That is a real, per-terminal incompatibility the user
+          may want to settle with `[frame] bar = false`, so it leaves the
+          marker `doctor` reads.
         - "shrunk": tandem's own row-floor policy fired because the window is
           below the height the reserved row is worth. Nothing is wrong,
           nothing is worth fixing, and the cause is visible on screen —
@@ -266,6 +276,11 @@ def run_in_pty(
         # would surface at whatever bytecode it interrupted, so swallow.
         try:
             r, c = _winsize(stdin_fd)
+            g = guard
+            if g is not None:
+                # keep the DECSTBM judgment honest across resizes: a region
+                # that was benign at the old height may cover the bar now
+                g.rows = r
             if bar is not None and not _bar_on(frame, r):
                 # too short now; drop_bar restores the full winsize
                 drop_bar("shrunk")

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -136,7 +136,10 @@ class PtyControl:
 class FrameIO:
     """Frame wiring for run_in_pty, built by the runner. The pump
     constructs the detector/guard/bar internally from these fields;
-    `bar_dropped` reports back that the bar had to be disabled."""
+    `bar_dropped` reports back that the bar was disabled over a *terminal
+    conflict* — the one drop cause worth remembering across sessions. A bar
+    dropped because the window got short is not recorded: the user can see
+    their own window."""
 
     flip_byte: int
     on_flip: Callable[[], None]
@@ -207,9 +210,23 @@ def run_in_pty(
         if bar is not None:
             _write_all(out_fd, bar.region() + bar.paint(frame.armed()))
 
-    def drop_bar() -> None:
+    def drop_bar(reason: str) -> None:
         """Terminal state: the guard's drop verdict is not latched, so the
-        pump latches it here by tearing the bar down for good."""
+        pump latches it here by tearing the bar down for good.
+
+        `reason` decides what is *recorded*, not what is torn down — the
+        teardown is identical and equally permanent either way (the bar does
+        not come back when the window grows again; the drop is session-
+        scoped by design).
+
+        - "conflict": the child asserted its own scroll region, so tandem and
+          the harness are fighting over the same rows. That is a real,
+          per-terminal incompatibility the user may want to settle with
+          `[frame] bar = false`, so it leaves the marker `doctor` reads.
+        - "shrunk": tandem's own row-floor policy fired because the window is
+          below the height the reserved row is worth. Nothing is wrong,
+          nothing is worth fixing, and the cause is visible on screen —
+          recording it would make `doctor` nag about a resize."""
         nonlocal bar_on, guard, bar
         # Claim the bar first, ask questions second. Drops and resizes are
         # causally correlated (a child sets DECSTBM *because* the terminal
@@ -226,7 +243,8 @@ def run_in_pty(
         if dying is None:
             return
         bar_on, guard = False, None
-        frame.bar_dropped = True
+        if reason == "conflict":
+            frame.bar_dropped = True
         if detector is not None:
             detector.bar_row = None
         _write_all(out_fd, dying.clear())
@@ -242,7 +260,8 @@ def run_in_pty(
         try:
             r, c = _winsize(stdin_fd)
             if bar is not None and not _bar_on(frame, r):
-                drop_bar()  # too short now; drop_bar restores the full winsize
+                # too short now; drop_bar restores the full winsize
+                drop_bar("shrunk")
                 return
             if bar is not None:
                 bar.resize(r, c)
@@ -309,7 +328,7 @@ def run_in_pty(
                 if guard is not None:
                     verdict = guard.feed(data)
                     if verdict == "drop":
-                        drop_bar()
+                        drop_bar("conflict")
                     elif verdict == "reassert":
                         paint()
             if stdin_open and stdin_fd in ready:

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -16,6 +16,8 @@ import struct
 import subprocess
 import sys
 import termios
+import threading
+import time
 import tty
 
 from ptyprocess import PtyProcess
@@ -30,6 +32,77 @@ def _winsize(fd: int) -> tuple[int, int]:
         return (rows or 24, cols or 80)
     except OSError:
         return (24, 80)
+
+
+def _is_alive(child) -> bool:
+    """isalive() is not thread-safe: it reaps via waitpid, so whichever of the
+    pump thread and the terminating thread loses the race gets ECHILD back as a
+    PtyProcessError. A child we can no longer ask about is a child that is
+    gone."""
+    try:
+        return child.isalive()
+    except Exception:
+        return False
+
+
+def _wait_dead(child, timeout: float) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _is_alive(child):
+            return True
+        time.sleep(0.05)
+    return not _is_alive(child)
+
+
+class PtyControl:
+    """Cross-thread termination handle. run_in_pty attaches the live child;
+    terminate() runs the escalation ladder from any other thread: soft quit
+    keystrokes (the CLI finalizes its own transcript), SIGTERM to the
+    process group, SIGKILL. Every rung tolerates a child that is already
+    gone."""
+
+    def __init__(self):
+        self._child = None
+        self._attached = threading.Event()
+
+    def attach(self, child) -> None:
+        self._child = child
+        self._attached.set()
+
+    def terminate(
+        self,
+        soft: list[bytes],
+        soft_timeout: float = 3.0,
+        term_timeout: float = 2.0,
+        attach_timeout: float = 5.0,
+    ) -> str:
+        self._attached.wait(timeout=attach_timeout)
+        child = self._child
+        if child is None or not _is_alive(child):
+            return "dead"
+        for chunk in soft:
+            try:
+                child.write(chunk)
+            except Exception:
+                break
+            time.sleep(0.25)
+        if _wait_dead(child, soft_timeout):
+            return "soft"
+        # ptyprocess spawns the child with setsid, so the child's pid is its
+        # process-group id — killpg(child.pid, …) takes the harness's whole
+        # tool-child tree down with it.
+        try:
+            os.killpg(child.pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        if _wait_dead(child, term_timeout):
+            return "term"
+        try:
+            os.killpg(child.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        _wait_dead(child, 1.0)
+        return "kill"
 
 
 def run_in_pty(argv: list[str], cwd: str | None = None, env: dict | None = None) -> int:

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -211,15 +211,20 @@ def run_in_pty(
         """Terminal state: the guard's drop verdict is not latched, so the
         pump latches it here by tearing the bar down for good."""
         nonlocal bar_on, guard, bar
-        if bar is None:
-            return
-        # State down before any syscall. Drops and resizes are causally
-        # correlated (a child sets DECSTBM *because* the terminal resized,
-        # and a drag-resize bursts SIGWINCH), so a handler landing inside the
-        # writes below must already see bar is None — otherwise it repaints
-        # the region and bar *after* the clear and nothing is left to remove
-        # them, corrupting the terminal past tandem's exit.
+        # Claim the bar first, ask questions second. Drops and resizes are
+        # causally correlated (a child sets DECSTBM *because* the terminal
+        # resized, and a drag-resize bursts SIGWINCH), so a SIGWINCH landing
+        # anywhere below must already see bar is None. Reading the guard
+        # before the swap leaves a one-statement window where a reentrant
+        # call passes the guard, swaps the bar out from under this one, and
+        # leaves `dying` None here — an AttributeError escaping the pump and
+        # orphaning the child. It also has to be None before the writes
+        # below, or the handler repaints region and bar *after* the clear
+        # with nothing left to remove them, corrupting the terminal past
+        # tandem's exit.
         dying, bar = bar, None
+        if dying is None:
+            return
         bar_on, guard = False, None
         frame.bar_dropped = True
         if detector is not None:

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -3,7 +3,9 @@
 The child gets a real pty (raw-mode stdin, terminal resize via SIGWINCH
 forwarding, control bytes delivered through the pty line discipline). Tandem
 never reads meaning from the terminal stream — transcript files are the
-source of truth — so this module just pumps bytes.
+source of truth — except the frame's enumerated sequences (flip byte, paste
+markers, mouse, and the output guard's reset set) — so this module just pumps
+bytes.
 """
 
 from __future__ import annotations
@@ -19,8 +21,12 @@ import termios
 import threading
 import time
 import tty
+from dataclasses import dataclass
+from typing import Callable
 
 from ptyprocess import PtyProcess
+
+from .frame import FlipDetector, OutputGuard, StatusBar
 
 
 def _winsize(fd: int) -> tuple[int, int]:
@@ -105,10 +111,46 @@ class PtyControl:
         return "kill"
 
 
-def run_in_pty(argv: list[str], cwd: str | None = None, env: dict | None = None) -> int:
+@dataclass
+class FrameIO:
+    """Frame wiring for run_in_pty, built by the runner. The pump
+    constructs the detector/guard/bar internally from these fields;
+    `bar_dropped` reports back that the bar had to be disabled."""
+
+    flip_byte: int
+    on_flip: Callable[[], None]
+    armed: Callable[[], bool]
+    bar: bool = True
+    active: str = ""
+    other: str = ""
+    bar_dropped: bool = False
+
+
+def _child_dims(rows: int, cols: int, bar_on: bool) -> tuple[int, int]:
+    """The winsize lie: with the bar on, the child gets one row fewer and
+    tandem owns the real bottom row."""
+    return (rows - 1 if bar_on else rows, cols)
+
+
+def _bar_on(frame: FrameIO | None, rows: int) -> bool:
+    """Bar policy, re-run on every resize: below the row floor the reserved
+    row costs the child more than the bar is worth (and at rows<2 the lie
+    would leave it no rows at all)."""
+    return frame is not None and frame.bar and rows >= 5
+
+
+def run_in_pty(
+    argv: list[str],
+    cwd: str | None = None,
+    env: dict | None = None,
+    frame: FrameIO | None = None,
+    control: PtyControl | None = None,
+) -> int:
     """Run argv on a pty, mirroring the controlling terminal. Returns the
-    child's exit status. Falls back to a plain subprocess when stdin is not a
-    tty (tests, pipes)."""
+    child's exit status. Falls back to a plain subprocess when stdin is not
+    a tty (tests, pipes). With `frame`, tandem reserves the bottom row for
+    the status bar and watches for the flip keybind; with `control`, the
+    child is attached for cross-thread termination."""
     try:
         stdin_fd = sys.stdin.fileno()
         is_tty = os.isatty(stdin_fd)
@@ -117,18 +159,71 @@ def run_in_pty(argv: list[str], cwd: str | None = None, env: dict | None = None)
     if not is_tty:
         return subprocess.run(argv, cwd=cwd, env=env).returncode
 
-    child = PtyProcess.spawn(
-        argv, cwd=cwd, env=env or dict(os.environ), dimensions=_winsize(stdin_fd)
+    rows, cols = _winsize(stdin_fd)
+    bar_on = _bar_on(frame, rows)
+    detector = (
+        FlipDetector(frame.flip_byte, bar_row=rows if bar_on else None)
+        if frame
+        else None
     )
+    guard = OutputGuard() if bar_on else None
+    bar = StatusBar(rows, cols, frame.active, frame.other) if bar_on else None
 
-    def on_winch(signum, frame):
-        rows, cols = _winsize(stdin_fd)
+    child = PtyProcess.spawn(
+        argv,
+        cwd=cwd,
+        env=env or dict(os.environ),
+        dimensions=_child_dims(rows, cols, bar_on),
+    )
+    # attach before anything can block: terminate() reads a missing child as
+    # "dead", so a late attach would report death on a live harness.
+    if control is not None:
+        control.attach(child)
+
+    out_fd = sys.stdout.fileno()
+
+    def paint() -> None:
+        if bar is not None:
+            os.write(out_fd, bar.region() + bar.paint(frame.armed()))
+
+    def drop_bar() -> None:
+        """Terminal state: the guard's drop verdict is not latched, so the
+        pump latches it here by tearing the bar down for good."""
+        nonlocal bar_on, guard, bar
+        if bar is None:
+            return
+        os.write(out_fd, bar.clear())
+        r, c = _winsize(stdin_fd)
         try:
-            child.setwinsize(rows, cols)
+            child.setwinsize(r, c)
+        except Exception:
+            pass
+        if detector is not None:
+            detector.bar_row = None
+        bar_on, guard, bar = False, None, None
+        frame.bar_dropped = True
+
+    def on_winch(signum, frm):
+        # runs as a signal handler in the pump thread: an escaping exception
+        # would surface at whatever bytecode it interrupted, so swallow.
+        try:
+            r, c = _winsize(stdin_fd)
+            if bar is not None and not _bar_on(frame, r):
+                drop_bar()  # too short now; drop_bar restores the full winsize
+                return
+            if bar is not None:
+                bar.resize(r, c)
+                if detector is not None:
+                    detector.bar_row = r
+            try:
+                child.setwinsize(*_child_dims(r, c, bar_on))
+            except Exception:
+                pass
+            paint()
         except Exception:
             pass
 
-    def on_term(signum, frame):
+    def on_term(signum, frm):
         try:
             child.kill(signal.SIGTERM)
         except Exception:
@@ -139,13 +234,30 @@ def run_in_pty(argv: list[str], cwd: str | None = None, env: dict | None = None)
     old_attrs = termios.tcgetattr(stdin_fd)
     try:
         tty.setraw(stdin_fd)
+        paint()
+        # seeded from the state just painted, so an already-armed frame does
+        # not draw a redundant repaint on the first iteration
+        last_armed = frame.armed() if bar is not None else False
         stdin_open = True
-        while child.isalive():
+        # _is_alive, not isalive(): a PtyControl on another thread polls
+        # liveness too, and the loser of the waitpid race gets ECHILD as a
+        # PtyProcessError — which must not escape the pump.
+        while _is_alive(child):
             rlist = [child.fd] + ([stdin_fd] if stdin_open else [])
             try:
                 ready, _, _ = select.select(rlist, [], [], 0.2)
             except InterruptedError:
                 continue  # signal (e.g. SIGWINCH) — loop again
+            if not ready and detector is not None:
+                # idle tick: release any escape fragment the detector is
+                # holding, so a lone ESC reaches the child without waiting
+                # for the next keypress to rule the sequence out.
+                stranded = detector.flush()
+                if stranded:
+                    try:
+                        child.write(stranded)
+                    except Exception:
+                        pass  # child gone; the liveness check ends the pump
             if child.fd in ready:
                 try:
                     data = child.read(65536)
@@ -153,15 +265,31 @@ def run_in_pty(argv: list[str], cwd: str | None = None, env: dict | None = None)
                     break
                 if not data:
                     break
-                os.write(sys.stdout.fileno(), data)
+                os.write(out_fd, data)
+                if guard is not None:
+                    verdict = guard.feed(data)
+                    if verdict == "drop":
+                        drop_bar()
+                    elif verdict == "reassert":
+                        paint()
             if stdin_open and stdin_fd in ready:
                 data = os.read(stdin_fd, 65536)
                 if data:
-                    child.write(data)
+                    if detector is not None:
+                        data, flips = detector.feed(data)
+                        for _ in range(flips):
+                            frame.on_flip()
+                    if data:
+                        child.write(data)
                 else:
                     child.sendeof()
                     stdin_open = False
+            if bar is not None and frame.armed() != last_armed:
+                last_armed = frame.armed()
+                paint()
     finally:
+        if bar is not None:
+            os.write(out_fd, bar.clear())
         termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)
         signal.signal(signal.SIGWINCH, old_winch)
         signal.signal(signal.SIGTERM, old_term)

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -147,6 +147,9 @@ class FrameIO:
     bar: bool = True
     active: str = ""
     other: str = ""
+    # how `flip_byte` is spelled on the bar; the runner derives it from the
+    # configured byte so a rebound key advertises itself correctly
+    key_label: str = "^]"
     bar_dropped: bool = False
 
 
@@ -191,7 +194,11 @@ def run_in_pty(
         else None
     )
     guard = OutputGuard() if bar_on else None
-    bar = StatusBar(rows, cols, frame.active, frame.other) if bar_on else None
+    bar = (
+        StatusBar(rows, cols, frame.active, frame.other, frame.key_label)
+        if bar_on
+        else None
+    )
 
     child = PtyProcess.spawn(
         argv,

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -40,6 +40,27 @@ def _winsize(fd: int) -> tuple[int, int]:
         return (24, 80)
 
 
+# seconds of keyboard quiet after which the detector's carried escape
+# fragment is released to the child (a lone ESC must not wait for a key)
+_IDLE_FLUSH_S = 0.2
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte. os.write comes back short when a signal lands
+    mid-write — PEP 475 only retries a write that transferred nothing — and
+    this module writes under SIGWINCH by design, so a plain os.write can
+    strand half a repaint (raw escape bytes) on the user's screen."""
+    view = memoryview(data)
+    while view:
+        try:
+            n = os.write(fd, view)
+        except InterruptedError:
+            continue
+        if n <= 0:
+            break
+        view = view[n:]
+
+
 def _is_alive(child) -> bool:
     """isalive() is not thread-safe: it reaps via waitpid, so whichever of the
     pump thread and the terminating thread loses the race gets ECHILD back as a
@@ -184,7 +205,7 @@ def run_in_pty(
 
     def paint() -> None:
         if bar is not None:
-            os.write(out_fd, bar.region() + bar.paint(frame.armed()))
+            _write_all(out_fd, bar.region() + bar.paint(frame.armed()))
 
     def drop_bar() -> None:
         """Terminal state: the guard's drop verdict is not latched, so the
@@ -192,16 +213,23 @@ def run_in_pty(
         nonlocal bar_on, guard, bar
         if bar is None:
             return
-        os.write(out_fd, bar.clear())
+        # State down before any syscall. Drops and resizes are causally
+        # correlated (a child sets DECSTBM *because* the terminal resized,
+        # and a drag-resize bursts SIGWINCH), so a handler landing inside the
+        # writes below must already see bar is None — otherwise it repaints
+        # the region and bar *after* the clear and nothing is left to remove
+        # them, corrupting the terminal past tandem's exit.
+        dying, bar = bar, None
+        bar_on, guard = False, None
+        frame.bar_dropped = True
+        if detector is not None:
+            detector.bar_row = None
+        _write_all(out_fd, dying.clear())
         r, c = _winsize(stdin_fd)
         try:
             child.setwinsize(r, c)
         except Exception:
             pass
-        if detector is not None:
-            detector.bar_row = None
-        bar_on, guard, bar = False, None, None
-        frame.bar_dropped = True
 
     def on_winch(signum, frm):
         # runs as a signal handler in the pump thread: an escaping exception
@@ -238,6 +266,7 @@ def run_in_pty(
         # seeded from the state just painted, so an already-armed frame does
         # not draw a redundant repaint on the first iteration
         last_armed = frame.armed() if bar is not None else False
+        last_stdin = time.monotonic()
         stdin_open = True
         # _is_alive, not isalive(): a PtyControl on another thread polls
         # liveness too, and the loser of the waitpid race gets ECHILD as a
@@ -248,10 +277,16 @@ def run_in_pty(
                 ready, _, _ = select.select(rlist, [], [], 0.2)
             except InterruptedError:
                 continue  # signal (e.g. SIGWINCH) — loop again
-            if not ready and detector is not None:
-                # idle tick: release any escape fragment the detector is
-                # holding, so a lone ESC reaches the child without waiting
-                # for the next keypress to rule the sequence out.
+            if (
+                detector is not None
+                and stdin_fd not in ready
+                and time.monotonic() - last_stdin >= _IDLE_FLUSH_S
+            ):
+                # Idle *keyboard*, not idle loop: gating on an empty select
+                # would never fire against a child that streams (a spinner is
+                # enough), and streaming output is exactly when the user
+                # reaches for ESC. Release the fragment the detector is
+                # holding so a lone ESC lands without a second keypress.
                 stranded = detector.flush()
                 if stranded:
                     try:
@@ -265,7 +300,7 @@ def run_in_pty(
                     break
                 if not data:
                     break
-                os.write(out_fd, data)
+                _write_all(out_fd, data)
                 if guard is not None:
                     verdict = guard.feed(data)
                     if verdict == "drop":
@@ -274,6 +309,7 @@ def run_in_pty(
                         paint()
             if stdin_open and stdin_fd in ready:
                 data = os.read(stdin_fd, 65536)
+                last_stdin = time.monotonic()
                 if data:
                     if detector is not None:
                         data, flips = detector.feed(data)
@@ -282,16 +318,32 @@ def run_in_pty(
                     if data:
                         child.write(data)
                 else:
+                    if detector is not None:
+                        # anything still carried belongs before the EOF
+                        stranded = detector.flush()
+                        if stranded:
+                            try:
+                                child.write(stranded)
+                            except Exception:
+                                pass
                     child.sendeof()
                     stdin_open = False
             if bar is not None and frame.armed() != last_armed:
                 last_armed = frame.armed()
                 paint()
     finally:
-        if bar is not None:
-            os.write(out_fd, bar.clear())
-        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)
+        # SIGWINCH goes back first: its handler is the one that paints, and
+        # both the clear and tcsetattr (which blocks until the tty drains)
+        # are long windows for it to land in — a repaint after the final
+        # clear would outlive tandem with nothing left to remove it.
+        # Restoring the handler shuts that window, where clearing `bar`
+        # afterwards would still race the write itself. SIGTERM's handler
+        # only signals the child, never the terminal, so it stays installed
+        # until the terminal is whole again.
         signal.signal(signal.SIGWINCH, old_winch)
+        if bar is not None:
+            _write_all(out_fd, bar.clear())
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)
         signal.signal(signal.SIGTERM, old_term)
     try:
         child.wait()

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -443,6 +443,13 @@ class InteractiveRunner:
         monitor = FlipMonitor(
             control, adapter.quit_keystrokes(), transcript, sentinel,
             marker_wired=bool(hook_extra),
+            # claude only: codex has no session registry, and a probe that
+            # answers None would flip eagerly mid-turn — absence, not None
+            # answers, is how codex opts out.
+            status_probe=(
+                (lambda: adapter.session_status(active_sid))
+                if active == "claude" else None
+            ),
         )
         frame = FrameIO(
             flip_byte=frame_cfg.flip_byte,

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -116,6 +116,7 @@ def wait_until_safe(
     quiesce: float | None = None,
     poll: float = 0.2,
     marker_wired: bool = False,
+    provider: Callable[[], Path | None] | None = None,
 ) -> bool:
     """Block until the turn boundary. The transcript's last append lands
     before the Stop hook / notify touches the sentinel, so idle means the
@@ -126,7 +127,7 @@ def wait_until_safe(
 
     - `marker_wired=True` (the harness was launched with the turn-complete
       hook — the common case): the marker touch is the only normal trigger.
-      Quiescence stays wired as a 30s valve for a marker that never arrives,
+      Quiescence stays wired as a valve for a marker that never arrives,
       never as a turn-pacing signal.
     - `marker_wired=False` (no hook — e.g. codex with a user-configured
       notify handler tandem refuses to clobber): 2s of transcript quiescence
@@ -135,18 +136,41 @@ def wait_until_safe(
     `quiesce=None` takes the mode's default, so the mode alone is enough to
     be safe; pass a number to override (tests scale it down).
 
+    The transcript is re-read every poll through `provider`, because the path
+    is not always known when the wait starts: codex mints its own session id
+    and the runner's tail thread discovers the rollout seconds later. The
+    default provider returns the `transcript` argument forever, which is the
+    standalone (already-known path) contract this function shipped with.
+
+    An unknown transcript is *not* evidence of idleness. `_mtime(None)` is
+    0.0, so the plain `s >= t` test would call every unknown-transcript
+    session idle and fire a flip in the middle of a turn. With the marker
+    wired there is a better answer: nothing is known, so hold and let the
+    valve decide — anchored to the moment the wait began rather than to a
+    file mtime that does not exist. (Marker-less sessions keep the old
+    reading: quiescence is all they have, and their transcript is always
+    known — only codex's fresh-mint path arrives here with None, and that
+    path always wires the marker or falls back to the 2s quiescence over a
+    real file once discovery lands.)
+
     Both clocks here are wall-clock on purpose: the deadline is derived from
     file mtimes, so `time.time()` is the only comparable reading (monotonic
-    would be right for a pure timeout, but there is none in this loop).
-    A missing file reads as mtime 0, which makes a fresh session (no files
-    yet) idle in either mode, and leaves a marker-less session on the
-    quiescence path for as long as it runs."""
+    would be right for a pure timeout, but there is none in this loop)."""
     if quiesce is None:
         quiesce = _quiesce_default(marker_wired)
+    if provider is None:
+        provider = lambda: transcript  # noqa: E731 - back-compat default
+    armed_at = time.time()
     while True:
         if cancelled():
             return False
-        t, s = _mtime(transcript), _mtime(sentinel)
+        path = provider()
+        if path is None and marker_wired:
+            if time.time() - armed_at >= quiesce:
+                return True   # valve, from arm time: no mtime to anchor to
+            time.sleep(poll)
+            continue
+        t, s = _mtime(path), _mtime(sentinel)
         if s >= t:
             return True
         if time.time() - t >= quiesce:
@@ -158,6 +182,13 @@ class FlipMonitor:
     """Owns the flip lifecycle: the armed flag (toggle to cancel), the
     turn-boundary wait, and the termination ladder through the PtyControl.
     One background thread; all public methods are thread-safe.
+
+    `transcript` is a live attribute, not a constructor snapshot: codex mints
+    its own session id, so the runner's tail thread discovers the rollout
+    after launch and publishes it here. The wait loop re-reads it every poll
+    through a provider closure — a plain attribute read/write, which the GIL
+    makes atomic, so no lock is needed (and none may be added: `armed()` runs
+    inside the SIGWINCH handler on the pump thread).
 
     `marker_wired` says whether this launch actually got a turn-complete
     hook, which decides how the wait reads transcript quiescence (see
@@ -233,6 +264,7 @@ class FlipMonitor:
                 quiesce=self.quiesce,
                 poll=self.poll,
                 marker_wired=self.marker_wired,
+                provider=lambda: self.transcript,
             )
             if self._stop.is_set():
                 return
@@ -400,6 +432,13 @@ class InteractiveRunner:
                                 store.set_native_session_id(session.tandem_id, "codex", sid)
                                 current = store.get_session(session.tandem_id) or current
                             path = found
+                            # Publish to the flip monitor: until this lands it
+                            # has no transcript to judge a turn boundary by,
+                            # and holds any armed flip behind its valve. A bare
+                            # attribute write is all the synchronization there
+                            # is or should be — the GIL makes it atomic and the
+                            # monitor's wait re-reads it every poll.
+                            monitor.transcript = path
                             break
                     if path is None:
                         return

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -134,6 +134,7 @@ def wait_until_safe(
     poll: float = 0.2,
     marker_wired: bool = False,
     provider: Callable[[], Path | None] | None = None,
+    status_probe: Callable[[], str | None] | None = None,
 ) -> bool:
     """Block until the turn boundary. The transcript's last append lands
     before the Stop hook / notify touches the sentinel, so idle means the
@@ -172,7 +173,20 @@ def wait_until_safe(
 
     Both clocks here are wall-clock on purpose: the deadline is derived from
     file mtimes, so `time.time()` is the only comparable reading (monotonic
-    would be right for a pure timeout, but there is none in this loop)."""
+    would be right for a pure timeout, but there is none in this loop).
+
+    With `status_probe` (claude sessions), the probe is the entire
+    boundary test and the marker/quiescence rules above never run: the
+    probe reads claude's own session registry, which distinguishes a
+    running turn ("busy") from an idle prompt ("waiting") directly.
+    Anything but "busy" — including no answer at all — flips
+    immediately: single-tier by spec, eager on registry schema drift.
+    The valve is deliberately absent here; it existed to cap a marker
+    that never arrives, and it killed genuinely long turns. The
+    transcript-noise problem this solves: modern claude appends
+    housekeeping (away_summary, last-prompt) minutes after Stop and
+    bumps the transcript mtime on resume, so sentinel >= transcript is
+    false while the session sits idle at its prompt."""
     if quiesce is None:
         quiesce = _quiesce_default(marker_wired)
     if provider is None:
@@ -181,6 +195,11 @@ def wait_until_safe(
     while True:
         if cancelled():
             return False
+        if status_probe is not None:
+            if status_probe() == "busy":
+                time.sleep(poll)
+                continue
+            return True
         path = provider()
         if path is None and marker_wired:
             if time.time() - armed_at >= quiesce:
@@ -215,12 +234,17 @@ class FlipMonitor:
     user-configured notify), so `marker_wired=bool(hook_extra)` — reusing the
     list that went into argv rather than calling the adapter a second time,
     since a second call re-reads config and could disagree with what was
-    actually launched."""
+    actually launched.
+
+    `status_probe` (claude only) reads the harness's own session
+    registry and, when present, replaces the transcript/sentinel rules
+    entirely — see `wait_until_safe`."""
 
     def __init__(self, control, quit_bytes: list[bytes],
                  transcript: Path | None, sentinel: Path,
                  marker_wired: bool = False,
-                 quiesce: float | None = None, poll: float = 0.2):
+                 quiesce: float | None = None, poll: float = 0.2,
+                 status_probe: Callable[[], str | None] | None = None):
         self.control = control
         self.quit_bytes = quit_bytes
         self.transcript = transcript
@@ -228,6 +252,7 @@ class FlipMonitor:
         self.marker_wired = marker_wired
         self.quiesce = _quiesce_default(marker_wired) if quiesce is None else quiesce
         self.poll = poll
+        self.status_probe = status_probe
         self.flip_requested = False
         self.how = ""
         self._armed = threading.Event()
@@ -282,6 +307,7 @@ class FlipMonitor:
                 poll=self.poll,
                 marker_wired=self.marker_wired,
                 provider=lambda: self.transcript,
+                status_probe=self.status_probe,
             )
             if self._stop.is_set():
                 return

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -440,16 +440,25 @@ class InteractiveRunner:
 
         frame_cfg = load_frame_config()
         control = PtyControl()
+        def claude_probe() -> str | None:
+            # A raising probe would kill the tandem-flip thread and leave
+            # the bar advertising an armed flip that can never fire (os.kill
+            # raises OverflowError — not OSError — on a pid outside C-long
+            # range, so registry garbage can escape session_status's own
+            # guards). Single tier reads any non-answer as flippable, so an
+            # escape maps to None, never to a dead thread.
+            try:
+                return adapter.session_status(active_sid)
+            except Exception:
+                return None
+
         monitor = FlipMonitor(
             control, adapter.quit_keystrokes(), transcript, sentinel,
             marker_wired=bool(hook_extra),
             # claude only: codex has no session registry, and a probe that
             # answers None would flip eagerly mid-turn — absence, not None
             # answers, is how codex opts out.
-            status_probe=(
-                (lambda: adapter.session_status(active_sid))
-                if active == "claude" else None
-            ),
+            status_probe=claude_probe if active == "claude" else None,
         )
         frame = FrameIO(
             flip_byte=frame_cfg.flip_byte,

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -84,6 +84,115 @@ def ctx_to_cursor(ctx: SessionContext, cursor: SyncCursor) -> None:
     )
 
 
+def _mtime(path: Path | None) -> float:
+    if path is None:
+        return 0.0
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def wait_until_safe(
+    transcript: Path | None,
+    sentinel: Path | None,
+    cancelled: Callable[[], bool],
+    quiesce: float = 2.0,
+    poll: float = 0.2,
+) -> bool:
+    """Block until the turn boundary. The transcript's last append lands
+    before the Stop hook / notify touches the sentinel, so idle means the
+    sentinel is at least as new as the transcript; otherwise wait for the
+    marker touch, with transcript quiescence as the marker-less fallback.
+    Returns False if `cancelled()` turned true first.
+
+    Both clocks here are wall-clock on purpose: the deadline is derived from
+    file mtimes, so `time.time()` is the only comparable reading (monotonic
+    would be right for a pure timeout, but there is none in this loop).
+    A missing file reads as mtime 0, which makes a fresh session (no files)
+    idle and a marker-less mid-turn session take the quiescence path."""
+    while True:
+        if cancelled():
+            return False
+        t, s = _mtime(transcript), _mtime(sentinel)
+        if s >= t:
+            return True
+        if time.time() - t >= quiesce:
+            return True
+        time.sleep(poll)
+
+
+class FlipMonitor:
+    """Owns the flip lifecycle: the armed flag (toggle to cancel), the
+    turn-boundary wait, and the termination ladder through the PtyControl.
+    One background thread; all public methods are thread-safe."""
+
+    def __init__(self, control, quit_bytes: list[bytes],
+                 transcript: Path | None, sentinel: Path):
+        self.control = control
+        self.quit_bytes = quit_bytes
+        self.transcript = transcript
+        self.sentinel = sentinel
+        self.flip_requested = False
+        self.how = ""
+        self._armed = threading.Event()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name="tandem-flip", daemon=True
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._armed.set()  # unblock the wait
+        # 15s outlasts the worst-case ladder (attach wait 5s + soft
+        # keystrokes + soft/term/kill timeouts ~6.75s), so a stop() landing
+        # mid-ladder still joins instead of abandoning a live thread.
+        self._thread.join(timeout=15)
+
+    def flip_pressed(self) -> None:
+        """Arm, or toggle off a pending flip. Called from the pty pump's
+        stdin branch, so it must not block: Event.set/clear take only the
+        Event's own lock and never do I/O. It must also stay off any lock
+        that `armed()` needs — `armed()` runs inside the SIGWINCH handler on
+        this same thread, and a shared lock would deadlock the pump."""
+        if self._armed.is_set():
+            self._armed.clear()  # toggle: cancel a pending flip
+        else:
+            self._armed.set()
+
+    def armed(self) -> bool:
+        """Bar state: armed and still pending. Reached from inside the pump's
+        SIGWINCH handler (on_winch -> paint -> armed), so it is deliberately
+        lock-free, allocation-free and non-raising: Event.is_set() is a bare
+        flag read and `flip_requested` a plain attribute. Never add a lock,
+        a stat/read, or a raise path here. Goes False once the flip actually
+        fires, so the bar stops advertising an arm that is already spent."""
+        return self._armed.is_set() and not self.flip_requested
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._armed.wait()
+            if self._stop.is_set():
+                return
+            ok = wait_until_safe(
+                self.transcript,
+                self.sentinel,
+                cancelled=lambda: (
+                    not self._armed.is_set() or self._stop.is_set()
+                ),
+            )
+            if self._stop.is_set():
+                return
+            if not ok:
+                continue  # cancelled: back to waiting for the next arm
+            self.flip_requested = True
+            self.how = self.control.terminate(self.quit_bytes)
+            return
+
+
 class TailLoop:
     """Tails one source transcript, parses, feeds the sink, persists the
     cursor. Usable standalone in tests (no PTY required)."""

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -117,6 +117,15 @@ def _quiesce_default(marker_wired: bool) -> float:
     return _MISSED_MARKER_VALVE_S if marker_wired else _QUIESCE_S
 
 
+def _key_label(byte: int) -> str:
+    """How the bar spells the flip keybind. `config._parse_flip_key` only ever
+    yields 0x01-0x1F, so the caret form always applies; the hex fallback is
+    there so a future non-control binding still prints something."""
+    if 0x00 < byte < 0x20:
+        return "^" + chr(byte + 0x40)
+    return f"0x{byte:02x}"
+
+
 def wait_until_safe(
     transcript: Path | None,
     sentinel: Path | None,
@@ -416,6 +425,7 @@ class InteractiveRunner:
             bar=frame_cfg.bar,
             active=active,
             other=session.shadow,
+            key_label=_key_label(frame_cfg.flip_byte),
         )
         self.flip_requested = False
         self.reports = []

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -371,8 +371,13 @@ class InteractiveRunner:
     def __init__(self, session: PairedSession, sink_factory: SinkFactory):
         self.session = session
         self.sink_factory = sink_factory
-        # set here too so the attribute exists even if run() raises early
+        # set here too so the attributes exist even if run() raises early
         self.flip_requested = False
+        # Formatted, ready-to-print report lines for the session that just
+        # ran. `run()` prints them itself on a normal exit; on a flip it does
+        # not, because the flip's screen clear would wipe them a moment
+        # later — the shell reprints them onto the fresh screen instead.
+        self.reports: list[str] = []
 
     def run(self) -> int:
         session = self.session
@@ -413,6 +418,7 @@ class InteractiveRunner:
             other=session.shadow,
         )
         self.flip_requested = False
+        self.reports = []
 
         stop = threading.Event()
         spawn_time = time.time()
@@ -508,8 +514,9 @@ class InteractiveRunner:
                 "status bar disabled for this session (terminal conflict);"
                 " set [frame] bar = false to silence"
             )
-        for err in errors:
-            print(f"tandem: sync error: {err}")
-        for note in notes:
-            print(f"tandem: {note}")
+        self.reports = [f"tandem: sync error: {err}" for err in errors]
+        self.reports += [f"tandem: {note}" for note in notes]
+        if not self.flip_requested:
+            for line in self.reports:
+                print(line)
         return code

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -377,6 +377,12 @@ class InteractiveRunner:
         stop = threading.Event()
         spawn_time = time.time()
         errors: list[str] = []
+        # Two lists, one reporting spot: `errors` are sync failures (the
+        # "sync error" prefix is load-bearing — it tells the user their
+        # transcripts diverged), `notes` are everything else tandem wants to
+        # mention on the way out. A note printed as a sync error sends people
+        # hunting a failure that never happened.
+        notes: list[str] = []
 
         def tail_thread() -> None:
             # Own store/connection: sqlite handles are thread-bound, and the
@@ -451,10 +457,12 @@ class InteractiveRunner:
             except OSError:
                 pass  # doctor loses one hint; the session's exit code is not
                       # negotiable, and the note below still reaches the user
-            errors.append(
+            notes.append(
                 "status bar disabled for this session (terminal conflict);"
                 " set [frame] bar = false to silence"
             )
         for err in errors:
             print(f"tandem: sync error: {err}")
+        for note in notes:
+            print(f"tandem: {note}")
         return code

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -93,24 +93,56 @@ def _mtime(path: Path | None) -> float:
         return 0.0
 
 
+# Quiescence means two different things depending on whether the
+# turn-complete marker was wired at launch, so it gets two constants.
+_QUIESCE_S = 2.0            # marker-less: the only turn-boundary signal there is
+_MISSED_MARKER_VALVE_S = 30.0
+"""Safety valve for a marker that was wired but never arrived — a hook that
+failed to run, a notify handler that died. NOT turn pacing: real turns go
+quiet for seconds at a time (a long tool call appends nothing between the
+tool_use line and the tool_result line), so anything near the marker-less 2s
+would fire the flip 58s into a 60s `npm test` and kill the harness mid-turn.
+When the marker is wired it is the trigger; this is the last resort."""
+
+
+def _quiesce_default(marker_wired: bool) -> float:
+    return _MISSED_MARKER_VALVE_S if marker_wired else _QUIESCE_S
+
+
 def wait_until_safe(
     transcript: Path | None,
     sentinel: Path | None,
     cancelled: Callable[[], bool],
-    quiesce: float = 2.0,
+    quiesce: float | None = None,
     poll: float = 0.2,
+    marker_wired: bool = False,
 ) -> bool:
     """Block until the turn boundary. The transcript's last append lands
     before the Stop hook / notify touches the sentinel, so idle means the
-    sentinel is at least as new as the transcript; otherwise wait for the
-    marker touch, with transcript quiescence as the marker-less fallback.
-    Returns False if `cancelled()` turned true first.
+    sentinel is at least as new as the transcript. Returns False if
+    `cancelled()` turned true first.
+
+    Two modes, because transcript quiescence means different things:
+
+    - `marker_wired=True` (the harness was launched with the turn-complete
+      hook — the common case): the marker touch is the only normal trigger.
+      Quiescence stays wired as a 30s valve for a marker that never arrives,
+      never as a turn-pacing signal.
+    - `marker_wired=False` (no hook — e.g. codex with a user-configured
+      notify handler tandem refuses to clobber): 2s of transcript quiescence
+      is the fallback boundary, because nothing better exists.
+
+    `quiesce=None` takes the mode's default, so the mode alone is enough to
+    be safe; pass a number to override (tests scale it down).
 
     Both clocks here are wall-clock on purpose: the deadline is derived from
     file mtimes, so `time.time()` is the only comparable reading (monotonic
     would be right for a pure timeout, but there is none in this loop).
-    A missing file reads as mtime 0, which makes a fresh session (no files)
-    idle and a marker-less mid-turn session take the quiescence path."""
+    A missing file reads as mtime 0, which makes a fresh session (no files
+    yet) idle in either mode, and leaves a marker-less session on the
+    quiescence path for as long as it runs."""
+    if quiesce is None:
+        quiesce = _quiesce_default(marker_wired)
     while True:
         if cancelled():
             return False
@@ -125,14 +157,29 @@ def wait_until_safe(
 class FlipMonitor:
     """Owns the flip lifecycle: the armed flag (toggle to cancel), the
     turn-boundary wait, and the termination ladder through the PtyControl.
-    One background thread; all public methods are thread-safe."""
+    One background thread; all public methods are thread-safe.
+
+    `marker_wired` says whether this launch actually got a turn-complete
+    hook, which decides how the wait reads transcript quiescence (see
+    `wait_until_safe`). The caller derives it from the adapter: the argv the
+    runner already appended, `adapter.hook_argv_extra(sentinel)`, is empty
+    exactly when no hook was wired (codex declining to clobber a
+    user-configured notify), so `marker_wired=bool(hook_extra)` — reusing the
+    list that went into argv rather than calling the adapter a second time,
+    since a second call re-reads config and could disagree with what was
+    actually launched."""
 
     def __init__(self, control, quit_bytes: list[bytes],
-                 transcript: Path | None, sentinel: Path):
+                 transcript: Path | None, sentinel: Path,
+                 marker_wired: bool = False,
+                 quiesce: float | None = None, poll: float = 0.2):
         self.control = control
         self.quit_bytes = quit_bytes
         self.transcript = transcript
         self.sentinel = sentinel
+        self.marker_wired = marker_wired
+        self.quiesce = _quiesce_default(marker_wired) if quiesce is None else quiesce
+        self.poll = poll
         self.flip_requested = False
         self.how = ""
         self._armed = threading.Event()
@@ -183,6 +230,9 @@ class FlipMonitor:
                 cancelled=lambda: (
                     not self._armed.is_set() or self._stop.is_set()
                 ),
+                quiesce=self.quiesce,
+                poll=self.poll,
+                marker_wired=self.marker_wired,
             )
             if self._stop.is_set():
                 return

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -96,13 +96,21 @@ def _mtime(path: Path | None) -> float:
 # Quiescence means two different things depending on whether the
 # turn-complete marker was wired at launch, so it gets two constants.
 _QUIESCE_S = 2.0            # marker-less: the only turn-boundary signal there is
-_MISSED_MARKER_VALVE_S = 30.0
+_MISSED_MARKER_VALVE_S = 120.0
 """Safety valve for a marker that was wired but never arrived — a hook that
 failed to run, a notify handler that died. NOT turn pacing: real turns go
-quiet for seconds at a time (a long tool call appends nothing between the
-tool_use line and the tool_result line), so anything near the marker-less 2s
-would fire the flip 58s into a 60s `npm test` and kill the harness mid-turn.
-When the marker is wired it is the trigger; this is the last resort."""
+quiet for minutes at a time (a long tool call appends nothing between the
+tool_use line and the tool_result line — a full test suite, a slow install,
+a `sleep 90`), and firing there kills the harness mid-turn.
+
+The two error costs are wildly asymmetric, which is what sets the number.
+Firing too early costs a live turn: the harness is terminated between the
+tool call and its result, and that work is gone. Firing too late costs
+nothing but a wait, and only in the case this valve exists for at all — a
+dead hook — where a second Ctrl-] cancels the pending flip and the user can
+quit the harness by hand. So the valve sits far above any plausible
+tool-call silence rather than close to it. When the marker is wired it is
+the trigger; this is the last resort."""
 
 
 def _quiesce_default(marker_wired: bool) -> float:

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -16,10 +16,10 @@ from pathlib import Path
 from typing import Callable, Protocol
 
 from . import paths
-from .config import load_harness_args
+from .config import load_frame_config, load_harness_args
 from .events import SessionContext
 from .harness import get_adapter
-from .ptyrun import run_in_pty
+from .ptyrun import FrameIO, PtyControl, run_in_pty
 from .state import PairedSession, StateStore, SyncCursor
 from .tailer import JsonlTailer, TailedLine, TranscriptTruncated, TranscriptWatcher
 from .util import json_line
@@ -331,6 +331,8 @@ class InteractiveRunner:
     def __init__(self, session: PairedSession, sink_factory: SinkFactory):
         self.session = session
         self.sink_factory = sink_factory
+        # set here too so the attribute exists even if run() raises early
+        self.flip_requested = False
 
     def run(self) -> int:
         session = self.session
@@ -350,7 +352,27 @@ class InteractiveRunner:
         sentinel.parent.mkdir(parents=True, exist_ok=True)
         argv = adapter.interactive_argv(active_sid, fresh)
         argv += load_harness_args(active)
-        argv += adapter.hook_argv_extra(sentinel)
+        # bound, not re-called: hook_argv_extra re-reads config per call
+        # (codex checks the user's config.toml for a notify handler), so a
+        # second call could disagree with the argv actually launched.
+        hook_extra = adapter.hook_argv_extra(sentinel)
+        argv += hook_extra
+
+        frame_cfg = load_frame_config()
+        control = PtyControl()
+        monitor = FlipMonitor(
+            control, adapter.quit_keystrokes(), transcript, sentinel,
+            marker_wired=bool(hook_extra),
+        )
+        frame = FrameIO(
+            flip_byte=frame_cfg.flip_byte,
+            on_flip=monitor.flip_pressed,
+            armed=monitor.armed,
+            bar=frame_cfg.bar,
+            active=active,
+            other=session.shadow,
+        )
+        self.flip_requested = False
 
         stop = threading.Event()
         spawn_time = time.time()
@@ -409,12 +431,30 @@ class InteractiveRunner:
 
         thread = threading.Thread(target=tail_thread, name="tandem-tail", daemon=True)
         thread.start()
+        monitor.start()   # before the try: stop() on an unstarted thread raises
         try:
-            code = run_in_pty(argv, cwd=session.cwd)
+            code = run_in_pty(argv, cwd=session.cwd, frame=frame, control=control)
         finally:
             stop.set()
+            # stop() first, and only then read the monitor: `flip_requested`
+            # and `how` are assigned as the ladder finishes, so a read before
+            # the join races the flip thread.
+            monitor.stop()
             thread.join(timeout=10)
             sentinel.unlink(missing_ok=True)
+            self.flip_requested = monitor.flip_requested
+        if frame.bar_dropped:
+            marker = paths.tandem_home() / "tmp" / f"{session.tandem_id}-bar-dropped"
+            try:
+                marker.parent.mkdir(parents=True, exist_ok=True)
+                marker.touch()
+            except OSError:
+                pass  # doctor loses one hint; the session's exit code is not
+                      # negotiable, and the note below still reaches the user
+            errors.append(
+                "status bar disabled for this session (terminal conflict);"
+                " set [frame] bar = false to silence"
+            )
         for err in errors:
             print(f"tandem: sync error: {err}")
         return code

--- a/src/tandem/shell.py
+++ b/src/tandem/shell.py
@@ -186,10 +186,26 @@ def _flip_loop(
     return code
 
 
-def _switch(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
+def _switch(
+    tandem_id: str, run_harness, code: int, fall_back: bool = True
+) -> tuple[int, bool]:
     """Flip roles and re-enter the newly active harness. Returns the exit
     code to carry forward (unchanged if the flip failed) and whether the
-    re-entered harness asked for another flip."""
+    re-entered harness asked for another flip.
+
+    Two failures, two answers. The switch itself failing means roles never
+    moved, so the prompt is the right place to land. The switch succeeding
+    and the *launch* failing is worse: the user is now sitting at a prompt
+    whose active harness cannot start (`codex` uninstalled, a bad
+    `[codex] args`), which is precisely the dead end the spec's ladder
+    exists to avoid. So the first rung is to flip straight back and re-enter
+    the harness they just left — never strand them.
+
+    `fall_back=False` marks that flip-back attempt: one retry, no ping-pong
+    between two harnesses that both refuse to launch. If it also fails, the
+    caller lands at the prompt with the error shown — and the session itself
+    is never at risk, since `run_shell`'s finally always prints the resume
+    hint."""
     from .cli import _report_switch
 
     with StateStore() as store:
@@ -211,28 +227,46 @@ def _switch(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
             )
             return code, False
     _report_switch(old, new_active, problems, mem)
-    return _enter(tandem_id, run_harness, code)
+    code, flip, launched = _try_enter(tandem_id, run_harness, code)
+    if launched or not fall_back:
+        return code, flip
+    click.secho(
+        f"{new_active} would not start — switching back to {old}.",
+        fg="yellow",
+        err=True,
+    )
+    return _switch(tandem_id, run_harness, code, fall_back=False)
 
 
-def _enter(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
-    """Run the active harness; returns (exit code, flip requested). A failed
-    launch (or a session row that vanished) is reported and `code` is carried
-    forward with no flip, so the caller returns to the prompt instead of
-    losing the session."""
+def _try_enter(tandem_id: str, run_harness, code: int) -> tuple[int, bool, bool]:
+    """Run the active harness; returns (exit code, flip requested, launched).
+    `launched` is False when the harness never got off the ground (a missing
+    binary, a vanished session row) as opposed to running and exiting — the
+    distinction `_switch` needs to decide whether to flip back."""
     try:
         with StateStore() as store:
             session = store.get_session(tandem_id)
             if session is None:
                 raise LookupError(f"session {tandem_id} is not in the state store")
             store.touch_used(tandem_id)
-        return _norm(run_harness(session))
+        return (*_norm(run_harness(session)), True)
     except Exception as exc:
         click.secho(
             f"could not run the harness: {type(exc).__name__}: {exc}",
             fg="red",
             err=True,
         )
-        return code, False
+        return code, False, False
+
+
+def _enter(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
+    """Run the active harness; returns (exit code, flip requested). A failed
+    launch (or a session row that vanished) is reported and `code` is carried
+    forward with no flip, so the caller returns to the prompt instead of
+    losing the session. No flip-back ladder here: roles never moved, so the
+    harness the user just failed to launch *is* the one they were in."""
+    c, flip, _ = _try_enter(tandem_id, run_harness, code)
+    return c, flip
 
 
 def _dispatch(argv: list[str], tandem_id: str) -> None:

--- a/src/tandem/shell.py
+++ b/src/tandem/shell.py
@@ -30,19 +30,28 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
     tests (real: `input` and an InteractiveRunner)."""
     if input_fn is None:  # pragma: no cover - interactive default
         input_fn = input
+    # Report lines the runner held back because the flip about to happen would
+    # clear the screen out from under them; `_flip_loop` prints them onto the
+    # fresh screen. Scoped to this shell, refilled by every harness run.
+    # Injected test runners never touch it, which leaves it empty — harmless.
+    reports: list[str] = []
     if run_harness is None:  # pragma: no cover - interactive default
 
         def run_harness(session):
             from .runner import InteractiveRunner
 
             r = InteractiveRunner(session, sink_factory=sink_factory)
-            return r.run(), r.flip_requested
+            code = r.run()
+            reports[:] = r.reports
+            return code, r.flip_requested
 
     # The resume hint is the only place the id is shown, so it prints from a
     # finally: no failure inside the loop may cost the user their session.
     code = 1
     try:
-        code = _flip_loop(tandem_id, run_harness, _enter(tandem_id, run_harness, code))
+        code = _flip_loop(
+            tandem_id, run_harness, _enter(tandem_id, run_harness, code), reports
+        )
         while True:
             with StateStore() as store:
                 session = store.get_session(tandem_id)
@@ -64,7 +73,8 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
                 break
             if line in ("", "resume"):
                 code = _flip_loop(
-                    tandem_id, run_harness, _enter(tandem_id, run_harness, code)
+                    tandem_id, run_harness, _enter(tandem_id, run_harness, code),
+                    reports,
                 )
                 continue
             if line.split(maxsplit=1)[0] == "run":
@@ -100,7 +110,8 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
                 continue
             if argv == ["switch"]:
                 code = _flip_loop(
-                    tandem_id, run_harness, _switch(tandem_id, run_harness, code)
+                    tandem_id, run_harness, _switch(tandem_id, run_harness, code),
+                    reports,
                 )
                 continue
             _dispatch(argv, tandem_id)
@@ -151,14 +162,26 @@ def _clear_screen() -> None:
         sys.stdout.flush()
 
 
-def _flip_loop(tandem_id: str, run_harness, first: tuple[int, bool]) -> int:
+def _flip_loop(
+    tandem_id: str, run_harness, first: tuple[int, bool],
+    reports: list[str] | None = None,
+) -> int:
     """Keep flipping (Ctrl-]) until a session ends without requesting one.
     No prompt stop between flips — this is the frame's tab feel. A failed
     flip reports itself and returns no-flip, which ends the loop and drops
-    the user back at the prompt with the session intact."""
+    the user back at the prompt with the session intact.
+
+    `reports` is the outgoing session's held-back report lines (sync errors,
+    notes). They print right after the clear, never before it: the clear is
+    what would otherwise erase them, and the whole point is that a flip must
+    not cost the user a sync-failure warning."""
     code, flip = first
     while flip:
         _clear_screen()
+        if reports:
+            for line in reports:
+                click.echo(line)
+            reports.clear()   # this session's news, reported once
         code, flip = _switch(tandem_id, run_harness, code)
     return code
 

--- a/src/tandem/shell.py
+++ b/src/tandem/shell.py
@@ -2,14 +2,16 @@
 
 Bare `tandem` / `tandem resume` enter here: run the active harness on its
 PTY; when the user exits it, offer a prompt instead of returning to the OS
-shell. `switch` flips roles and re-enters immediately; other lines are
-dispatched through the click group so one-shot and prompt behavior never
-drift apart.
+shell. `switch` flips roles and re-enters immediately, and a flip asked for
+from inside the harness (Ctrl-]) re-enters the other one with no prompt stop
+at all; other lines are dispatched through the click group so one-shot and
+prompt behavior never drift apart.
 """
 
 from __future__ import annotations
 
 import shlex
+import sys
 
 import click
 
@@ -33,13 +35,14 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
         def run_harness(session):
             from .runner import InteractiveRunner
 
-            return InteractiveRunner(session, sink_factory=sink_factory).run()
+            r = InteractiveRunner(session, sink_factory=sink_factory)
+            return r.run(), r.flip_requested
 
     # The resume hint is the only place the id is shown, so it prints from a
     # finally: no failure inside the loop may cost the user their session.
     code = 1
     try:
-        code = _enter(tandem_id, run_harness, code)
+        code = _flip_loop(tandem_id, run_harness, _enter(tandem_id, run_harness, code))
         while True:
             with StateStore() as store:
                 session = store.get_session(tandem_id)
@@ -60,7 +63,9 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
             if line in ("exit", "quit"):
                 break
             if line in ("", "resume"):
-                code = _enter(tandem_id, run_harness, code)
+                code = _flip_loop(
+                    tandem_id, run_harness, _enter(tandem_id, run_harness, code)
+                )
                 continue
             if line.split(maxsplit=1)[0] == "run":
                 parsed = _split_run_line(line)
@@ -94,7 +99,9 @@ def run_shell(tandem_id: str, sink_factory, input_fn=None, run_harness=None) -> 
                 )
                 continue
             if argv == ["switch"]:
-                code = _switch(tandem_id, run_harness, code)
+                code = _flip_loop(
+                    tandem_id, run_harness, _switch(tandem_id, run_harness, code)
+                )
                 continue
             _dispatch(argv, tandem_id)
     finally:
@@ -132,9 +139,34 @@ def _split_run_line(line: str) -> tuple[str, str] | None:
     return target, prompt
 
 
-def _switch(tandem_id: str, run_harness, code: int) -> int:
+def _norm(res) -> tuple[int, bool]:
+    """run_harness returns `(code, flip)`; a bare int (legacy callers and
+    test seams) means "exited, no flip"."""
+    return res if isinstance(res, tuple) else (res, False)
+
+
+def _clear_screen() -> None:
+    if sys.stdout.isatty():  # pragma: no cover - interactive only
+        sys.stdout.write("\x1b[2J\x1b[H")
+        sys.stdout.flush()
+
+
+def _flip_loop(tandem_id: str, run_harness, first: tuple[int, bool]) -> int:
+    """Keep flipping (Ctrl-]) until a session ends without requesting one.
+    No prompt stop between flips — this is the frame's tab feel. A failed
+    flip reports itself and returns no-flip, which ends the loop and drops
+    the user back at the prompt with the session intact."""
+    code, flip = first
+    while flip:
+        _clear_screen()
+        code, flip = _switch(tandem_id, run_harness, code)
+    return code
+
+
+def _switch(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
     """Flip roles and re-enter the newly active harness. Returns the exit
-    code to carry forward (unchanged if the flip failed)."""
+    code to carry forward (unchanged if the flip failed) and whether the
+    re-entered harness asked for another flip."""
     from .cli import _report_switch
 
     with StateStore() as store:
@@ -146,7 +178,7 @@ def _switch(tandem_id: str, run_harness, code: int) -> int:
                 fg="red",
                 err=True,
             )
-            return code
+            return code, False
         old = session.active
         try:
             new_active, problems, mem = ops.switch_session(store, session)
@@ -154,29 +186,30 @@ def _switch(tandem_id: str, run_harness, code: int) -> int:
             click.secho(
                 f"switch failed: {type(exc).__name__}: {exc}", fg="red", err=True
             )
-            return code
+            return code, False
     _report_switch(old, new_active, problems, mem)
     return _enter(tandem_id, run_harness, code)
 
 
-def _enter(tandem_id: str, run_harness, code: int) -> int:
-    """Run the active harness and return its exit code. A failed launch (or a
-    session row that vanished) is reported and `code` is carried forward, so
-    the caller returns to the prompt instead of losing the session."""
+def _enter(tandem_id: str, run_harness, code: int) -> tuple[int, bool]:
+    """Run the active harness; returns (exit code, flip requested). A failed
+    launch (or a session row that vanished) is reported and `code` is carried
+    forward with no flip, so the caller returns to the prompt instead of
+    losing the session."""
     try:
         with StateStore() as store:
             session = store.get_session(tandem_id)
             if session is None:
                 raise LookupError(f"session {tandem_id} is not in the state store")
             store.touch_used(tandem_id)
-        return run_harness(session)
+        return _norm(run_harness(session))
     except Exception as exc:
         click.secho(
             f"could not run the harness: {type(exc).__name__}: {exc}",
             fg="red",
             err=True,
         )
-        return code
+        return code, False
 
 
 def _dispatch(argv: list[str], tandem_id: str) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,12 @@
 """config.toml: defaults on missing/broken file, validated values."""
 
-from tandem.config import SubagentsConfig, load_harness_args, load_subagents_config
+from tandem.config import (
+    FrameConfig,
+    SubagentsConfig,
+    load_frame_config,
+    load_harness_args,
+    load_subagents_config,
+)
 
 
 def test_defaults_when_file_missing(tmp_path, monkeypatch):
@@ -105,3 +111,52 @@ def test_harness_args_invalid_shapes_fall_back(tmp_path, monkeypatch):
     for body in cases:
         (home / "config.toml").write_text(body)
         assert load_harness_args("claude") == [], body
+
+
+def _write_config(tmp_path, monkeypatch, text):
+    """The file's home/config.toml idiom, folded up: the [frame] tests differ
+    only in the table body."""
+    home = tmp_path / ".tandem"
+    home.mkdir(exist_ok=True)
+    (home / "config.toml").write_text(text)
+    monkeypatch.setenv("TANDEM_HOME", str(home))
+
+
+def test_frame_defaults_without_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path / ".tandem"))
+    cfg = load_frame_config()
+    assert cfg == FrameConfig(flip_byte=0x1D, bar=True)
+
+
+def test_frame_flip_key_ctrl_name(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "ctrl-t"\n')
+    assert load_frame_config().flip_byte == 0x14
+
+
+def test_frame_flip_key_hex(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "0x1e"\n')
+    assert load_frame_config().flip_byte == 0x1E
+
+
+def test_frame_flip_key_printable_rejected(tmp_path, monkeypatch):
+    # a printable key would swallow real typing — fall back to default
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "a"\n')
+    assert load_frame_config().flip_byte == 0x1D
+
+
+def test_frame_bar_off(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nbar = false\n')
+    assert load_frame_config().bar is False
+
+
+def test_frame_flip_key_multichar_casefold_does_not_raise(tmp_path, monkeypatch):
+    # "ß".upper() == "SS", so case-folding before ord() raises TypeError and
+    # takes the launch down with it — no [frame] value may ever raise. 0xDF &
+    # 0x1F is a control byte, so this one is accepted rather than defaulted.
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = "ctrl-ß"\n')
+    assert load_frame_config() == FrameConfig(flip_byte=0x1F, bar=True)
+
+
+def test_frame_malformed_values_fall_back(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = 29\nbar = "yes"\n')
+    assert load_frame_config() == FrameConfig()

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -131,6 +131,96 @@ def test_flip_after_dead_escape_fragment_still_fires():
     assert f1 + f2 == 1
 
 
+# -- kitty keyboard protocol (CSI u) flip encoding -------------------------
+#
+# codex's TUI pushes kitty enhancement flags (\x1b[>7u) on terminals that
+# support them, after which Ctrl-] arrives as \x1b[93;5u — never as the raw
+# 0x1D byte. The detector has to speak both encodings or the flip key is
+# silently dead for the whole codex phase (observed live on codex 0.147).
+
+
+def test_kitty_flip_press_consumed_and_counted():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"a\x1b[93;5ub")
+    assert out == b"ab"
+    assert flips == 1
+
+
+def test_kitty_flip_event_type_press_counted():
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[93;5:1u")
+    assert out == b"" and flips == 1
+
+
+def test_kitty_flip_repeat_counted_like_legacy_autorepeat():
+    # legacy autorepeat delivers the raw byte again and again; the CSI-u
+    # repeat event (:2) keeps that behavior instead of inventing a new one
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[93;5:2u")
+    assert out == b"" and flips == 1
+
+
+def test_kitty_flip_release_swallowed_not_counted():
+    # the release (:3) belongs to a press tandem already consumed: forwarding
+    # it hands the child a key-up for a key it never saw go down, and
+    # counting it would double every flip
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[93;5:3u")
+    assert out == b"" and flips == 0
+
+
+def test_kitty_flip_with_lock_modifiers_counted():
+    # capslock (64) and numlock (128) ride along on real keyboards and must
+    # not unbind the flip key
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[93;69u\x1b[93;133u")
+    assert out == b"" and flips == 2
+
+
+def test_kitty_flip_with_alternate_codepoints_counted():
+    # "report alternate keys" (flag 4, part of the >7u push) appends
+    # shifted/base-layout codepoints after a colon
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[93:125;5u")
+    assert out == b"" and flips == 1
+
+
+def test_kitty_other_ctrl_key_passes_through():
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[97;5u")   # ctrl-a
+    assert out == b"\x1b[97;5u" and flips == 0
+
+
+def test_kitty_flip_key_without_plain_ctrl_passes_through():
+    # ctrl+shift+] (mods 6) is a different chord, not the flip key
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[93;6u")
+    assert out == b"\x1b[93;6u" and flips == 0
+
+
+def test_kitty_flip_split_across_feeds_still_fires():
+    d = FlipDetector(FLIP)
+    out1, f1 = d.feed(b"\x1b[93;5")
+    out2, f2 = d.feed(b"u")
+    assert out1 + out2 == b""
+    assert f1 + f2 == 1
+
+
+def test_kitty_flip_inside_bracketed_paste_passes_through():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"\x1b[200~\x1b[93;5u\x1b[201~")
+    assert out == b"\x1b[200~\x1b[93;5u\x1b[201~"
+    assert flips == 0
+
+
+def test_kitty_flip_for_rebound_letter_key():
+    # [frame] flip_key = "ctrl-t" (0x14): kitty reports the lowercase
+    # codepoint (116); the legacy byte stays bound alongside
+    d = FlipDetector(0x14)
+    out, flips = d.feed(b"\x1b[116;5u")
+    assert out == b"" and flips == 1
+    out, flips = d.feed(b"\x14")
+    assert out == b"" and flips == 1
+
+
+def test_kitty_lookalike_ctrl_arrow_passes_through():
+    out, flips = FlipDetector(FLIP).feed(b"\x1b[1;5C")
+    assert out == b"\x1b[1;5C" and flips == 0
+
+
 def test_guard_plain_output_no_verdict():
     assert OutputGuard().feed(b"hello \x1b[31mred\x1b[0m") == ""
 
@@ -154,8 +244,55 @@ def test_guard_bare_region_reset_triggers_reassert():
 
 
 def test_guard_parameterized_region_triggers_drop():
-    # the child drives its own scroll regions: the bar cannot coexist
+    # rows unknown (the default): any parameterized region must be assumed
+    # to cover the bar row
     assert OutputGuard().feed(b"\x1b[5;40r") == "drop"
+
+
+def test_guard_child_region_above_the_bar_is_benign():
+    # codex's TUI asserts \x1b[1;<rows-2>r at startup to guard its own
+    # composer rows. That region never touches tandem's bar row, so it is
+    # not a conflict — dropping here means the bar can never survive a
+    # codex phase (the live-validation blocker).
+    g = OutputGuard(rows=40)
+    assert g.feed(b"\x1b[1;38r") == "reassert"
+    assert g.child_owns_region is True
+
+
+def test_guard_region_bottom_just_under_the_bar_is_benign():
+    # rows-1 is exactly tandem's own region shape
+    assert OutputGuard(rows=40).feed(b"\x1b[1;39r") == "reassert"
+
+
+def test_guard_child_region_reaching_the_bar_row_drops():
+    assert OutputGuard(rows=40).feed(b"\x1b[1;40r") == "drop"
+
+
+def test_guard_single_param_region_still_drops():
+    # bottom omitted defaults to the last row: bar row included
+    assert OutputGuard(rows=40).feed(b"\x1b[5r") == "drop"
+
+
+def test_guard_bare_reset_releases_the_child_region():
+    g = OutputGuard(rows=40)
+    assert g.feed(b"\x1b[1;38r") == "reassert"
+    assert g.feed(b"\x1b[r") == "reassert"
+    assert g.child_owns_region is False
+
+
+def test_guard_ris_releases_the_child_region():
+    g = OutputGuard(rows=40)
+    g.feed(b"\x1b[1;38r")
+    assert g.feed(b"\x1bc") == "reassert"
+    assert g.child_owns_region is False
+
+
+def test_guard_resize_rejudges_regions():
+    # the pump updates rows on SIGWINCH: the same sequence that was benign
+    # at 40 rows covers the bar after a shrink to 30
+    g = OutputGuard(rows=40)
+    g.rows = 30
+    assert g.feed(b"\x1b[1;38r") == "drop"
 
 
 def test_guard_drop_wins_over_reassert():

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3,6 +3,7 @@
 from unicodedata import east_asian_width
 
 from tandem.frame import FlipDetector, OutputGuard, StatusBar
+from tandem.harness import get_adapter
 
 FLIP = 0x1D  # Ctrl-]
 
@@ -367,3 +368,15 @@ def test_feed_after_flush_starts_clean():
     assert d.flush() == b"\x1b[2"
     out, flips = d.feed(b"00~\x1d")          # no longer a paste-begin
     assert out == b"00~" and flips == 1
+
+
+def test_claude_quit_recipe():
+    # Ctrl-C clears the composer / interrupts, Ctrl-D on the empty
+    # composer exits
+    assert get_adapter("claude").quit_keystrokes() == [b"\x03", b"\x04"]
+
+
+def test_codex_quit_recipe():
+    # Ctrl-C clears/interrupts, second Ctrl-C quits ("press again"),
+    # Ctrl-D backstops older builds
+    assert get_adapter("codex").quit_keystrokes() == [b"\x03", b"\x03", b"\x04"]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -331,3 +331,39 @@ def test_bar_region_and_clear_track_resize():
     bar.resize(rows=30, cols=50)
     assert bar.region() == b"\x1b7\x1b[1;29r\x1b8"
     assert bar.clear() == b"\x1b7\x1b[r\x1b[30;1H\x1b[2K\x1b8"
+
+
+def test_flush_returns_and_clears_carry():
+    # a lone ESC sits in the carry until the next keypress rules the sequence
+    # out — and ESC is the interrupt key in both TUIs, so the pump flushes the
+    # carry on an idle tick rather than making the user press another key
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"\x1b")
+    assert out == b"" and flips == 0
+    assert d.flush() == b"\x1b"
+    assert d.flush() == b""                  # carry is cleared, not re-emitted
+
+
+def test_flush_empty_when_nothing_carried():
+    d = FlipDetector(FLIP)
+    d.feed(b"hello")
+    assert d.flush() == b""
+
+
+def test_flush_preserves_paste_state():
+    # paste state is not carry state: flushing a stranded fragment must not
+    # reopen the flip keybind in the middle of someone's paste
+    d = FlipDetector(FLIP)
+    d.feed(b"\x1b[200~abc")
+    d.feed(b"\x1b")
+    assert d.flush() == b"\x1b"
+    out, flips = d.feed(b"\x1d")
+    assert out == b"\x1d" and flips == 0     # still inside the paste
+
+
+def test_feed_after_flush_starts_clean():
+    d = FlipDetector(FLIP)
+    d.feed(b"\x1b[2")                        # possible paste marker, carried
+    assert d.flush() == b"\x1b[2"
+    out, flips = d.feed(b"00~\x1d")          # no longer a paste-begin
+    assert out == b"00~" and flips == 1

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,6 +1,6 @@
 """Frame state machines: pure bytes-in/bytes-out, no PTY, no threads."""
 
-from tandem.frame import FlipDetector
+from tandem.frame import FlipDetector, OutputGuard
 
 FLIP = 0x1D  # Ctrl-]
 
@@ -126,3 +126,91 @@ def test_flip_after_dead_escape_fragment_still_fires():
     out2, f2 = d.feed(b"\x1d")
     assert out1 + out2 == b"\x1b[<"
     assert f1 + f2 == 1
+
+
+def test_guard_plain_output_no_verdict():
+    assert OutputGuard().feed(b"hello \x1b[31mred\x1b[0m") == ""
+
+
+def test_guard_clear_screen_triggers_reassert():
+    assert OutputGuard().feed(b"\x1b[2J") == "reassert"
+
+
+def test_guard_alt_screen_enter_and_leave_trigger_reassert():
+    g = OutputGuard()
+    assert g.feed(b"\x1b[?1049h") == "reassert"
+    assert g.feed(b"\x1b[?1049l") == "reassert"
+
+
+def test_guard_ris_triggers_reassert():
+    assert OutputGuard().feed(b"\x1bc") == "reassert"
+
+
+def test_guard_bare_region_reset_triggers_reassert():
+    assert OutputGuard().feed(b"\x1b[r") == "reassert"
+
+
+def test_guard_parameterized_region_triggers_drop():
+    # the child drives its own scroll regions: the bar cannot coexist
+    assert OutputGuard().feed(b"\x1b[5;40r") == "drop"
+
+
+def test_guard_drop_wins_over_reassert():
+    assert OutputGuard().feed(b"\x1b[2J\x1b[5;40r") == "drop"
+
+
+def test_guard_sequence_split_across_feeds():
+    g = OutputGuard()
+    assert g.feed(b"text\x1b[?10") == ""
+    assert g.feed(b"49h more") == "reassert"
+
+
+def test_guard_does_not_double_count_carry():
+    g = OutputGuard()
+    assert g.feed(b"\x1b[2J") == "reassert"
+    # the sequence sits inside the carry window now; a new feed with no
+    # fresh trigger must not re-fire it
+    assert g.feed(b"quiet") == ""
+
+
+def test_guard_bare_region_reset_followed_by_digit_still_fires():
+    # \x1b[r is a complete bare DECSTBM no matter what follows it, and it can
+    # never be the front of a parameterized one (those put the digits *before*
+    # the r). Suppressing it when a digit follows makes the verdict depend on
+    # where the read boundary fell: split right after the r it fires, unsplit
+    # it never does — the same child output, two different frames.
+    assert OutputGuard().feed(b"\x1b[r5 lines") == "reassert"
+    g = OutputGuard()
+    assert g.feed(b"\x1b[r") == "reassert"
+    assert g.feed(b"5 lines") == ""      # already fired; not re-fired either
+
+
+def test_guard_widest_watched_sequence_split_across_feeds():
+    # the longest watched sequence is 12 bytes (\x1b[1234;5678r), so the carry
+    # window has to span it; a window sized to the common \x1b[5;40r would drop
+    # the verdict whenever a read boundary lands near its head
+    g = OutputGuard()
+    assert g.feed(b"tail\x1b[1234;5678") == ""
+    assert g.feed(b"r") == "drop"
+
+
+def test_guard_ignores_lookalike_sequences():
+    # 256-colour SGR (digits and a ; but terminates in m), a cursor position
+    # report (capital R, not r) and erase-below (no parameter) are all routine
+    # output that must not cost the bar
+    assert OutputGuard().feed(b"\x1b[38;5;196mhi\x1b[0m\x1b[24;80R\x1b[J") == ""
+
+
+def test_guard_refires_once_the_carry_window_has_scrolled_past():
+    # suppression is "already reported", not "seen once": a second clear must
+    # still be reported
+    g = OutputGuard()
+    assert g.feed(b"\x1b[2J") == "reassert"
+    assert g.feed(b"z" * 20) == ""
+    assert g.feed(b"\x1b[2J") == "reassert"
+
+
+def test_guard_empty_feed_is_inert():
+    g = OutputGuard()
+    assert g.feed(b"\x1b[2J") == "reassert"
+    assert g.feed(b"") == ""

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,128 @@
+"""Frame state machines: pure bytes-in/bytes-out, no PTY, no threads."""
+
+from tandem.frame import FlipDetector
+
+FLIP = 0x1D  # Ctrl-]
+
+
+def test_flip_byte_consumed_and_counted():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"hello\x1dworld")
+    assert out == b"helloworld"
+    assert flips == 1
+
+
+def test_plain_bytes_pass_through_untouched():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"ls -la\r")
+    assert out == b"ls -la\r"
+    assert flips == 0
+
+
+def test_flip_byte_inside_bracketed_paste_passes_through():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"\x1b[200~abc\x1ddef\x1b[201~")
+    assert out == b"\x1b[200~abc\x1ddef\x1b[201~"
+    assert flips == 0
+
+
+def test_flip_after_paste_end_fires():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"\x1b[200~x\x1b[201~\x1d")
+    assert out == b"\x1b[200~x\x1b[201~"
+    assert flips == 1
+
+
+def test_paste_marker_split_across_feeds():
+    d = FlipDetector(FLIP)
+    out1, f1 = d.feed(b"\x1b[20")          # partial paste-begin marker
+    out2, f2 = d.feed(b"0~\x1d\x1b[201~")  # completes it; 0x1D is pasted
+    assert out1 + out2 == b"\x1b[200~\x1d\x1b[201~"
+    assert f1 == 0 and f2 == 0
+
+
+def test_paste_state_persists_across_feeds():
+    d = FlipDetector(FLIP)
+    d.feed(b"\x1b[200~abc")
+    out, flips = d.feed(b"\x1ddef")        # still inside the paste
+    assert out == b"\x1ddef"
+    assert flips == 0
+
+
+def test_paste_begin_split_after_one_digit():
+    # \x1b[2 is a legitimate prefix of both paste markers and must be carried:
+    # flushing it de-syncs paste state and eats a pasted 0x1D as a phantom flip
+    d = FlipDetector(FLIP)
+    out1, f1 = d.feed(b"\x1b[2")
+    out2, f2 = d.feed(b"00~x\x1dy\x1b[201~")
+    assert out1 + out2 == b"\x1b[200~x\x1dy\x1b[201~"
+    assert f1 == 0 and f2 == 0          # pasted 0x1D relays, no phantom flip
+
+
+def test_paste_end_split_after_one_digit():
+    # same split inside PASTE_END: if it flushes, _in_paste latches on and the
+    # flip keybind is silently dead for the rest of the session
+    d = FlipDetector(FLIP)
+    d.feed(b"\x1b[200~abc")
+    out1, f1 = d.feed(b"\x1b[2")
+    out2, f2 = d.feed(b"01~")
+    out3, f3 = d.feed(b"\x1d")           # paste closed: flip must fire again
+    assert out1 + out2 == b"\x1b[201~"
+    assert f3 == 1
+    assert out3 == b"" and f1 == 0 and f2 == 0
+
+
+def test_mouse_click_on_bar_row_swallowed():
+    d = FlipDetector(FLIP, bar_row=40)
+    out, flips = d.feed(b"\x1b[<0;12;40M")
+    assert out == b""
+    assert flips == 0
+
+
+def test_mouse_click_elsewhere_passes_through():
+    d = FlipDetector(FLIP, bar_row=40)
+    out, _ = d.feed(b"\x1b[<0;12;39M")
+    assert out == b"\x1b[<0;12;39M"
+
+
+def test_mouse_ignored_when_no_bar():
+    d = FlipDetector(FLIP, bar_row=None)
+    out, _ = d.feed(b"\x1b[<0;12;40M")
+    assert out == b"\x1b[<0;12;40M"
+
+
+def test_lone_esc_not_swallowed():
+    # a bare ESC keypress must reach the child promptly-ish: it is carried
+    # only while it could still become a tracked sequence, and flushed as
+    # soon as following bytes rule that out
+    d = FlipDetector(FLIP)
+    out1, _ = d.feed(b"\x1b")
+    out2, _ = d.feed(b"q")
+    assert out1 + out2 == b"\x1bq"
+
+
+def test_repeated_flips_in_one_chunk_all_counted():
+    d = FlipDetector(FLIP)
+    out, flips = d.feed(b"a\x1db\x1d\x1dc")
+    assert out == b"abc"
+    assert flips == 3
+
+
+def test_wide_mouse_event_split_across_feeds_still_swallowed():
+    # scroll button (64) at a 3-digit column: the fragment before the final
+    # M is 12 bytes, so the carry window must span the longest trackable
+    # prefix, not just the width of the narrowest mouse event
+    d = FlipDetector(FLIP, bar_row=40)
+    out1, _ = d.feed(b"\x1b[<64;120;40")
+    out2, _ = d.feed(b"M")
+    assert out1 + out2 == b""
+
+
+def test_flip_after_dead_escape_fragment_still_fires():
+    # \x1b[< is carried as a possible mouse event; the flip byte rules that
+    # out, so the fragment flushes verbatim and the flip still counts
+    d = FlipDetector(FLIP)
+    out1, f1 = d.feed(b"\x1b[<")
+    out2, f2 = d.feed(b"\x1d")
+    assert out1 + out2 == b"\x1b[<"
+    assert f1 + f2 == 1

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,6 +1,8 @@
 """Frame state machines: pure bytes-in/bytes-out, no PTY, no threads."""
 
-from tandem.frame import FlipDetector, OutputGuard
+from unicodedata import east_asian_width
+
+from tandem.frame import FlipDetector, OutputGuard, StatusBar
 
 FLIP = 0x1D  # Ctrl-]
 
@@ -214,3 +216,118 @@ def test_guard_empty_feed_is_inert():
     g = OutputGuard()
     assert g.feed(b"\x1b[2J") == "reassert"
     assert g.feed(b"") == ""
+
+
+def test_bar_line_shows_active_and_other():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    line = bar.line(armed=False)
+    assert "claude ●" in line and "codex ○" in line and "^] flips" in line
+    assert len(line) == 60
+
+
+def test_bar_line_armed_state():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    line = bar.line(armed=True)
+    assert "flipping at turn end" in line and "^] cancels" in line
+
+
+def test_bar_line_truncates_to_width():
+    bar = StatusBar(rows=40, cols=12, active="claude", other="codex")
+    assert len(bar.line(armed=False)) == 12
+
+
+def test_bar_paint_targets_real_bottom_row_and_restores_cursor():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    b = bar.paint(armed=False)
+    assert b.startswith(b"\x1b7")        # DECSC save cursor
+    assert b"\x1b[40;1H" in b            # jump to the real bottom row
+    assert b"\x1b[7m" in b               # inverse video
+    assert b.endswith(b"\x1b[0m\x1b8")   # reset attrs, DECRC restore
+
+
+def test_bar_region_reserves_all_but_last_row():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    b = bar.region()
+    assert b == b"\x1b7\x1b[1;39r\x1b8"  # DECSTBM homes the cursor: save/restore
+
+
+def test_bar_clear_restores_full_region_and_wipes_row():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    b = bar.clear()
+    assert b"\x1b[r" in b                # full-screen scroll region back
+    assert b"\x1b[40;1H" in b and b"\x1b[2K" in b
+
+
+def test_bar_resize_recomputes():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    bar.resize(rows=30, cols=50)
+    assert b"\x1b[30;1H" in bar.paint(armed=False)
+    assert len(bar.line(armed=False)) == 50
+
+
+def _body(painted: bytes) -> str:
+    """The line as painted: the bytes between inverse-video on and reset."""
+    head, _, rest = painted.partition(b"\x1b[7m")
+    body, _, tail = rest.partition(b"\x1b[0m")
+    assert head and tail == b"\x1b8"
+    return body.decode()
+
+
+def test_bar_armed_line_also_truncates_to_width():
+    # the armed text is the longer of the two, so a narrow terminal truncates
+    # it where the idle one still fits: the width invariant has to hold in
+    # both states or an armed repaint overruns the row
+    bar = StatusBar(rows=40, cols=12, active="claude", other="codex")
+    assert len(bar.line(armed=True)) == 12
+    assert len(_body(bar.paint(armed=True))) == 12
+
+
+def test_bar_paint_body_is_exactly_cols_wide_in_both_states():
+    # what task 6 writes is paint(), not line(): the width invariant is only
+    # worth anything if it survives composition
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    assert len(_body(bar.paint(armed=False))) == 60
+    assert len(_body(bar.paint(armed=True))) == 60
+
+
+def test_bar_line_has_no_double_width_glyphs():
+    # line() pads and truncates by character count, so a glyph the terminal
+    # draws in two cells makes the painted row one cell wider than cols and
+    # wraps off the last row. Ambiguous-width glyphs (● │ ○ ◐, EAW 'A') are
+    # one cell outside CJK-wide terminal configs; unconditionally wide ones
+    # (EAW 'W'/'F' — e.g. ⏳ U+23F3) are never safe here.
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    for armed in (False, True):
+        wide = [c for c in bar.line(armed) if east_asian_width(c) in "WF"]
+        assert wide == [], f"armed={armed}: double-width glyphs {wide}"
+
+
+def test_bar_region_floors_at_one_row():
+    # ioctl reports 0×0 when the terminal size is unknown, and a 1-row pane is
+    # legal: rows-1 must not emit `\x1b[1;0r` (bottom <= top, silently ignored,
+    # leaving whatever region was set) or the malformed `\x1b[1;-1r`
+    assert StatusBar(rows=2, cols=60, active="a", other="b").region() == b"\x1b7\x1b[1;1r\x1b8"
+    assert StatusBar(rows=1, cols=60, active="a", other="b").region() == b"\x1b7\x1b[1;1r\x1b8"
+    assert StatusBar(rows=0, cols=0, active="a", other="b").region() == b"\x1b7\x1b[1;1r\x1b8"
+
+
+def test_bar_degenerate_width_composes_empty_row():
+    # cols=0 (size unknown) must compose an empty bar, not raise
+    bar = StatusBar(rows=0, cols=0, active="claude", other="codex")
+    assert bar.line(armed=False) == ""
+    assert bar.paint(armed=False) == b"\x1b7\x1b[0;1H\x1b[7m\x1b[0m\x1b8"
+
+
+def test_bar_clear_exact_shape():
+    # pinned whole: the region reset has to precede the row wipe (wiping first
+    # then resetting leaves the cursor parked on the bar row), and the pair is
+    # wrapped in DECSC/DECRC like every other emission
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    assert bar.clear() == b"\x1b7\x1b[r\x1b[40;1H\x1b[2K\x1b8"
+
+
+def test_bar_region_and_clear_track_resize():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    bar.resize(rows=30, cols=50)
+    assert bar.region() == b"\x1b7\x1b[1;29r\x1b8"
+    assert bar.clear() == b"\x1b7\x1b[r\x1b[30;1H\x1b[2K\x1b8"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -232,6 +232,23 @@ def test_bar_line_armed_state():
     assert "flipping at turn end" in line and "^] cancels" in line
 
 
+def test_bar_line_names_the_rebound_key():
+    # [frame] flip_key = "ctrl-t": the bar is the only place the keybind is
+    # advertised, so a hardcoded ^] would send the user pressing a key that
+    # goes straight through to the harness.
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex",
+                    key_label="^T")
+    assert "^T flips" in bar.line(armed=False)
+    assert "^T cancels" in bar.line(armed=True)
+    assert "^]" not in bar.line(armed=False)
+    assert "^]" not in bar.line(armed=True)
+
+
+def test_bar_line_defaults_to_ctrl_bracket():
+    bar = StatusBar(rows=40, cols=60, active="claude", other="codex")
+    assert "^] flips" in bar.line(armed=False)
+
+
 def test_bar_line_truncates_to_width():
     bar = StatusBar(rows=40, cols=12, active="claude", other="codex")
     assert len(bar.line(armed=False)) == 12

--- a/tests/test_memory_doctor.py
+++ b/tests/test_memory_doctor.py
@@ -142,3 +142,20 @@ class TestDoctor:
             for c in report.checks
             if c.status == "warn"
         )
+
+    def test_warns_on_bar_drop_marker(self, env_factory):
+        from tandem import paths
+
+        env = env_factory()
+        marker = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-bar-dropped"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+        report = run_doctor(env.store, env.session)
+        assert any(
+            c.status == "warn" and "status bar" in c.message for c in report.checks
+        )
+
+    def test_quiet_without_bar_drop_marker(self, env_factory):
+        env = env_factory()
+        report = run_doctor(env.store, env.session)
+        assert not any("status bar" in c.message for c in report.checks)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -3,7 +3,10 @@ the incoming side, and never echo synced entries back."""
 
 import json
 
+import pytest
+
 from tandem import ops
+from tandem.sync import SyncSetupError
 from tandem.util import read_jsonl
 
 from conftest import (
@@ -102,6 +105,42 @@ class TestSwitch:
         assert any("[via codex] Thing done." in c for c in contents)
         # the pre-switch claude turn must not have bounced back into claude
         assert sum("before switch" in c for c in contents) == 1  # only the original
+
+    def test_switch_back_to_never_run_claude_seeds_shadow(self, env_factory):
+        # Pairing seeds only the shadow side's file; claude's CLI creates its
+        # own transcript on the first *turn*, not at launch. Flipping away
+        # from a zero-turn claude therefore leaves the recorded session id
+        # with no file (the test env pre-creates it, so remove it), and the
+        # flip back must seed one rather than die in the codex->claude drain.
+        env = env_factory(active="claude")
+        env.claude_shadow.unlink()
+
+        ops.switch_session(env.store, env.session)
+        session = env.refresh()
+        assert session.active == "codex"
+
+        for obj in codex_turn("hello from codex", "Hi!"):
+            write_line(env.codex_shadow, obj)
+
+        new_active, problems, _mem = ops.switch_session(env.store, session)
+        assert new_active == "claude"
+        assert problems == []
+        contents = [json.dumps(e) for e in read_jsonl(env.claude_shadow)]
+        assert any("[via codex] hello from codex" in c for c in contents)
+        assert any("[via codex] Hi!" in c for c in contents)
+
+    def test_switch_back_after_claude_file_loss_still_errors(self, env_factory):
+        # A claude cursor that has consumed bytes means the transcript
+        # existed; its file going missing mid-session is data loss, not the
+        # never-ran case, and must keep the hard error.
+        env = env_factory(active="claude")
+        ops.fast_forward(env.store, env.session, "claude")
+        ops.switch_session(env.store, env.session)
+        session = env.refresh()
+
+        env.claude_shadow.unlink()
+        with pytest.raises(SyncSetupError, match="shadow transcript missing"):
+            ops.switch_session(env.store, session)
 
     def test_double_switch_round_trip(self, env_factory):
         env = env_factory(active="claude")

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -147,6 +147,7 @@ def test_frame_io_defaults():
     frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
     assert frame.bar is True
     assert (frame.active, frame.other) == ("", "")
+    assert frame.key_label == "^]"
     assert frame.bar_dropped is False
 
 

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -338,6 +338,40 @@ def test_pump_drops_the_bar_when_the_child_asserts_its_own_scroll_region(monkeyp
     assert pump.child.winsizes[-1] == (24, 80)
 
 
+def test_a_window_shrunk_below_the_row_floor_drops_the_bar_but_records_nothing(
+    monkeypatch,
+):
+    """tandem's own row-floor policy is not a terminal conflict: the bar goes
+    away (permanently, for this session) but nothing is persisted, so the next
+    `doctor` does not warn about a window the user simply made small."""
+    pump = _Pump(monkeypatch)
+
+    def drive():
+        pump.winch(3)                       # below the 5-row floor
+        assert pump.await_clear()
+
+    assert pump.run(drive) == 0
+    assert pump.frame.bar_dropped is False
+    assert pump.child.winsizes[-1] == (3, 80)   # child gets the whole window
+
+
+def test_a_bar_dropped_by_the_row_floor_does_not_come_back_on_grow(monkeypatch):
+    """Session-scoped drop semantics are unchanged by the reason: growing the
+    window back does not re-enable the bar."""
+    pump = _Pump(monkeypatch)
+
+    def drive():
+        pump.winch(3)
+        assert pump.await_clear()
+        before = len(pump.writes)
+        pump.winch(40)
+        time.sleep(0.2)
+        assert not any(b"\x1b[7m" in w for w in pump.writes[before:])
+
+    assert pump.run(drive) == 0
+    assert pump.frame.bar_dropped is False
+
+
 def test_drop_bar_survives_a_sigwinch_landing_inside_its_own_teardown(monkeypatch):
     """Drops and resizes are causally correlated, so the SIGWINCH handler
     lands inside drop_bar's writes all the time. The bar must already be gone

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -1,6 +1,6 @@
 import sys
 
-from tandem.ptyrun import PtyControl, run_in_pty
+from tandem.ptyrun import FrameIO, PtyControl, _bar_on, _child_dims, run_in_pty
 
 
 def test_non_tty_fallback_runs_subprocess(capfd):
@@ -103,3 +103,53 @@ def test_terminate_survives_reap_race_mid_ladder():
     c = PtyControl()
     c.attach(_ReapedChild(alive_checks_before_raise=1))
     assert c.terminate([b"\x04"], soft_timeout=0.2, term_timeout=0.2) == "soft"
+
+
+def test_child_dims_reserves_bottom_row_when_bar_on():
+    assert _child_dims(40, 120, bar_on=True) == (39, 120)
+    assert _child_dims(40, 120, bar_on=False) == (40, 120)
+
+
+def test_bar_activation_policy():
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
+    assert _bar_on(frame, rows=40) is True
+    assert _bar_on(frame, rows=4) is False      # too small
+    assert _bar_on(None, rows=40) is False      # no frame wiring
+    frame_off = FrameIO(
+        flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False, bar=False
+    )
+    assert _bar_on(frame_off, rows=40) is False  # [frame] bar = false
+
+
+def test_bar_policy_leaves_the_child_at_least_one_row_at_every_size():
+    # on_winch re-runs _bar_on precisely so the winsize lie can never hand the
+    # child a 0-row terminal: wherever the policy allows the bar, the reserved
+    # row still leaves the child rows to live on; where it doesn't, the child
+    # gets the terminal whole.
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
+    for rows in range(0, 12):
+        if _bar_on(frame, rows):
+            assert _child_dims(rows, 80, bar_on=True)[0] >= 1
+        else:
+            assert _child_dims(rows, 80, bar_on=False) == (rows, 80)
+
+
+def test_frame_io_defaults():
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
+    assert frame.bar is True
+    assert (frame.active, frame.other) == ("", "")
+    assert frame.bar_dropped is False
+
+
+def test_non_tty_fallback_ignores_frame_and_control(capfd):
+    from tandem.ptyrun import PtyControl
+
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False)
+    code = run_in_pty(
+        [sys.executable, "-c", "print('fallback-ok')"],
+        frame=frame,
+        control=PtyControl(),
+    )
+    assert code == 0
+    assert "fallback-ok" in capfd.readouterr().out
+    assert frame.bar_dropped is False        # nothing to drop off-tty

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -326,17 +326,40 @@ class _Pump:
                     pass
 
 
-def test_pump_drops_the_bar_when_the_child_asserts_its_own_scroll_region(monkeypatch):
+def test_pump_drops_the_bar_when_the_child_region_covers_the_bar_row(monkeypatch):
     pump = _Pump(monkeypatch)
 
     def drive():
-        pump.feed(b"\x1b[1;20r")            # child's own DECSTBM
+        pump.feed(b"\x1b[1;24r")            # DECSTBM down to the real bottom row
         assert pump.await_clear()
 
     assert pump.run(drive) == 0
     assert pump.frame.bar_dropped is True
     # the bar's row is handed back to the child at the full terminal height
     assert pump.child.winsizes[-1] == (24, 80)
+
+
+def test_pump_keeps_the_bar_when_the_child_region_stays_above_it(monkeypatch):
+    """codex asserts \\x1b[1;<its rows-2>r at startup for its composer. With
+    the winsize lie the region bottom is below the real bottom row, so the
+    bar is untouched: no drop, and the repaint that follows must not stomp
+    the child's region with tandem's own (\\x1b[1;23r at 24 rows)."""
+    pump = _Pump(monkeypatch)
+
+    def drive():
+        before = len(pump.writes)
+        pump.feed(b"\x1b[1;22r")
+        deadline = time.time() + 3
+        while time.time() < deadline:
+            if any(b"\x1b[7m" in w for w in pump.writes[before:]):
+                break
+            time.sleep(0.02)
+        assert any(b"\x1b[7m" in w for w in pump.writes[before:])   # repainted
+        assert not any(b"\x1b[2K" in w for w in pump.writes)        # never torn down
+        assert not any(b"\x1b[1;23r" in w for w in pump.writes[before:])
+
+    assert pump.run(drive) == 0
+    assert pump.frame.bar_dropped is False
 
 
 def test_a_window_shrunk_below_the_row_floor_drops_the_bar_but_records_nothing(
@@ -391,7 +414,7 @@ def test_drop_bar_survives_a_sigwinch_landing_inside_its_own_teardown(monkeypatc
     pump.on_write = on_write
 
     def drive():
-        pump.feed(b"\x1b[1;20r")
+        pump.feed(b"\x1b[1;24r")
         assert pump.await_clear()
 
     assert pump.run(drive) == 0             # no AttributeError escaped the pump

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -1,6 +1,6 @@
 import sys
 
-from tandem.ptyrun import run_in_pty
+from tandem.ptyrun import PtyControl, run_in_pty
 
 
 def test_non_tty_fallback_runs_subprocess(capfd):
@@ -12,3 +12,94 @@ def test_non_tty_fallback_runs_subprocess(capfd):
 
 def test_exit_code_propagates():
     assert run_in_pty([sys.executable, "-c", "raise SystemExit(3)"]) == 3
+
+
+class _StubChild:
+    """Stands in for a PtyProcess: records writes, dies on command."""
+
+    def __init__(self, dies_after_writes=None, dies_on_signal=None):
+        self.pid = 99999999  # killpg will fail -> ladder must survive that
+        self.writes = []
+        self._alive = True
+        self._dies_after_writes = dies_after_writes
+        self._dies_on_signal = dies_on_signal
+
+    def write(self, data):
+        self.writes.append(data)
+        if self._dies_after_writes and len(self.writes) >= self._dies_after_writes:
+            self._alive = False
+
+    def isalive(self):
+        return self._alive
+
+    def kill_externally(self):
+        self._alive = False
+
+
+def test_terminate_soft_exit():
+    c = PtyControl()
+    child = _StubChild(dies_after_writes=2)
+    c.attach(child)
+    how = c.terminate([b"\x03", b"\x04"], soft_timeout=1.0, term_timeout=0.2)
+    assert how == "soft"
+    assert child.writes == [b"\x03", b"\x04"]
+
+
+def test_terminate_already_dead():
+    c = PtyControl()
+    child = _StubChild()
+    child.kill_externally()
+    c.attach(child)
+    assert c.terminate([b"\x04"], soft_timeout=0.2) == "dead"
+
+
+def test_terminate_never_attached_returns_dead():
+    c = PtyControl()
+    assert c.terminate([b"\x04"], soft_timeout=0.1, attach_timeout=0.1) == "dead"
+
+
+def test_terminate_escalates_past_failing_killpg(monkeypatch):
+    # killpg raising (fake pid) must not break the ladder; the child dying
+    # during the term wait is still detected
+    c = PtyControl()
+    child = _StubChild()
+    c.attach(child)
+
+    import tandem.ptyrun as ptyrun
+
+    def fake_killpg(pgid, sig):
+        child.kill_externally()
+
+    monkeypatch.setattr(ptyrun.os, "killpg", fake_killpg)
+    how = c.terminate([b"\x03"], soft_timeout=0.3, term_timeout=1.0)
+    assert how == "term"
+
+
+class _ReapedChild(_StubChild):
+    """A child the pump thread already reaped: ptyprocess raises
+    PtyProcessError from isalive() when waitpid comes back ECHILD."""
+
+    def __init__(self, alive_checks_before_raise=0):
+        super().__init__()
+        self._checks = alive_checks_before_raise
+
+    def isalive(self):
+        if self._checks <= 0:
+            raise RuntimeError("no child process — someone else called waitpid()")
+        self._checks -= 1
+        return True
+
+
+def test_terminate_treats_unqueryable_child_as_dead():
+    # the other thread reaped the child before terminate even looked
+    c = PtyControl()
+    c.attach(_ReapedChild())
+    assert c.terminate([b"\x04"], soft_timeout=0.2, term_timeout=0.2) == "dead"
+
+
+def test_terminate_survives_reap_race_mid_ladder():
+    # child looks alive at the gate, then the pump thread reaps it while the
+    # ladder is waiting — that must read as death, not blow up the ladder
+    c = PtyControl()
+    c.attach(_ReapedChild(alive_checks_before_raise=1))
+    assert c.terminate([b"\x04"], soft_timeout=0.2, term_timeout=0.2) == "soft"

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -153,3 +153,45 @@ def test_non_tty_fallback_ignores_frame_and_control(capfd):
     assert code == 0
     assert "fallback-ok" in capfd.readouterr().out
     assert frame.bar_dropped is False        # nothing to drop off-tty
+
+
+def test_write_all_finishes_a_short_write(monkeypatch):
+    # os.write returns a short count when a signal lands mid-write (PEP 475
+    # only retries a write that moved nothing), so a repaint interrupted by
+    # SIGWINCH would otherwise leave half an escape sequence on screen
+    import tandem.ptyrun as ptyrun
+
+    seen = []
+
+    def fake_write(fd, data):
+        b = bytes(data)
+        seen.append(b[:3])
+        return min(3, len(b))
+
+    monkeypatch.setattr(ptyrun.os, "write", fake_write)
+    ptyrun._write_all(7, b"abcdefgh")
+    assert b"".join(seen) == b"abcdefgh"
+
+
+def test_write_all_retries_after_interrupted_error(monkeypatch):
+    import tandem.ptyrun as ptyrun
+
+    calls = []
+
+    def fake_write(fd, data):
+        calls.append(bytes(data))
+        if len(calls) == 1:
+            raise InterruptedError
+        return len(data)
+
+    monkeypatch.setattr(ptyrun.os, "write", fake_write)
+    ptyrun._write_all(7, b"xy")
+    assert calls == [b"xy", b"xy"]
+
+
+def test_write_all_gives_up_on_a_zero_byte_write(monkeypatch):
+    # a fd that accepts nothing must not spin the pump forever
+    import tandem.ptyrun as ptyrun
+
+    monkeypatch.setattr(ptyrun.os, "write", lambda fd, data: 0)
+    ptyrun._write_all(7, b"abc")   # returns instead of hanging

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -1,5 +1,14 @@
+import fcntl
+import os
+import pty
+import signal
+import struct
 import sys
+import termios
+import threading
+import time
 
+import tandem.ptyrun as ptyrun
 from tandem.ptyrun import FrameIO, PtyControl, _bar_on, _child_dims, run_in_pty
 
 
@@ -195,3 +204,163 @@ def test_write_all_gives_up_on_a_zero_byte_write(monkeypatch):
 
     monkeypatch.setattr(ptyrun.os, "write", lambda fd, data: 0)
     ptyrun._write_all(7, b"abc")   # returns instead of hanging
+
+
+# -- driving the real pump ------------------------------------------------
+#
+# The bar teardown paths only exist inside run_in_pty's closure, and they
+# only run against a tty. These give the pump a real pty for stdin (so
+# tcgetattr/setraw/ioctl are honest) and a stub child whose "fd" is a pipe
+# the test writes into, which is enough to exercise the output guard, the
+# SIGWINCH handler, and drop_bar end to end.
+
+
+class _FakeStdin:
+    def __init__(self, fd):
+        self._fd = fd
+
+    def fileno(self):
+        return self._fd
+
+
+class _PumpChild:
+    """Stub PtyProcess whose `fd` is a real pipe the test feeds. Closing the
+    write end is how a test ends the pump (read -> EOF -> loop breaks)."""
+
+    def __init__(self):
+        self.rd, self.wr = os.pipe()
+        self.pid = os.getpid()
+        self.exitstatus = 0
+        self.writes = []
+        self.winsizes = []
+
+    @property
+    def fd(self):
+        return self.rd
+
+    def read(self, n):
+        data = os.read(self.rd, n)
+        if not data:
+            raise EOFError
+        return data
+
+    def write(self, data):
+        self.writes.append(bytes(data))
+
+    def isalive(self):
+        return True
+
+    def setwinsize(self, rows, cols):
+        self.winsizes.append((rows, cols))
+
+    def sendeof(self):
+        pass
+
+    def wait(self):
+        return 0
+
+
+class _Pump:
+    def __init__(self, monkeypatch, frame=None, rows=24, cols=80):
+        self.frame = frame or FrameIO(
+            flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False
+        )
+        self.master, self.slave = pty.openpty()
+        self.child = _PumpChild()
+        self.writes: list[bytes] = []
+        self.painted = threading.Event()
+        self.on_write = None
+        self.set_rows(rows, cols)
+        monkeypatch.setattr(ptyrun, "_write_all", self._record)
+        monkeypatch.setattr(ptyrun.sys, "stdin", _FakeStdin(self.slave))
+        monkeypatch.setattr(
+            ptyrun, "PtyProcess",
+            type("_Spawner", (), {"spawn": staticmethod(lambda *a, **kw: self.child)}),
+        )
+
+    def _record(self, fd, data):
+        data = bytes(data)
+        self.writes.append(data)
+        self.painted.set()      # the first paint proves the pump is running
+        if self.on_write is not None:
+            self.on_write(data)
+
+    def set_rows(self, rows, cols=80):
+        fcntl.ioctl(
+            self.slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0)
+        )
+
+    def feed(self, data: bytes) -> None:
+        os.write(self.child.wr, data)
+
+    def winch(self, rows, cols=80):
+        self.set_rows(rows, cols)
+        os.kill(os.getpid(), signal.SIGWINCH)   # delivered to the pump thread
+
+    def await_clear(self, timeout=3.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if any(b"\x1b[2K" in w for w in self.writes):
+                return True
+            time.sleep(0.02)
+        return False
+
+    def run(self, drive) -> int:
+        def driver():
+            try:
+                assert self.painted.wait(timeout=5)
+                drive()
+            finally:
+                os.close(self.child.wr)     # EOF: ends the pump
+        thread = threading.Thread(target=driver, daemon=True)
+        thread.start()
+        try:
+            return run_in_pty(["fake-harness"], frame=self.frame)
+        finally:
+            thread.join(timeout=5)
+            for fd in (self.master, self.slave, self.child.rd):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+
+def test_pump_drops_the_bar_when_the_child_asserts_its_own_scroll_region(monkeypatch):
+    pump = _Pump(monkeypatch)
+
+    def drive():
+        pump.feed(b"\x1b[1;20r")            # child's own DECSTBM
+        assert pump.await_clear()
+
+    assert pump.run(drive) == 0
+    assert pump.frame.bar_dropped is True
+    # the bar's row is handed back to the child at the full terminal height
+    assert pump.child.winsizes[-1] == (24, 80)
+
+
+def test_drop_bar_survives_a_sigwinch_landing_inside_its_own_teardown(monkeypatch):
+    """Drops and resizes are causally correlated, so the SIGWINCH handler
+    lands inside drop_bar's writes all the time. The bar must already be gone
+    by then: a reentrant drop that still saw it would write a second clear (or
+    repaint the region *after* the clear) and outlive tandem's exit."""
+    pump = _Pump(monkeypatch)
+    reentered = []
+
+    def on_write(data):
+        if b"\x1b[2K" in data and not reentered:
+            reentered.append(True)
+            pump.set_rows(3)                # a resize the drop raced
+            os.kill(os.getpid(), signal.SIGWINCH)
+            time.sleep(0.05)                # let the handler run to completion
+
+    pump.on_write = on_write
+
+    def drive():
+        pump.feed(b"\x1b[1;20r")
+        assert pump.await_clear()
+
+    assert pump.run(drive) == 0             # no AttributeError escaped the pump
+    assert reentered == [True]              # the reentrant path really ran
+    clears = [w for w in pump.writes if b"\x1b[2K" in w]
+    assert len(clears) == 1                 # torn down exactly once
+    assert not any(b"\x1b[7m" in w for w in pump.writes[pump.writes.index(clears[0]):])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -394,7 +394,7 @@ def test_runner_reports_flip_requested(env_factory, monkeypatch):
     assert r.flip_requested is True
 
 
-def test_runner_writes_bar_drop_marker(env_factory, monkeypatch):
+def test_runner_writes_bar_drop_marker(env_factory, monkeypatch, capsys):
     env = env_factory(active="claude")
 
     def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
@@ -405,6 +405,11 @@ def test_runner_writes_bar_drop_marker(env_factory, monkeypatch):
     runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
     marker = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-bar-dropped"
     assert marker.exists()
+    # A dropped bar is a note, not a sync failure: labelling it "sync error"
+    # sends the user hunting a transcript divergence that never happened.
+    out = capsys.readouterr().out
+    assert "status bar disabled for this session" in out
+    assert "sync error" not in out
 
 
 def _run_capturing_monitor(env, monkeypatch):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -159,7 +159,7 @@ def test_wait_wired_ignores_turn_pacing_quiet(tmp_path):
     # With the marker wired, transcript quiet is NOT a turn boundary: a long
     # tool call writes nothing between the tool_use append and the tool_result
     # append, and firing there kills the harness mid-turn. quiesce is scaled
-    # down (1.0 stands in for the real 30s valve) to keep the test fast — the
+    # down (1.0 stands in for the real 120s valve) to keep the test fast — the
     # valve does eventually trip, it is just never the normal trigger.
     t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
     _touch(t, time.time())         # turn in flight
@@ -197,8 +197,8 @@ def test_wait_wired_default_quiesce_is_the_valve_not_2s(tmp_path):
         done.set()
 
     threading.Thread(target=waiter, daemon=True).start()
-    assert not done.wait(timeout=0.4)   # parked behind the 30s valve
-    cancel.set()                        # don't leave it parked for 30s
+    assert not done.wait(timeout=0.4)   # parked behind the 120s valve
+    cancel.set()                        # don't leave it parked for 120s
     assert done.wait(timeout=2)
     assert result["ok"] is False
 
@@ -440,8 +440,12 @@ def test_monitor_quiesce_defaults_by_mode(tmp_path):
     override = FlipMonitor(_StubControl(), [], None, s, marker_wired=True,
                            quiesce=1.5)
     assert unwired.quiesce == 2.0        # marker-less fallback
-    assert wired.quiesce == 30.0         # missed-marker valve, not turn pacing
+    assert wired.quiesce == 120.0        # missed-marker valve, not turn pacing
     assert override.quiesce == 1.5       # explicit injection wins
+    # The valve has to outlast the longest silence a real turn can produce (a
+    # full test suite between the tool_use and tool_result appends), because
+    # firing early kills that turn while firing late only costs a wait.
+    assert wired.quiesce > 60.0
 
 
 def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
@@ -465,7 +469,7 @@ def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
         time.sleep(0.05)
     m.stop()
     assert m.flip_requested is True
-    assert seen == {"quiesce": 30.0, "poll": 0.05, "marker_wired": True,
+    assert seen == {"quiesce": 120.0, "poll": 0.05, "marker_wired": True,
                     "provider_reads": None}
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,7 @@ import json
 import os
 import threading
 import time
+from pathlib import Path
 
 from tandem import paths, runner
 from tandem.runner import FlipMonitor, wait_until_safe
@@ -852,3 +853,48 @@ def test_monitor_probe_waiting_fires_immediately(tmp_path):
     assert m.flip_requested is True
     assert m.how == "soft"
     assert control.calls == [[b"\x04"]]
+
+
+def test_runner_wires_status_probe_for_claude(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["kw"] = kw
+        return real(*a, **kw)
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    probe = made["kw"]["status_probe"]
+    assert probe is not None
+    # the probe closes over the claude sid: feed the registry and ask it
+    me = os.getpid()
+    d = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "sessions"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{me}.json").write_text(json.dumps(
+        {"pid": me, "sessionId": env.session.claude_session_id,
+         "status": "busy"}))
+    assert probe() == "busy"
+
+
+def test_runner_wires_no_probe_for_codex(env_factory, monkeypatch):
+    env = env_factory(active="codex")
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["kw"] = kw
+        return real(*a, **kw)
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    assert made["kw"]["status_probe"] is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,7 +18,7 @@ def _run_capturing_argv(env, monkeypatch):
     calls = {}
     monkeypatch.setattr(
         runner, "run_in_pty",
-        lambda argv, cwd=None: calls.update(argv=argv) or 0,
+        lambda argv, cwd=None, **kw: calls.update(argv=argv) or 0,
     )
     code = runner.InteractiveRunner(
         env.session, lambda store, session, source: _Sink()).run()
@@ -75,7 +75,7 @@ def test_codex_fresh_mint_gets_args_after_bare_binary(env_factory, monkeypatch):
     calls = {}
     monkeypatch.setattr(
         runner, "run_in_pty",
-        lambda argv, cwd=None: calls.update(argv=argv) or 0,
+        lambda argv, cwd=None, **kw: calls.update(argv=argv) or 0,
     )
     code = runner.InteractiveRunner(
         session, lambda store, session, source: _Sink()).run()
@@ -336,3 +336,120 @@ def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
     m.stop()
     assert m.flip_requested is True
     assert seen == {"quiesce": 30.0, "poll": 0.05, "marker_wired": True}
+
+
+# -- the runner wiring the frame ------------------------------------------
+
+
+class _DeadChild:
+    """Stands in for the pty child a real run_in_pty attaches; the
+    termination ladder reads it as already gone ("dead") without waiting out
+    the attach timeout."""
+
+    def isalive(self):
+        return False
+
+
+def test_runner_passes_frame_and_control(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+    seen = {}
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        seen.update(frame=frame, control=control)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    r = runner.InteractiveRunner(env.session, lambda st, se, so: _Sink())
+    code = r.run()
+    assert code == 0
+    assert seen["control"] is not None
+    frame = seen["frame"]
+    assert frame is not None
+    assert frame.flip_byte == 0x1D
+    assert frame.active == "claude" and frame.other == "codex"
+    assert r.flip_requested is False
+
+
+def test_runner_reports_flip_requested(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+    sentinel = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-claude.turn"
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        control.attach(_DeadChild())
+        frame.on_flip()  # user pressed the keybind
+        deadline = time.time() + 3
+        while not frame.armed() and time.time() < deadline:
+            time.sleep(0.02)
+        sentinel.touch()  # turn-complete marker: the wait releases
+        # the monitor's ladder finds no real child: control.terminate
+        # returns "dead", flip_requested still set
+        deadline = time.time() + 3
+        while frame.armed() and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    r = runner.InteractiveRunner(env.session, lambda st, se, so: _Sink())
+    r.run()
+    assert r.flip_requested is True
+
+
+def test_runner_writes_bar_drop_marker(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        frame.bar_dropped = True
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    marker = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-bar-dropped"
+    assert marker.exists()
+
+
+def _run_capturing_monitor(env, monkeypatch):
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["monitor"] = real(*a, **kw)
+        return made["monitor"]
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    return made["monitor"]
+
+
+def test_marker_wired_derived_from_the_argv_hook_extras(env_factory, monkeypatch):
+    # The hook extras that went into argv decide the mode, and they are read
+    # once: hook_argv_extra re-reads config per call, so a second call could
+    # disagree with what was actually launched.
+    from tandem.harness.claude_code import ClaudeCodeAdapter
+
+    env = env_factory(active="claude")
+    calls = []
+    real_extra = ClaudeCodeAdapter.hook_argv_extra
+
+    def counting(self, sentinel):
+        calls.append(sentinel)
+        return real_extra(self, sentinel)
+
+    monkeypatch.setattr(ClaudeCodeAdapter, "hook_argv_extra", counting)
+    monitor = _run_capturing_monitor(env, monkeypatch)
+    assert monitor.marker_wired is True
+    assert len(calls) == 1
+
+
+def test_marker_wired_false_when_adapter_injects_no_hook(env_factory, monkeypatch):
+    # The marker-less shape: the adapter declined to wire a hook (codex
+    # refusing to clobber a user notify), so quiescence is the only boundary.
+    from tandem.harness.claude_code import ClaudeCodeAdapter
+
+    env = env_factory(active="claude")
+    monkeypatch.setattr(ClaudeCodeAdapter, "hook_argv_extra", lambda self, s: [])
+    monitor = _run_capturing_monitor(env, monkeypatch)
+    assert monitor.marker_wired is False

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -537,7 +537,8 @@ def test_runner_writes_bar_drop_marker(env_factory, monkeypatch, capsys):
         return 0
 
     monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
-    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    r = runner.InteractiveRunner(env.session, lambda st, se, so: _Sink())
+    r.run()
     marker = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-bar-dropped"
     assert marker.exists()
     # A dropped bar is a note, not a sync failure: labelling it "sync error"
@@ -545,6 +546,39 @@ def test_runner_writes_bar_drop_marker(env_factory, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "status bar disabled for this session" in out
     assert "sync error" not in out
+    assert out.count("status bar disabled for this session") == 1  # no dupes
+    assert r.reports == [
+        "tandem: status bar disabled for this session (terminal conflict);"
+        " set [frame] bar = false to silence"
+    ]
+
+
+def test_runner_holds_its_reports_back_for_a_flip(env_factory, monkeypatch, capsys):
+    # A flip clears the screen a moment after run() returns, so anything
+    # printed here is wiped before the user can read it. Collect, don't print
+    # — the shell reprints onto the fresh screen.
+    env = env_factory(active="claude")
+    sentinel = paths.tandem_home() / "tmp" / f"{env.session.tandem_id}-claude.turn"
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        control.attach(_DeadChild())
+        frame.bar_dropped = True
+        frame.on_flip()
+        deadline = time.time() + 3
+        while not frame.armed() and time.time() < deadline:
+            time.sleep(0.02)
+        sentinel.touch()
+        deadline = time.time() + 3
+        while frame.armed() and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    r = runner.InteractiveRunner(env.session, lambda st, se, so: _Sink())
+    r.run()
+    assert r.flip_requested is True
+    assert any("status bar disabled" in line for line in r.reports)
+    assert "status bar disabled" not in capsys.readouterr().out
 
 
 def _run_capturing_monitor(env, monkeypatch):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,11 @@
 """InteractiveRunner: user-configured [harness] args land in the spawned argv."""
 
+import os
+import threading
+import time
+
 from tandem import paths, runner
+from tandem.runner import FlipMonitor, wait_until_safe
 
 
 class _Sink:
@@ -102,3 +107,114 @@ def test_no_config_leaves_argv_unchanged(env_factory, monkeypatch):
     argv = _run_capturing_argv(env, monkeypatch)
     assert argv[:3] == ["claude", "--resume", env.session.claude_session_id]
     assert argv[3] == "--settings"
+
+
+def _touch(path, mtime):
+    path.write_text("x")
+    os.utime(path, (mtime, mtime))
+
+
+def test_wait_idle_when_sentinel_newer_than_transcript(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    now = time.time()
+    _touch(t, now - 10)
+    _touch(s, now - 5)   # marker closed the last turn
+    assert wait_until_safe(t, s, cancelled=lambda: False) is True
+
+
+def test_wait_idle_when_no_files(tmp_path):
+    assert (
+        wait_until_safe(tmp_path / "none", tmp_path / "none2",
+                        cancelled=lambda: False)
+        is True
+    )
+
+
+def test_wait_quiescence_fallback(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    now = time.time()
+    _touch(t, now - 3)   # transcript quiet for 3s, no marker since
+    _touch(s, now - 10)
+    assert (
+        wait_until_safe(t, s, cancelled=lambda: False, quiesce=2.0) is True
+    )
+
+
+def test_wait_blocks_midturn_then_marker_releases(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())          # a line just landed: turn in flight
+    _touch(s, time.time() - 30)
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       quiesce=30.0, poll=0.05)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    time.sleep(0.2)
+    assert not done.is_set()        # still waiting
+    _touch(s, time.time() + 1)      # marker fires
+    assert done.wait(timeout=2)
+    assert result["ok"] is True
+
+
+def test_wait_cancelled(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    assert (
+        wait_until_safe(t, s, cancelled=lambda: True, quiesce=30.0) is False
+    )
+
+
+class _StubControl:
+    def __init__(self):
+        self.calls = []
+
+    def terminate(self, soft, **kw):
+        self.calls.append(soft)
+        return "soft"
+
+
+def test_monitor_arm_wait_terminate(tmp_path):
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=None,
+                    sentinel=tmp_path / "s.turn")
+    m.start()
+    assert m.armed() is False
+    m.flip_pressed()                 # idle (no files) -> fires immediately
+    deadline = time.time() + 3
+    while not m.flip_requested and time.time() < deadline:
+        time.sleep(0.05)
+    m.stop()
+    assert m.flip_requested is True
+    assert m.how == "soft"
+    assert control.calls == [[b"\x04"]]
+
+
+def test_monitor_toggle_cancels(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())           # mid-turn: monitor will block
+    _touch(s, time.time() - 30)
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=t, sentinel=s)
+    m.start()
+    m.flip_pressed()
+    time.sleep(0.1)
+    assert m.armed() is True
+    m.flip_pressed()                 # toggle: cancel
+    time.sleep(0.3)
+    assert m.armed() is False
+    assert m.flip_requested is False
+    m.stop()
+    assert control.calls == []
+
+
+def test_monitor_stop_unblocks_cleanly(tmp_path):
+    m = FlipMonitor(_StubControl(), [b"\x04"], transcript=None,
+                    sentinel=tmp_path / "s.turn")
+    m.start()
+    m.stop()                         # never armed: must not hang or fire
+    assert m.flip_requested is False

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -131,13 +131,97 @@ def test_wait_idle_when_no_files(tmp_path):
 
 
 def test_wait_quiescence_fallback(tmp_path):
-    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
-    now = time.time()
-    _touch(t, now - 3)   # transcript quiet for 3s, no marker since
-    _touch(s, now - 10)
+    # The marker-less shape, built honestly: tandem refused to clobber a
+    # user-configured codex notify, so the hook was never wired and the
+    # sentinel file never appears at all (mtime 0 < transcript, forever).
+    # Quiescence is the only exit, which is exactly what the fallback is for.
+    t, s = tmp_path / "t.jsonl", tmp_path / "never-touched.turn"
+    _touch(t, time.time() - 3)   # transcript quiet for 3s, no marker since
+    assert not s.exists()
     assert (
-        wait_until_safe(t, s, cancelled=lambda: False, quiesce=2.0) is True
+        wait_until_safe(t, s, cancelled=lambda: False, quiesce=2.0,
+                        marker_wired=False) is True
     )
+
+
+def test_wait_idle_when_no_files_wired(tmp_path):
+    # Fresh session: the harness has written nothing and the hook has not run
+    # yet, so 0 >= 0 reads idle in *both* modes. The flip must fire at once,
+    # not sit behind the wired mode's missed-marker valve.
+    assert (
+        wait_until_safe(tmp_path / "none", tmp_path / "none2",
+                        cancelled=lambda: False, marker_wired=True)
+        is True
+    )
+
+
+def test_wait_wired_ignores_turn_pacing_quiet(tmp_path):
+    # With the marker wired, transcript quiet is NOT a turn boundary: a long
+    # tool call writes nothing between the tool_use append and the tool_result
+    # append, and firing there kills the harness mid-turn. quiesce is scaled
+    # down (1.0 stands in for the real 30s valve) to keep the test fast — the
+    # valve does eventually trip, it is just never the normal trigger.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())         # turn in flight
+    _touch(s, time.time() - 30)    # marker live, but this turn is still open
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       quiesce=1.0, poll=0.05,
+                                       marker_wired=True)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    assert not done.wait(timeout=0.5)   # 0.5s of quiet: still waiting
+    assert done.wait(timeout=3)         # valve trips once quiesce elapses
+    assert result["ok"] is True
+
+
+def test_wait_wired_default_quiesce_is_the_valve_not_2s(tmp_path):
+    # The mode's whole point: the same 3s-quiet mid-turn transcript that the
+    # marker-less mode calls idle must still be mid-turn when the marker is
+    # wired, on default settings.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time() - 3)
+    _touch(s, time.time() - 30)
+    assert wait_until_safe(t, s, cancelled=lambda: False,
+                           marker_wired=False) is True
+    cancel, done = threading.Event(), threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(t, s, cancelled=cancel.is_set,
+                                       poll=0.05, marker_wired=True)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    assert not done.wait(timeout=0.4)   # parked behind the 30s valve
+    cancel.set()                        # don't leave it parked for 30s
+    assert done.wait(timeout=2)
+    assert result["ok"] is False
+
+
+def test_wait_wired_marker_touch_releases_promptly(tmp_path):
+    # The marker path is unchanged by the mode: the touch is the trigger.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       poll=0.05, marker_wired=True)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    time.sleep(0.2)
+    assert not done.is_set()
+    _touch(s, time.time() + 1)      # marker fires
+    assert done.wait(timeout=2)
+    assert result["ok"] is True
 
 
 def test_wait_blocks_midturn_then_marker_releases(tmp_path):
@@ -218,3 +302,37 @@ def test_monitor_stop_unblocks_cleanly(tmp_path):
     m.start()
     m.stop()                         # never armed: must not hang or fire
     assert m.flip_requested is False
+
+
+def test_monitor_quiesce_defaults_by_mode(tmp_path):
+    s = tmp_path / "s.turn"
+    unwired = FlipMonitor(_StubControl(), [], None, s)
+    wired = FlipMonitor(_StubControl(), [], None, s, marker_wired=True)
+    override = FlipMonitor(_StubControl(), [], None, s, marker_wired=True,
+                           quiesce=1.5)
+    assert unwired.quiesce == 2.0        # marker-less fallback
+    assert wired.quiesce == 30.0         # missed-marker valve, not turn pacing
+    assert override.quiesce == 1.5       # explicit injection wins
+
+
+def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_wait(transcript, sentinel, cancelled, quiesce=None, poll=0.2,
+                  marker_wired=False):
+        seen.update(quiesce=quiesce, poll=poll, marker_wired=marker_wired)
+        return True
+
+    monkeypatch.setattr(runner, "wait_until_safe", fake_wait)
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=None,
+                    sentinel=tmp_path / "s.turn", marker_wired=True,
+                    poll=0.05)
+    m.start()
+    m.flip_pressed()
+    deadline = time.time() + 3
+    while not m.flip_requested and time.time() < deadline:
+        time.sleep(0.05)
+    m.stop()
+    assert m.flip_requested is True
+    assert seen == {"quiesce": 30.0, "poll": 0.05, "marker_wired": True}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -244,6 +244,135 @@ def test_wait_blocks_midturn_then_marker_releases(tmp_path):
     assert result["ok"] is True
 
 
+def test_wait_unknown_transcript_wired_is_not_read_as_idle(tmp_path):
+    # codex mints its own session id, so the flip monitor starts with no
+    # transcript at all. _mtime(None) is 0.0, which would make `s >= t` true
+    # against any sentinel and fire the flip instantly — mid-turn. No
+    # evidence is not idleness: hold, and let the valve decide.
+    s = tmp_path / "s.turn"
+    _touch(s, time.time() - 30)      # a previous turn's marker exists
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(None, s, cancelled=lambda: False,
+                                       quiesce=1.0, poll=0.05,
+                                       marker_wired=True)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    assert not done.wait(timeout=0.5)   # did NOT fire instantly
+    assert done.wait(timeout=3)         # valve, anchored to arm time
+    assert result["ok"] is True
+
+
+def test_wait_provider_publishing_a_path_restores_normal_rules(tmp_path):
+    # The tail thread discovers the rollout mid-wait and publishes it; from
+    # that poll on the ordinary marker/quiescence rules apply.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(s, time.time() - 30)
+    published: list = [None]
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(None, s, cancelled=lambda: False,
+                                       quiesce=30.0, poll=0.05,
+                                       marker_wired=True,
+                                       provider=lambda: published[0])
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    assert not done.wait(timeout=0.3)   # unknown transcript: parked
+    _touch(t, time.time())              # a turn is in flight
+    published[0] = t
+    assert not done.wait(timeout=0.3)   # known now, and mid-turn: still parked
+    _touch(s, time.time() + 1)          # marker closes the turn
+    assert done.wait(timeout=2)
+    assert result["ok"] is True
+
+
+def test_wait_standalone_default_provider_reads_its_argument(tmp_path):
+    # Back-compat: with no provider the positional transcript is what every
+    # poll reads, exactly as before the provider existed.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    done = threading.Event()
+    result = {}
+
+    def waiter():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       poll=0.05, marker_wired=True)
+        done.set()
+
+    threading.Thread(target=waiter, daemon=True).start()
+    assert not done.wait(timeout=0.3)
+    _touch(s, time.time() + 1)
+    assert done.wait(timeout=2)
+    assert result["ok"] is True
+
+
+def test_monitor_transcript_published_midwait_is_picked_up(tmp_path):
+    # The monitor half of the same story: the runner's tail thread assigns
+    # monitor.transcript once codex's rollout appears, and the live wait sees
+    # it on its next poll.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=None, sentinel=s,
+                    marker_wired=True, quiesce=30.0, poll=0.05)
+    m.start()
+    m.flip_pressed()
+    time.sleep(0.3)
+    assert m.flip_requested is False     # unknown transcript: no instant fire
+    m.transcript = t                     # tail thread discovered the rollout
+    time.sleep(0.2)
+    assert m.flip_requested is False     # mid-turn under the normal rules
+    _touch(s, time.time() + 1)           # marker fires
+    deadline = time.time() + 3
+    while not m.flip_requested and time.time() < deadline:
+        time.sleep(0.05)
+    m.stop()
+    assert m.flip_requested is True
+    assert control.calls == [[b"\x04"]]
+
+
+def test_runner_publishes_the_discovered_codex_rollout_to_the_monitor(
+    env_factory, monkeypatch
+):
+    # Fresh codex (no session id yet): the tail thread finds the rollout and
+    # hands it to the monitor, so an armed flip stops being judged blind.
+    env = env_factory(active="codex")
+    session = env.store.create_session(
+        env.cwd, "codex", env.session.claude_session_id, None
+    )
+    rollout = env.codex_shadow
+    monkeypatch.setattr(
+        runner, "await_codex_rollout",
+        lambda cwd, after, timeout=None: rollout,
+    )
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["monitor"] = real(*a, **kw)
+        return made["monitor"]
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None):
+        deadline = time.time() + 3
+        while made["monitor"].transcript is None and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(session, lambda st, se, so: _Sink()).run()
+    assert made["monitor"].transcript == rollout
+
+
 def test_wait_cancelled(tmp_path):
     t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
     _touch(t, time.time())
@@ -319,8 +448,9 @@ def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
     seen = {}
 
     def fake_wait(transcript, sentinel, cancelled, quiesce=None, poll=0.2,
-                  marker_wired=False):
-        seen.update(quiesce=quiesce, poll=poll, marker_wired=marker_wired)
+                  marker_wired=False, provider=None):
+        seen.update(quiesce=quiesce, poll=poll, marker_wired=marker_wired,
+                    provider_reads=provider())
         return True
 
     monkeypatch.setattr(runner, "wait_until_safe", fake_wait)
@@ -335,7 +465,8 @@ def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
         time.sleep(0.05)
     m.stop()
     assert m.flip_requested is True
-    assert seen == {"quiesce": 30.0, "poll": 0.05, "marker_wired": True}
+    assert seen == {"quiesce": 30.0, "poll": 0.05, "marker_wired": True,
+                    "provider_reads": None}
 
 
 # -- the runner wiring the frame ------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -453,7 +453,7 @@ def test_monitor_passes_mode_through_to_wait(tmp_path, monkeypatch):
     seen = {}
 
     def fake_wait(transcript, sentinel, cancelled, quiesce=None, poll=0.2,
-                  marker_wired=False, provider=None):
+                  marker_wired=False, provider=None, status_probe=None):
         seen.update(quiesce=quiesce, poll=poll, marker_wired=marker_wired,
                     provider_reads=provider())
         return True
@@ -744,3 +744,111 @@ def test_session_status_tolerates_garbage_files(tmp_path, monkeypatch):
         f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting"},
     })
     assert _claude_adapter().session_status(_SID) == "waiting"
+
+
+# ---- status probe replaces the mtime rules ---------------------------------
+
+
+def test_wait_probe_waiting_overrides_busy_mtimes(tmp_path):
+    # transcript newer than sentinel: the mtime rules read mid-turn and
+    # would hold for the 120s valve. The probe says the session is at its
+    # prompt, and the probe is the whole test now.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    assert wait_until_safe(t, s, cancelled=lambda: False, marker_wired=True,
+                           status_probe=lambda: "waiting") is True
+
+
+def test_wait_probe_no_answer_flips_eagerly(tmp_path):
+    # single tier by spec: registry missing/unreadable -> flip now.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    _touch(s, time.time() - 30)
+    assert wait_until_safe(t, s, cancelled=lambda: False, marker_wired=True,
+                           status_probe=lambda: None) is True
+
+
+def test_wait_probe_busy_blocks_then_releases(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(s, time.time())  # mtime rules would say idle (sentinel newest)
+    _touch(t, time.time() - 30)
+    state = {"status": "busy"}
+    result = {}
+    done = threading.Event()
+
+    def wait():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       marker_wired=True, poll=0.05,
+                                       status_probe=lambda: state["status"])
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    assert not done.wait(timeout=0.4)   # busy verdict outranks idle mtimes
+    state["status"] = "waiting"
+    assert done.wait(timeout=3)
+    assert result["ok"] is True
+
+
+def test_wait_probe_busy_suppresses_valve(tmp_path):
+    # A long-silent tool call: transcript ancient, quiesce tiny — the old
+    # valve would fire and kill the live turn. The probe's "busy" holds.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time() - 3600)
+    _touch(s, time.time() - 7200)
+    state = {"status": "busy"}
+    result = {}
+    done = threading.Event()
+
+    def wait():
+        result["ok"] = wait_until_safe(t, s, cancelled=lambda: False,
+                                       marker_wired=True, quiesce=0.1,
+                                       poll=0.05,
+                                       status_probe=lambda: state["status"])
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    assert not done.wait(timeout=0.5)   # outlives quiesce: no valve
+    state["status"] = "waiting"
+    assert done.wait(timeout=3)
+    assert result["ok"] is True
+
+
+def test_wait_probe_busy_cancel_honored(tmp_path):
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    cancel = threading.Event()
+    result = {}
+    done = threading.Event()
+
+    def wait():
+        result["ok"] = wait_until_safe(t, s, cancelled=cancel.is_set,
+                                       marker_wired=True, poll=0.05,
+                                       status_probe=lambda: "busy")
+        done.set()
+
+    threading.Thread(target=wait, daemon=True).start()
+    assert not done.wait(timeout=0.3)
+    cancel.set()
+    assert done.wait(timeout=3)
+    assert result["ok"] is False
+
+
+def test_monitor_probe_waiting_fires_immediately(tmp_path):
+    # End-to-end through FlipMonitor: mtimes scream mid-turn, probe says
+    # waiting -> the ladder runs. Mirrors test_monitor_arm_wait_terminate.
+    t, s = tmp_path / "t.jsonl", tmp_path / "s.turn"
+    _touch(t, time.time())
+    control = _StubControl()
+    m = FlipMonitor(control, [b"\x04"], transcript=t, sentinel=s,
+                    marker_wired=True, poll=0.05,
+                    status_probe=lambda: "waiting")
+    m.start()
+    m.flip_pressed()
+    deadline = time.time() + 3
+    while not m.flip_requested and time.time() < deadline:
+        time.sleep(0.05)
+    m.stop()
+    assert m.flip_requested is True
+    assert m.how == "soft"
+    assert control.calls == [[b"\x04"]]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -898,3 +898,41 @@ def test_runner_wires_no_probe_for_codex(env_factory, monkeypatch):
     )
     runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
     assert made["kw"]["status_probe"] is None
+
+
+def test_session_status_rejects_nonpositive_and_bool_pids(tmp_path, monkeypatch):
+    # os.kill(0,0)/os.kill(-N,0) probe process groups and would read
+    # "alive"; with busy-wins and no valve a pid-0 busy entry pins the
+    # flip forever. The guard drops them before _pid_alive runs.
+    _registry(tmp_path, monkeypatch, {
+        "zero.json": {"pid": 0, "sessionId": _SID, "status": "busy"},
+        "neg.json": {"pid": -1, "sessionId": _SID, "status": "busy"},
+        "bool.json": {"pid": True, "sessionId": _SID, "status": "busy"},
+    })
+    assert _claude_adapter().session_status(_SID) is None
+
+
+def test_runner_probe_swallows_raising_session_status(env_factory, monkeypatch):
+    # OverflowError from os.kill on an absurd pid is not an OSError; a
+    # probe that raises would kill the flip thread. The wiring maps any
+    # escape to None (single tier: no answer -> flippable).
+    env = env_factory(active="claude")
+    made = {}
+    real = runner.FlipMonitor
+
+    def capture(*a, **kw):
+        made["kw"] = kw
+        return real(*a, **kw)
+
+    monkeypatch.setattr(runner, "FlipMonitor", capture)
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    from tandem.harness.claude_code import ClaudeCodeAdapter
+    monkeypatch.setattr(
+        ClaudeCodeAdapter, "session_status",
+        lambda self, sid: (_ for _ in ()).throw(OverflowError()),
+    )
+    assert made["kw"]["status_probe"]() is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,6 @@
 """InteractiveRunner: user-configured [harness] args land in the spawned argv."""
 
+import json
 import os
 import threading
 import time
@@ -652,3 +653,94 @@ def test_marker_wired_false_when_adapter_injects_no_hook(env_factory, monkeypatc
     monkeypatch.setattr(ClaudeCodeAdapter, "hook_argv_extra", lambda self, s: [])
     monitor = _run_capturing_monitor(env, monkeypatch)
     assert monitor.marker_wired is False
+
+
+# ---- claude session-status probe -------------------------------------------
+
+
+def _registry(tmp_path, monkeypatch, entries):
+    """Fake ~/.claude/sessions with the given {filename: dict-or-raw} files."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    d = tmp_path / ".claude" / "sessions"
+    d.mkdir(parents=True)
+    for name, entry in entries.items():
+        text = entry if isinstance(entry, str) else json.dumps(entry)
+        (d / name).write_text(text)
+    return d
+
+
+_SID = "11111111-1111-4111-8111-111111111111"
+
+
+def _claude_adapter():
+    from tandem.harness import get_adapter
+    return get_adapter("claude")
+
+
+def test_pid_alive_own_pid():
+    from tandem.harness.claude_code import _pid_alive
+    assert _pid_alive(os.getpid()) is True
+
+
+def test_session_status_reads_busy_and_waiting(tmp_path, monkeypatch):
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "busy"},
+    })
+    assert _claude_adapter().session_status(_SID) == "busy"
+    _registry(tmp_path.joinpath("b"), monkeypatch, {
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting",
+                       "waitingFor": "input needed"},
+    })
+    assert _claude_adapter().session_status(_SID) == "waiting"
+
+
+def test_session_status_none_when_no_match(tmp_path, monkeypatch):
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        f"{me}.json": {"pid": me, "sessionId": "someone-else", "status": "busy"},
+    })
+    assert _claude_adapter().session_status(_SID) is None
+
+
+def test_session_status_none_when_dir_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    assert _claude_adapter().session_status(_SID) is None
+
+
+def test_session_status_skips_stale_dead_pid_entry(tmp_path, monkeypatch):
+    # A crashed run of this same resumed session leaves a dead-pid file
+    # frozen at "busy"; the live entry must win.
+    from tandem.harness import claude_code
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        "99999.json": {"pid": 99999, "sessionId": _SID, "status": "busy"},
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting"},
+    })
+    monkeypatch.setattr(claude_code, "_pid_alive", lambda pid: pid == me)
+    assert claude_code.ClaudeCodeAdapter().session_status(_SID) == "waiting"
+    # dead-only: no live entry at all reads as no answer
+    monkeypatch.setattr(claude_code, "_pid_alive", lambda pid: False)
+    assert claude_code.ClaudeCodeAdapter().session_status(_SID) is None
+
+
+def test_session_status_busy_wins_among_live_matches(tmp_path, monkeypatch):
+    from tandem.harness import claude_code
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        "11.json": {"pid": 11, "sessionId": _SID, "status": "waiting"},
+        "22.json": {"pid": 22, "sessionId": _SID, "status": "busy"},
+    })
+    monkeypatch.setattr(claude_code, "_pid_alive", lambda pid: True)
+    assert claude_code.ClaudeCodeAdapter().session_status(_SID) == "busy"
+
+
+def test_session_status_tolerates_garbage_files(tmp_path, monkeypatch):
+    me = os.getpid()
+    _registry(tmp_path, monkeypatch, {
+        "junk.json": "not json{",
+        "list.json": '["not", "a", "dict"]',
+        "nopid.json": {"sessionId": _SID, "status": "busy"},
+        f"{me}.json": {"pid": me, "sessionId": _SID, "status": "waiting"},
+    })
+    assert _claude_adapter().session_status(_SID) == "waiting"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -501,8 +501,33 @@ def test_runner_passes_frame_and_control(env_factory, monkeypatch):
     frame = seen["frame"]
     assert frame is not None
     assert frame.flip_byte == 0x1D
+    assert frame.key_label == "^]"
     assert frame.active == "claude" and frame.other == "codex"
     assert r.flip_requested is False
+
+
+def test_runner_labels_a_rebound_flip_key_for_the_bar(env_factory, monkeypatch):
+    # [frame] flip_key = "ctrl-t" must reach the bar as "^T", not just as the
+    # byte the detector watches.
+    env = env_factory(active="claude")
+    (paths.tandem_home() / "config.toml").write_text(
+        '[frame]\nflip_key = "ctrl-t"\n'
+    )
+    seen = {}
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None: seen.update(frame=frame) or 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so: _Sink()).run()
+    assert seen["frame"].flip_byte == 0x14
+    assert seen["frame"].key_label == "^T"
+
+
+def test_key_label_spells_control_bytes_with_a_caret():
+    assert runner._key_label(0x1D) == "^]"
+    assert runner._key_label(0x14) == "^T"
+    assert runner._key_label(0x01) == "^A"
+    assert runner._key_label(0x7F) == "0x7f"   # not a control byte: fallback
 
 
 def test_runner_reports_flip_requested(env_factory, monkeypatch):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -374,6 +374,130 @@ def test_malformed_run_still_gets_click_usage_error(sess, capsys, monkeypatch):
     assert "commands:" in cap.out
 
 
+def test_flip_reenters_other_harness_without_prompt(sess, monkeypatch):
+    """Ctrl-] inside the harness flips and re-enters with no prompt stop."""
+    def fake_switch(store, session):
+        new = "codex" if session.active == "claude" else "claude"
+        store.set_active(session.tandem_id, new)
+        return new, [], FakeMem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        if len(calls) == 1:
+            return 0, True   # user pressed Ctrl-]
+        return 0, False      # then exited normally
+
+    prompts = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        raise EOFError       # leave the shell at the first prompt
+
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=input_fn, run_harness=run_harness,
+    )
+    assert code == 0
+    assert calls == ["claude", "codex"]  # flip switched roles
+    assert prompts == ["tandem (codex)> "]  # one prompt, after the plain exit
+
+
+def test_flip_loop_keeps_flipping_until_a_plain_exit(sess, monkeypatch):
+    """Successive flips chain without ever touching the prompt."""
+    def fake_switch(store, session):
+        new = "codex" if session.active == "claude" else "claude"
+        store.set_active(session.tandem_id, new)
+        return new, [], FakeMem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        return 0, len(calls) < 4
+
+    prompts = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        raise EOFError
+
+    shell.run_shell(sess.tandem_id, None, input_fn=input_fn, run_harness=run_harness)
+    assert calls == ["claude", "codex", "claude", "codex"]
+    assert len(prompts) == 1
+
+
+def test_flip_from_the_typed_switch_command(sess, monkeypatch):
+    """A flip requested inside the harness `switch` entered also chains."""
+    def fake_switch(store, session):
+        new = "codex" if session.active == "claude" else "claude"
+        store.set_active(session.tandem_id, new)
+        return new, [], FakeMem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        return 0, len(calls) == 2  # flip out of the harness `switch` entered
+
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("switch", "exit"),
+        run_harness=run_harness,
+    )
+    assert calls == ["claude", "codex", "claude"]
+
+
+def test_flip_failure_falls_back_to_prompt(sess, capsys, monkeypatch):
+    """ops.switch_session raising must not lose the session or spin."""
+    def run_harness(session):
+        return 0, True
+
+    def boom(store, session):
+        raise RuntimeError("no flip for you")
+
+    monkeypatch.setattr(shell.ops, "switch_session", boom)
+
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted(), run_harness=run_harness,
+    )
+    cap = capsys.readouterr()
+    assert code == 0  # carried through; session intact at the prompt
+    assert "switch failed: RuntimeError: no flip for you" in cap.err
+    assert f"to continue this session: tandem resume {sess.tandem_id}" in cap.out
+
+
+def test_flip_with_a_vanished_session_row_stops_the_loop(sess, capsys):
+    """A session deleted mid-flight breaks the loop instead of spinning."""
+    def run_harness(session):
+        conn = sqlite3.connect(paths.state_db_path())
+        with conn:
+            conn.execute(
+                "DELETE FROM sessions WHERE tandem_id = ?", (sess.tandem_id,)
+            )
+        conn.close()
+        return 0, True
+
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted(), run_harness=run_harness,
+    )
+    assert code == 0
+    assert "switch failed" in capsys.readouterr().err
+
+
+def test_int_returning_run_harness_still_works(sess):
+    """Legacy seam: a plain int means no flip."""
+    def run_harness(session):
+        return 7
+
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted(), run_harness=run_harness,
+    )
+    assert code == 7
+
+
 def test_prompt_switch_reports_like_the_one_shot(sess, capsys, monkeypatch):
     """Display names, memory actions and the doctor advisory — the prompt is
     the primary switch path, so it must not report less than `tandem switch`."""

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -487,6 +487,72 @@ def test_flip_with_a_vanished_session_row_stops_the_loop(sess, capsys):
     assert "switch failed" in capsys.readouterr().err
 
 
+class FakeInteractiveRunner:
+    """Stands in for the real runner behind `run_shell`'s own closure — the
+    seam the reports plumbing actually lives in, so the injected `run_harness`
+    used by every other test would skip it entirely."""
+
+    script: list = []
+    seen: list = []
+
+    def __init__(self, session, sink_factory=None):
+        self.session = session
+        self.reports = []
+        self.flip_requested = False
+
+    def run(self):
+        FakeInteractiveRunner.seen.append(self.session.active)
+        reports, flip = FakeInteractiveRunner.script.pop(0)
+        self.reports = list(reports)
+        self.flip_requested = flip
+        if not flip:  # the real runner prints its own on a non-flip exit
+            for line in self.reports:
+                print(line)
+        return 0
+
+
+def _fake_runner_shell(monkeypatch, sess, script):
+    from tandem import runner as runner_mod
+
+    def fake_switch(store, session):
+        new = "codex" if session.active == "claude" else "claude"
+        store.set_active(session.tandem_id, new)
+        return new, [], FakeMem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+    monkeypatch.setattr(runner_mod, "InteractiveRunner", FakeInteractiveRunner)
+    FakeInteractiveRunner.script = list(script)
+    FakeInteractiveRunner.seen = []
+    shell.run_shell(sess.tandem_id, None, input_fn=scripted())
+    return FakeInteractiveRunner.seen
+
+
+def test_flip_reprints_the_runners_reports_after_the_clear(sess, capsys, monkeypatch):
+    """The flip clears the screen; a sync error the user never gets to read is
+    the same as no sync error at all, so the held-back lines print after it."""
+    lines = [
+        "tandem: sync error: transcript shrank",
+        "tandem: status bar disabled for this session (terminal conflict)",
+    ]
+    seen = _fake_runner_shell(
+        monkeypatch, sess, [(lines, True), ([], False)]
+    )
+    out = capsys.readouterr().out
+    assert seen == ["claude", "codex"]        # the flip really happened
+    for line in lines:
+        assert out.count(line) == 1           # shown once, on the fresh screen
+
+
+def test_non_flip_exit_prints_its_reports_once(sess, capsys, monkeypatch):
+    """No flip, no clear: the runner prints them itself and the shell must not
+    print a second copy."""
+    lines = ["tandem: sync error: transcript shrank"]
+    seen = _fake_runner_shell(monkeypatch, sess, [(lines, False)])
+    out = capsys.readouterr().out
+    assert seen == ["claude"]
+    assert out.count(lines[0]) == 1
+
+
 def test_int_returning_run_harness_still_works(sess):
     """Legacy seam: a plain int means no flip."""
     def run_harness(session):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -469,6 +469,116 @@ def test_flip_failure_falls_back_to_prompt(sess, capsys, monkeypatch):
     assert f"to continue this session: tandem resume {sess.tandem_id}" in cap.out
 
 
+def _flipping_switch(monkeypatch):
+    def fake_switch(store, session):
+        new = "codex" if session.active == "claude" else "claude"
+        store.set_active(session.tandem_id, new)
+        return new, [], FakeMem()
+
+    monkeypatch.setattr(shell.ops, "switch_session", fake_switch)
+
+
+def test_failed_launch_after_a_flip_returns_to_the_harness_we_left(
+    sess, capsys, monkeypatch
+):
+    """The spec's first rung: never strand the user at a prompt whose active
+    harness cannot launch. Flip the roles back and re-enter the one they were
+    in a second ago."""
+    _flipping_switch(monkeypatch)
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        if session.active == "codex":
+            raise FileNotFoundError("codex: command not found")
+        return 0, len(calls) == 1   # the first claude session asks for a flip
+
+    prompts = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        raise EOFError
+
+    shell.run_shell(sess.tandem_id, None, input_fn=input_fn, run_harness=run_harness)
+    cap = capsys.readouterr()
+    assert calls == ["claude", "codex", "claude"]  # flipped, failed, flipped back
+    assert "codex would not start — switching back to claude." in cap.err
+    with StateStore() as store:
+        assert store.get_session(sess.tandem_id).active == "claude"  # roles restored
+    assert prompts == ["tandem (claude)> "]  # one prompt, after the working run
+
+
+def test_both_harnesses_failing_lands_at_the_prompt_with_the_session_intact(
+    sess, capsys, monkeypatch
+):
+    """Second rung: the flip-back cannot launch either, so fall to the prompt
+    with the errors shown — and the resume hint still prints."""
+    _flipping_switch(monkeypatch)
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        if len(calls) == 1:
+            return 0, True          # flip requested
+        raise FileNotFoundError(f"{session.active}: command not found")
+
+    prompts = []
+
+    def input_fn(prompt):
+        prompts.append(prompt)
+        raise EOFError
+
+    code = shell.run_shell(
+        sess.tandem_id, None, input_fn=input_fn, run_harness=run_harness
+    )
+    cap = capsys.readouterr()
+    assert calls == ["claude", "codex", "claude"]  # one retry only, no ping-pong
+    assert cap.err.count("could not run the harness: FileNotFoundError") == 2
+    assert prompts == ["tandem (claude)> "]
+    assert code == 0
+    assert f"to continue this session: tandem resume {sess.tandem_id}" in cap.out
+
+
+def test_flip_back_does_not_run_when_the_switch_itself_fails(sess, capsys, monkeypatch):
+    """`ops.switch_session` raising means roles never moved: there is nothing
+    to flip back from, so the prompt is the right landing (unchanged)."""
+    def boom(store, session):
+        raise RuntimeError("no flip for you")
+
+    monkeypatch.setattr(shell.ops, "switch_session", boom)
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        return 0, len(calls) == 1
+
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted(), run_harness=run_harness
+    )
+    cap = capsys.readouterr()
+    assert calls == ["claude"]
+    assert "switch failed: RuntimeError: no flip for you" in cap.err
+    assert "would not start" not in cap.err
+
+
+def test_plain_reentry_failure_has_no_flip_back(sess, capsys):
+    """`_enter` off the prompt never moved roles, so a failed launch must not
+    drag the session into the other harness."""
+    calls = []
+
+    def run_harness(session):
+        calls.append(session.active)
+        raise FileNotFoundError("claude: command not found")
+
+    shell.run_shell(
+        sess.tandem_id, None, input_fn=scripted("exit"), run_harness=run_harness
+    )
+    assert calls == ["claude"]
+    with StateStore() as store:
+        assert store.get_session(sess.tandem_id).active == "claude"
+    assert "would not start" not in capsys.readouterr().err
+
+
 def test_flip_with_a_vanished_session_row_stops_the_loop(sess, capsys):
     """A session deleted mid-flight breaks the loop instead of spinning."""
     def run_harness(session):

--- a/tests/test_sub.py
+++ b/tests/test_sub.py
@@ -421,7 +421,7 @@ class TestSubLockCoverage:
 
         monkeypatch.setattr(ops, "_sub_lock", recording_lock)
         monkeypatch.setattr(runner.TailLoop, "drain", drain)
-        monkeypatch.setattr(runner, "run_in_pty", lambda argv, cwd=None: 0)
+        monkeypatch.setattr(runner, "run_in_pty", lambda argv, cwd=None, **kw: 0)
 
         class _Sink:
             def handle(self, line, ctx, cursor): ...


### PR DESCRIPTION
## What this is

The meta-harness frame: `tandem` becomes the CLI you launch, and the native harness TUIs become the tabs inside it. **Ctrl-]** flips the screen between Claude Code and Codex (~1–3 s, same conversation — the sync engine has already kept the shadow transcript current), with a one-row tab bar on the terminal's bottom row. No conversation UI was built: the native TUIs render everything; tandem stays a byte pump plus transcript translation.

## How it works

- **Flip keybind** (`[frame] flip_key`, default Ctrl-], configurable): consumed at the PTY layer, ignored inside bracketed paste. Mid-turn press arms (`◐ flipping at turn end…` on the bar) and fires at the turn-complete marker; a second press cancels. Marker-aware waiting: when the marker is wired, quiescence is only a 120 s dead-hook safety valve — a mid-turn flip waits for the turn, full stop. Marker-less sessions (codex with a user-owned `notify`) keep the ~2 s quiescence fallback.
- **Graceful exit ladder:** per-harness quit keystrokes → SIGTERM to the process group → bounded SIGKILL; transcripts are append-safe on every rung.
- **The tab bar:** bottom row, `claude ● │ codex ○   ^] flips` (hint follows the rebind). The child is told the terminal is one row shorter — bottom placement keeps every child coordinate identity-mapped — and a scroll region plus a targeted output watcher (RIS, DECSTBM, alt-screen, full ED) keep the bar intact. If a terminal can't sustain it, the bar drops for the session (flip keeps working) and `tandem doctor` explains; `[frame] bar = false` opts out. A shrink below 5 rows drops it silently — that's policy, not a conflict.
- **Resume-failure rungs per spec:** launch failure after a flip flips back to the harness you just left; double failure lands at the tandem prompt with the resume hint — the session is never lost.
- Plain exits, the tandem prompt, `switch`, one-shot commands, subagents, and sync are all unchanged.

## Review process

Built task-by-task with a fresh implementer + adversarial reviewer per task (5 fix rounds across tasks 1/2/6/8/9), then a final whole-branch review whose 8 findings (4 Important) were fixed in a single verified wave. Highlights the reviews caught: a paste-marker carry hole that could permanently latch the flip key off, SIGWINCH-reentrancy in the bar teardown that could corrupt the terminal past exit, and the mid-turn quiescence kill that led to the marker-aware wait design.

## Test plan

- 497 passing (`uv run pytest -q`), 111 added on this branch; the pure state machines (detector/guard/bar) are exhaustively split-point tested against oracles.
- **Still required before merge: the operator live-validation checklist** — `docs/plans/2026-08-09-meta-harness-frame.md`, Task 13 + addendum. The interactive pump path can't run under pytest (no tty), so this pass is its only integration test. The final review flags one item as the merge gate: the bar must survive first contact with both TUIs (a startup full-height DECSTBM from either would drop it session-1).
- Post-merge follow-ups (none blocking) are listed at the bottom of the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
