### PR TITLE
Always-warm standby + flip/exit latency fixes

### DIFF
--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -87,7 +87,7 @@ def load_harness_args(harness: str) -> list[str]:
 class FrameConfig:
     flip_byte: int = 0x1D   # Ctrl-]
     bar: bool = True
-    warm: bool = True       # boot the other harness during the flip's teardown
+    warm: bool = True       # keep the other harness booted on a hidden PTY
 
 
 def _parse_flip_key(value: str) -> int | None:

--- a/src/tandem/flip.py
+++ b/src/tandem/flip.py
@@ -248,11 +248,14 @@ def _switch(
     _report_switch(old, new_active, problems, mem)
     if carry is not None:
         standby = carry.get("standby")
-        if standby is not None and not _standby_fresh(
-            standby, new_active, session, mem
-        ):
-            carry["standby"] = None
-            _reap(standby, carry)   # off-thread: the flip must not wait
+        if standby is not None:
+            from .runner import _flip_debug
+
+            fresh = _standby_fresh(standby, new_active, session, mem)
+            _flip_debug(f"standby-gate side={new_active} fresh={fresh}")
+            if not fresh:
+                carry["standby"] = None
+                _reap(standby, carry)   # off-thread: the flip must not wait
     code, flip, launched = _try_enter(tandem_id, run_harness)
     if launched or not fall_back:
         return code, flip

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -146,7 +146,10 @@ class ClaudeCodeAdapter(HarnessAdapter):
         return ["--settings", json.dumps(settings)]
 
     def quit_keystrokes(self) -> list[bytes]:
-        return [b"\x03", b"\x04"]
+        # claude ≥2.1.229 exits only on a same-key double-press; ^C both
+        # clears a drafted composer and arms the confirmation, so three
+        # presses cover every prompt state (live-verified 2026-08-13)
+        return [b"\x03", b"\x03", b"\x03"]
 
     def session_status(self, session_id: str) -> str | None:
         """Live turn state from claude's session registry: "busy" while a

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -141,6 +141,20 @@ def _stdin_tty() -> bool:
         return False
 
 
+def _flip_debug(msg: str) -> None:
+    """Timestamped line into ~/.tandem/logs/flip-debug.log. Temporary
+    diagnostic for the live flip-latency hunt: never raises, and never
+    called from the pump thread (flip_pressed records to memory instead;
+    the monitor thread writes on its behalf)."""
+    try:
+        path = paths.log_dir() / "flip-debug.log"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(f"{time.time():.3f} pid={os.getpid()} {msg}\n")
+    except Exception:
+        pass
+
+
 def wait_until_safe(
     transcript: Path | None,
     sentinel: Path | None,
@@ -280,6 +294,7 @@ class FlipMonitor:
         self.on_flip_decided = on_flip_decided
         self.flip_requested = False
         self.how = ""
+        self._key_events: list[tuple[float, str]] = []
         self._armed = threading.Event()
         self._stop = threading.Event()
         self._thread = threading.Thread(
@@ -307,8 +322,12 @@ class FlipMonitor:
         that `armed()` needs — `armed()` runs inside the SIGWINCH handler on
         this same thread, and a shared lock would deadlock the pump."""
         if self._armed.is_set():
+            # memory only — this thread must never do I/O (see docstring);
+            # the monitor thread flushes these to the debug log
+            self._key_events.append((time.time(), "cancel"))
             self._armed.clear()  # toggle: cancel a pending flip
         else:
+            self._key_events.append((time.time(), "arm"))
             self._armed.set()
 
     def armed(self) -> bool:
@@ -320,11 +339,18 @@ class FlipMonitor:
         fires, so the bar stops advertising an arm that is already spent."""
         return self._armed.is_set() and not self.flip_requested
 
+    def _flush_key_events(self) -> None:
+        while self._key_events:
+            ts, ev = self._key_events.pop(0)
+            _flip_debug(f"key {ev} pressed_at={ts:.3f}")
+
     def _run(self) -> None:
         while not self._stop.is_set():
             self._armed.wait()
             if self._stop.is_set():
                 return
+            self._flush_key_events()
+            _flip_debug("wait-start")
             ok = wait_until_safe(
                 self.transcript,
                 self.sentinel,
@@ -339,8 +365,11 @@ class FlipMonitor:
             )
             if self._stop.is_set():
                 return
+            self._flush_key_events()
             if not ok:
+                _flip_debug("wait-cancelled")
                 continue  # cancelled: back to waiting for the next arm
+            _flip_debug("wait-released ladder-start")
             self.flip_requested = True
             if self.on_flip_decided is not None:
                 try:
@@ -348,6 +377,7 @@ class FlipMonitor:
                 except Exception:
                     pass   # a failed fire means a cold flip, never a dead thread
             self.how = self.control.terminate(self.quit_bytes)
+            _flip_debug(f"ladder-done how={self.how}")
             return
 
 
@@ -505,6 +535,7 @@ class InteractiveRunner:
         # otherwise: rebuilding for an adopted child could disagree with what
         # is already running.
         recipe = self.adopt_child.recipe if adopting else build_launch(session, active)
+        _flip_debug(f"run-start side={active} adopting={adopting}")
         transcript = recipe.transcript
         sentinel = recipe.sentinel
         argv = recipe.argv
@@ -512,6 +543,8 @@ class InteractiveRunner:
 
         frame_cfg = load_frame_config()
         control = PtyControl()
+        probe_last: dict = {"status": "<unpolled>"}
+
         def claude_probe() -> str | None:
             # A raising probe would kill the tandem-flip thread and leave
             # the bar advertising an armed flip that can never fire (os.kill
@@ -520,9 +553,13 @@ class InteractiveRunner:
             # guards). Single tier reads any non-answer as flippable, so an
             # escape maps to None, never to a dead thread.
             try:
-                return adapter.session_status(active_sid)
+                status = adapter.session_status(active_sid)
             except Exception:
-                return None
+                status = None
+            if status != probe_last["status"]:
+                _flip_debug(f"probe {probe_last['status']} -> {status}")
+                probe_last["status"] = status
+            return status
 
         monitor = FlipMonitor(
             control, adapter.quit_keystrokes(), transcript, sentinel,
@@ -583,6 +620,11 @@ class InteractiveRunner:
                     with fired_lock:
                         fired["spawning"] = False
                     return   # a failed fire means a cold flip
+                _flip_debug(
+                    f"warm-spawned side={shadow}"
+                    f" child={getattr(getattr(child, 'child', None), 'pid', '?')}"
+                    f" shadow_size={size}"
+                )
                 displaced = None
                 with fired_lock:
                     fired["spawning"] = False
@@ -756,6 +798,9 @@ class InteractiveRunner:
             )
         self.reports = [f"tandem: sync error: {err}" for err in errors]
         self.reports += [f"tandem: {note}" for note in notes]
+        _flip_debug(
+            f"run-exit side={active} code={code} flip={self.flip_requested}"
+        )
         if not self.flip_requested:
             for line in self.reports:
                 print(line)

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -256,8 +256,8 @@ class FlipMonitor:
     entirely — see `wait_until_safe`.
 
     `on_flip_decided` fires once, on this thread, in the gap between the
-    decision and the ladder — the runner starts the incoming harness's launch
-    worker there, so its boot overlaps the outgoing one's teardown. It is
+    decision and the ladder — the runner makes a final freshness check on the
+    resident incoming harness there. It is
     called with the flag already set (`flip_requested` is what makes the flip
     inevitable, and a callback must not be able to take it back) and its
     exceptions are swallowed: a failed hook costs a cold flip, never the flip
@@ -447,8 +447,8 @@ class InteractiveRunner:
         # set here too so the attributes exist even if run() raises early
         self._released = False
         self.flip_requested = False
-        # The harness this run fired at its flip decision, surrendered to the
-        # flip loop's carry. Only a flip can fill it: no flip, no fire.
+        # The resident standby this run surrenders to the flip loop's carry.
+        # A normal exit reaps it instead of publishing it here.
         self.warm_child: WarmChild | None = None
         # Formatted, ready-to-print report lines for the session that just
         # ran. `run()` prints them itself on a normal exit; on a flip it does
@@ -532,19 +532,21 @@ class InteractiveRunner:
             # answers, is how codex opts out.
             status_probe=claude_probe if active == "claude" else None,
         )
-        # Fired at most once, on the monitor thread, between the flip
-        # decision and the ladder. It starts a worker and returns immediately,
-        # so a slow fork/exec cannot hold up teardown of the outgoing harness.
+        # Keeps one shadow harness resident. It starts at runner entry and is
+        # refreshed after a tail drain changes the shadow transcript; the flip
+        # monitor calls it once more between the decision and the ladder as a
+        # final freshness check. Spawn and stale-child teardown stay off the
+        # caller, so neither the PTY pump nor transcript tailing blocks on them.
         # The finally below closes the handoff slot after the ladder: a child
         # that has landed by then is adopted, while a worker that lands later
         # sees the closed slot and kills its child instead of stranding it.
-        # The non-tty path never flips, so a spawn there could only ever
-        # leak a hidden harness: the gate is read at fire time, and takes
-        # both the [frame] `warm` flag and a real stdin tty.
-        fired: dict = {"child": None, "closed": False}
+        # The non-tty path cannot adopt a standby, so a spawn there could only
+        # leak a hidden harness. The gate takes both the [frame] `warm` flag
+        # and a real stdin tty.
+        fired: dict = {"child": None, "closed": False, "spawning": False}
         fired_lock = threading.Lock()
 
-        def fire_warm() -> None:
+        def ensure_warm() -> None:
             if not (frame_cfg.warm and _stdin_tty()):
                 return
             shadow = session.shadow
@@ -554,31 +556,67 @@ class InteractiveRunner:
                          # + a cold spawn own that flip; never fresh-mint
             # not `recipe`: that name is taken by the *active* side's launch,
             # which this closure must never rebuild or shadow
-            shadow_recipe = build_launch(session, shadow)
-            dims = _winsize(sys.stdin.fileno())
+            with fired_lock:
+                current = fired["child"]
+                if (
+                    current is not None
+                    and current.alive()
+                    and current.shadow_size == size
+                ):
+                    return
+                if fired["closed"] or fired["spawning"]:
+                    return
+                fired["spawning"] = True
+
+            try:
+                shadow_recipe = build_launch(session, shadow)
+                dims = _winsize(sys.stdin.fileno())
+            except Exception:
+                with fired_lock:
+                    fired["spawning"] = False
+                return   # standby setup must never cost the active harness
 
             def spawn() -> None:
                 try:
                     child = spawn_hidden(shadow_recipe, dims, size)
                 except Exception:
+                    with fired_lock:
+                        fired["spawning"] = False
                     return   # a failed fire means a cold flip
+                displaced = None
                 with fired_lock:
+                    fired["spawning"] = False
                     if not fired["closed"]:
+                        displaced = fired["child"]
                         fired["child"] = child
-                        return
-                try:
-                    child.kill()   # the runner already read the slot and left
-                except Exception:
-                    pass
+                    else:
+                        displaced = child
+                if displaced is not None:
+                    threading.Thread(
+                        target=lambda: _kill_warm(displaced),
+                        name="tandem-warm-replace", daemon=True,
+                    ).start()
+                # The shadow may have grown while this process was booting.
+                # The tail-side refresh saw `spawning` and deliberately did
+                # not start a duplicate worker, so the landing worker owns the
+                # follow-up that closes that race.
+                if _shadow_size(session, shadow) != size:
+                    ensure_warm()
 
             threading.Thread(
                 target=spawn, name="tandem-warm-fire", daemon=True
             ).start()
 
+        def _kill_warm(child: WarmChild) -> None:
+            try:
+                child.kill()
+            except Exception:
+                pass
+
         # The monitor exists before the closure does, so the hook is wired by
         # assignment — `monitor.start()` is called far below, which is what
         # makes a plain write safe: the thread has not run yet.
-        monitor.on_flip_decided = fire_warm
+        monitor.on_flip_decided = ensure_warm
         frame = FrameIO(
             flip_byte=frame_cfg.flip_byte,
             on_flip=monitor.flip_pressed,
@@ -650,7 +688,9 @@ class InteractiveRunner:
                 try:
                     while not stop.is_set():
                         with ops._sub_lock():
-                            loop.drain()
+                            drained = loop.drain()
+                        if drained:
+                            ensure_warm()
                         watcher.wait()
                     # final drain after the CLI exits
                     with ops._sub_lock():
@@ -663,6 +703,7 @@ class InteractiveRunner:
         thread = threading.Thread(target=tail_thread, name="tandem-tail", daemon=True)
         thread.start()
         monitor.start()   # before the try: stop() on an unstarted thread raises
+        ensure_warm()
         try:
             # A release that returns None means the discard reader still owns
             # the fd, so there is nothing safe to hand over: run_in_pty spawns

--- a/src/tandem/warm.py
+++ b/src/tandem/warm.py
@@ -133,15 +133,18 @@ class WarmChild:
     def kill(self) -> None:
         """Short version of the ladder: soft quit keys first so the CLI
         cleans its own state (claude removes its session-registry file),
-        then TERM/KILL to the process group."""
-        self._stop.set()
-        self._reader.join(timeout=2)
+        then TERM/KILL to the process group. Keep draining through the
+        ladder so the CLI cannot block while writing its exit repaint."""
         control = PtyControl()
         control.attach(self.child)
-        control.terminate(
-            get_adapter(self.recipe.side).quit_keystrokes(),
-            soft_timeout=1.5, term_timeout=1.0,
-        )
+        try:
+            control.terminate(
+                get_adapter(self.recipe.side).quit_keystrokes(),
+                soft_timeout=1.5, term_timeout=1.0,
+            )
+        finally:
+            self._stop.set()
+            self._reader.join(timeout=2)
 
 
 def spawn_hidden(

--- a/src/tandem/warm.py
+++ b/src/tandem/warm.py
@@ -1,11 +1,10 @@
-"""Process warmup: the incoming harness boots while the outgoing one dies.
+"""Process warmup: keep the incoming harness booted on a hidden PTY.
 
-Nothing here runs on its own schedule. The runner fires `spawn_hidden`
-from the monitor thread the moment a flip is decided, so the child boots
-through the outgoing harness's teardown; whether that child is still
-usable by the time the flip lands is flip.py's freshness gate to decide,
-and this module only hands it the evidence (the recipe, the shadow-size
-snapshot).
+Nothing here runs on its own schedule. The runner calls `spawn_hidden` at
+entry and refreshes the standby when transcript sync grows the shadow;
+whether that child is still usable by the time the flip lands is flip.py's
+freshness gate to decide, and this module only hands it the evidence (the
+recipe, the shadow-size snapshot).
 
 `LaunchRecipe` is the frozen record of how a harness invocation was (or
 will be) launched. It exists because config is read per call

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -525,9 +525,13 @@ def test_feed_after_flush_starts_clean():
 
 
 def test_claude_quit_recipe():
-    # Ctrl-C clears the composer / interrupts, Ctrl-D on the empty
-    # composer exits
-    assert get_adapter("claude").quit_keystrokes() == [b"\x03", b"\x04"]
+    # claude ≥2.1.229 exits only on a same-key double-press ("press
+    # Ctrl-C again to exit") — a mixed ^C/^D recipe arms two different
+    # confirmations and never quits, so the ladder SIGTERMs and claude
+    # skips its own transcript finalization. First ^C clears the
+    # composer AND arms, second exits; third backstops a dismissed
+    # dialog eating one press.
+    assert get_adapter("claude").quit_keystrokes() == [b"\x03", b"\x03", b"\x03"]
 
 
 def test_codex_quit_recipe():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -449,11 +449,9 @@ def _fire_and_join(control, hook, tmp_path):
 
 
 def test_monitor_fires_the_flip_hook_before_the_ladder(tmp_path):
-    # The hook is where the incoming harness is spawned, and the whole point
-    # of firing it from here is that the boot overlaps the outgoing harness's
-    # teardown. Run after `control.terminate` it would still spawn, still
-    # hand over, still pass every runner test — and serialize precisely what
-    # this pipelines. So the order is the contract.
+    # The hook is the resident standby's final freshness check. It must run
+    # before teardown so a replacement, when needed, boots in parallel with
+    # the outgoing harness's quit ladder. The order is the contract.
     order = []
     m = _fire_and_join(_OrderingControl(order), lambda: order.append("fired"),
                        tmp_path)
@@ -1010,7 +1008,7 @@ def test_runner_probe_swallows_raising_session_status(env_factory, monkeypatch):
     assert made["kw"]["status_probe"]() is None
 
 
-# -- the fire-at-flip warm spawn ------------------------------------------
+# -- resident warm spawn --------------------------------------------------
 
 
 class _StdinWithFileno:
@@ -1177,7 +1175,10 @@ def test_a_slow_fire_does_not_delay_the_termination_ladder(env_factory,
         release_spawn.wait(timeout=1)
         order.append("spawn-done")
         spawn_done.set()
-        return _DeadChild()
+        child = _DeadChild()
+        child.shadow_size = args[2]
+        child.alive = lambda: True
+        return child
 
     def terminate(self, soft, **kwargs):
         order.append("ladder")
@@ -1198,28 +1199,182 @@ def test_a_slow_fire_does_not_delay_the_termination_ladder(env_factory,
     assert order.index("ladder") < order.index("spawn-done")
 
 
-def test_no_flip_leaves_no_fire_spawn(env_factory, monkeypatch):
+def test_warm_starts_before_flip_and_normal_exit_reaps_it(env_factory, monkeypatch):
     env = env_factory(active="claude")
     import tandem.runner as runner_mod
     spawns = []
-    monkeypatch.setattr(runner_mod, "spawn_hidden",
-                        lambda *a, **kw: spawns.append(1))
+
+    class FakeChild:
+        def __init__(self, shadow_size):
+            self.shadow_size = shadow_size
+            self.killed = False
+
+        def alive(self):
+            return True
+
+        def kill(self):
+            self.killed = True
+
+    def fake_spawn_hidden(recipe, dims, shadow_size):
+        spawns.append(FakeChild(shadow_size))
+        return spawns[-1]
+
+    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
     monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
     monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
-    monkeypatch.setattr(runner_mod, "run_in_pty", lambda *a, **kw: 0)
+    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
+
+    def fake_run_in_pty(*args, **kwargs):
+        deadline = time.time() + 3
+        while not spawns and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner_mod, "run_in_pty", fake_run_in_pty)
     r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
     r.run()
-    assert not r.flip_requested and spawns == [] and r.warm_child is None
+    assert not r.flip_requested
+    assert len(spawns) == 1 and spawns[0].killed
+    assert r.warm_child is None
 
 
-def test_fire_kills_its_child_when_the_slot_is_already_closed(env_factory,
-                                                             monkeypatch):
-    # The one case monitor.stop()'s join cannot cover: its timeout expires
-    # with a spawn still in flight, so the runner's finally reads and closes
-    # the slot first and the fire lands after. Driven by calling the fire
-    # hook once run() has returned — the slot is then closed for good, which
-    # is exactly the state an expired join leaves behind. The child must be
-    # killed by the fire itself; nothing else is left to reap it.
+def test_sync_growth_replaces_the_resident_warm_child(env_factory, monkeypatch):
+    env = env_factory(active="claude")
+    import tandem.runner as runner_mod
+
+    with open(env.claude_shadow, "a") as fh:
+        fh.write(json.dumps({
+            "type": "user",
+            "uuid": "warm-refresh-user",
+            "message": {"role": "user", "content": "refresh warm child"},
+        }) + "\n")
+
+    spawns = []
+    first_spawned = threading.Event()
+
+    class FakeChild:
+        def __init__(self, shadow_size):
+            self.shadow_size = shadow_size
+            self.killed = False
+
+        def alive(self):
+            return True
+
+        def kill(self):
+            self.killed = True
+
+    def fake_spawn_hidden(recipe, dims, shadow_size):
+        child = FakeChild(shadow_size)
+        spawns.append(child)
+        first_spawned.set()
+        return child
+
+    class GrowingSink(_Sink):
+        def handle(self, line, ctx, cursor):
+            assert first_spawned.wait(3)
+            with open(env.codex_shadow, "ab") as fh:
+                fh.write(b'{"synced":true}\n')
+
+    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
+    monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
+    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
+    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
+
+    def fake_run_in_pty(*args, **kwargs):
+        deadline = time.time() + 3
+        while len(spawns) < 2 and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner_mod, "run_in_pty", fake_run_in_pty)
+    r = runner_mod.InteractiveRunner(
+        env.session, sink_factory=lambda *args: GrowingSink()
+    )
+    r.run()
+
+    assert len(spawns) == 2
+    assert spawns[0].shadow_size < spawns[1].shadow_size
+    assert spawns[0].killed and spawns[1].killed
+
+
+def test_sync_growth_during_spawn_gets_a_followup_warm_child(env_factory,
+                                                            monkeypatch):
+    env = env_factory(active="claude")
+    import tandem.runner as runner_mod
+
+    with open(env.claude_shadow, "a") as fh:
+        fh.write(json.dumps({
+            "type": "user", "uuid": "warm-race-user",
+            "message": {"role": "user", "content": "race warm spawn"},
+        }) + "\n")
+
+    spawn_started = threading.Event()
+    shadow_grew = threading.Event()
+    drain_cycle_done = threading.Event()
+    release_spawn = threading.Event()
+    spawns = []
+
+    class FakeChild:
+        def __init__(self, shadow_size):
+            self.shadow_size = shadow_size
+            self.killed = False
+
+        def alive(self):
+            return True
+
+        def kill(self):
+            self.killed = True
+
+    def fake_spawn_hidden(recipe, dims, shadow_size):
+        if not spawns:
+            spawn_started.set()
+            assert release_spawn.wait(3)
+        child = FakeChild(shadow_size)
+        spawns.append(child)
+        return child
+
+    class GrowingSink(_Sink):
+        def handle(self, line, ctx, cursor):
+            assert spawn_started.wait(3)
+            with open(env.codex_shadow, "ab") as fh:
+                fh.write(b'{"synced":"during-spawn"}\n')
+            shadow_grew.set()
+
+    class SignalingWatcher(_QuietWatcher):
+        def wait(self):
+            drain_cycle_done.set()
+            super().wait()
+
+    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
+    monkeypatch.setattr(runner_mod, "TranscriptWatcher", SignalingWatcher)
+    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
+    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
+
+    def fake_run_in_pty(*args, **kwargs):
+        assert shadow_grew.wait(3)
+        assert drain_cycle_done.wait(3)
+        release_spawn.set()
+        deadline = time.time() + 3
+        while len(spawns) < 2 and time.time() < deadline:
+            time.sleep(0.02)
+        return 0
+
+    monkeypatch.setattr(runner_mod, "run_in_pty", fake_run_in_pty)
+    runner_mod.InteractiveRunner(
+        env.session, sink_factory=lambda *args: GrowingSink()
+    ).run()
+
+    assert len(spawns) == 2
+    assert spawns[0].shadow_size < spawns[1].shadow_size
+    assert spawns[0].killed and spawns[1].killed
+
+
+def test_a_closed_slot_rejects_a_refire(env_factory, monkeypatch):
+    # ensure_warm called after the run ended (a monitor join that expired
+    # mid-flip can leave the hook to fire this late) must not boot anything:
+    # the slot is closed for good, and a child spawned now would have nobody
+    # left to adopt or reap it. Driven by calling the hook once run() has
+    # returned.
     import tandem.runner as runner_mod
     env = env_factory(active="claude")
     monitors = []
@@ -1230,8 +1385,12 @@ def test_fire_kills_its_child_when_the_slot_is_already_closed(env_factory,
             monitors.append(self)
 
     class FakeChild:
-        def __init__(self):
+        def __init__(self, shadow_size):
+            self.shadow_size = shadow_size
             self.killed = False
+
+        def alive(self):
+            return True
 
         def kill(self):
             self.killed = True
@@ -1239,7 +1398,7 @@ def test_fire_kills_its_child_when_the_slot_is_already_closed(env_factory,
     spawns = []
 
     def fake_spawn_hidden(recipe, dims, shadow_size):
-        spawns.append(FakeChild())
+        spawns.append(FakeChild(shadow_size))
         return spawns[-1]
 
     monkeypatch.setattr(runner_mod, "FlipMonitor", CapturingMonitor)
@@ -1250,14 +1409,55 @@ def test_fire_kills_its_child_when_the_slot_is_already_closed(env_factory,
     monkeypatch.setattr(runner_mod, "run_in_pty", lambda *a, **kw: 0)
     r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
     r.run()
-    assert spawns == [] and r.warm_child is None   # nothing fired during the run
+    assert len(spawns) == 1 and spawns[0].killed
+    assert r.warm_child is None
 
-    monitors[0].on_flip_decided()                  # the in-flight spawn lands
-    deadline = time.time() + 3
-    while not spawns and time.time() < deadline:
-        time.sleep(0.02)
-    assert len(spawns) == 1 and spawns[0].killed   # reaped, not stranded
+    monitors[0].on_flip_decided()                  # fires against a closed slot
+    time.sleep(0.05)
+    assert len(spawns) == 1 and spawns[0].killed   # no second spawn
     assert r.warm_child is None                    # and never adopted
+
+
+def test_a_spawn_landing_after_close_kills_its_child(env_factory, monkeypatch):
+    # The startup fire is still in flight when the run ends: the finally
+    # closes the slot with the worker blocked inside spawn_hidden, so nothing
+    # was published to adopt. The landing worker must see the closed slot and
+    # kill the child it just booted — nothing else holds a reference to it.
+    import tandem.runner as runner_mod
+    env = env_factory(active="claude")
+    release_spawn = threading.Event()
+    reaped = threading.Event()
+    spawns = []
+
+    class FakeChild:
+        def __init__(self, shadow_size):
+            self.shadow_size = shadow_size
+            self.killed = False
+
+        def alive(self):
+            return True
+
+        def kill(self):
+            self.killed = True
+            reaped.set()
+
+    def fake_spawn_hidden(recipe, dims, shadow_size):
+        assert release_spawn.wait(3)
+        spawns.append(FakeChild(shadow_size))
+        return spawns[-1]
+
+    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
+    monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
+    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
+    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
+    monkeypatch.setattr(runner_mod, "run_in_pty", lambda *a, **kw: 0)
+    r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
+    r.run()
+    assert spawns == []          # the worker never landed during the run
+    release_spawn.set()          # now it lands on a closed slot
+    assert reaped.wait(3)
+    assert len(spawns) == 1 and spawns[0].killed
+    assert r.warm_child is None
 
 
 def test_runner_adopts_a_live_child(env_factory, monkeypatch):
@@ -1441,7 +1641,8 @@ def test_a_fired_child_is_not_leaked_when_run_in_pty_raises(env_factory,
     spawned = []
 
     class FakeChild:
-        def __init__(self):
+        def __init__(self, shadow_size):
+            self.shadow_size = shadow_size
             self.killed = False
 
         def alive(self):
@@ -1451,7 +1652,7 @@ def test_a_fired_child_is_not_leaked_when_run_in_pty_raises(env_factory,
             self.killed = True
 
     def fake_spawn_hidden(recipe, dims, shadow_size):
-        spawned.append(FakeChild())
+        spawned.append(FakeChild(shadow_size))
         return spawned[-1]
 
     driver = _flip_driver(env)

--- a/tests/test_warm.py
+++ b/tests/test_warm.py
@@ -168,7 +168,9 @@ def test_release_refuses_to_hand_over_a_still_owned_fd(env_factory):
     assert wc.release() is fake
 
 
-def test_kill_runs_the_short_ladder(env_factory, monkeypatch):
+def test_kill_keeps_reader_draining_through_the_short_ladder(
+    env_factory, monkeypatch
+):
     env = env_factory()
     fake = _FakePty()
     wc = WarmChild(_recipe(env), fake, shadow_size=0)
@@ -178,6 +180,7 @@ def test_kill_runs_the_short_ladder(env_factory, monkeypatch):
                        attach_timeout=5.0):
         calls["soft"] = soft
         calls["timeouts"] = (soft_timeout, term_timeout)
+        calls["reader_alive"] = wc._reader.is_alive()
         return "soft"
 
     from tandem import ptyrun
@@ -186,6 +189,7 @@ def test_kill_runs_the_short_ladder(env_factory, monkeypatch):
     from tandem.harness import get_adapter
     assert calls["soft"] == get_adapter("codex").quit_keystrokes()
     assert calls["timeouts"] == (1.5, 1.0)
+    assert calls["reader_alive"]
     assert not wc._reader.is_alive()
 
 


### PR DESCRIPTION
## Summary

Two commits that together make flips feel instant and exits clean:

**Always-warm resident standby (`510a685`)** — `fire_warm` becomes an idempotent `ensure_warm`: a no-op while the resident hidden child is alive and its shadow-size snapshot matches the shadow transcript, otherwise a worker spawns a replacement and reaps the displaced child off-thread. Fired from runner entry, the tail thread after any drain that consumed lines, and `on_flip_decided`. A worker that lands on a shadow that grew while booting re-fires itself; a `spawning` flag stops concurrent callers stacking workers. Downstream (slot-close protocol, carry, freshness gate, adoption) untouched — warm now means "keep the other harness resident", not "boot it at flip time".

**Flip/exit latency fixes (`c4e2df2`)** — two live-probed root causes:
- claude ≥2.1.229 exits only on a same-key double-press, so the old `[^C, ^D]` quit recipe armed two different confirmations and never soft-quit: every claude→codex flip rode the 3s soft ladder into SIGTERM, and claude skipped its own transcript finalization. Recipe is now `[^C, ^C, ^C]`.
- `WarmChild.kill` stopped the discard reader before running the short ladder, so the exiting CLI wedged writing its exit repaint into the undrained hidden pty — soft quit and SIGTERM both died and every exit SIGKILLed the standby (~4.4s). The reader now drains through `terminate` and joins after.

Also adds temporary flip-debug logging to `~/.tandem/logs/flip-debug.log` (arm/cancel key events, probe transitions, standby freshness gate, warm spawns, ladder timing) — the diagnostic that found both bugs; can be stripped before or after merge if we'd rather not carry it.

## Validation

- 567 tests pass locally.
- Live-validated on real CLIs: standby resident within 0.5s of boot and on resume; a flip adopted a 95s-old standby PID-for-PID with the synced turn visible in the adopted TUI; quit-recipe and drain fixes probe-verified 2026-08-13 via the flip-debug log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)