### PR TITLE
release: 0.3.0

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump to 0.3.0 (pyproject.toml + plugin manifest) for the 0.3.0 release: the Ctrl-] frame, warm flips, model-pin recovery, and the N-harness core.

Release gates in #38 deferred to 0.3.1 per operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)