### PR TITLE
fix: update uv.lock for the 0.3.0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
#42 bumped pyproject.toml to 0.3.0 without regenerating uv.lock, so `uv sync --locked` fails CI on main. This is the one-line lockfile refresh (verified locally with CI's exact commands: `uv sync --locked` + 600 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)