### PR TITLE
Opencode adapter (PR 2: storage capabilities, full-peer opencode harness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 **One coding session. Two AI agents. Zero lost context.**
 
-Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and
-[OpenAI Codex CLI](https://github.com/openai/codex) as a single paired
-session — each model in its own native harness. Work in either one,
-flip to the other with **Ctrl-]**, and pick up exactly where you left
-off. Only one model runs per turn; the other stays in sync through pure
-local file translation.
+Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code),
+[OpenAI Codex CLI](https://github.com/openai/codex), and
+[opencode](https://opencode.ai) as a single paired session — each model
+in its own native harness. Work in any one, flip to the next with
+**Ctrl-]**, and pick up exactly where you left off. Only one model runs
+per turn; the others stay in sync through pure local translation.
 
 [![CI](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml/badge.svg)](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tandem-cli)](https://pypi.org/project/tandem-cli/)
@@ -28,7 +28,9 @@ uv tool install tandem-cli
 
 ## Quick start
 
-You'll need Python 3.11+ and the `claude` and `codex` CLIs on your PATH.
+You'll need Python 3.11+ and at least two of the `claude`, `codex`, and
+`opencode` CLIs on your PATH (any pair works; all three make a
+three-way session).
 
 ```bash
 uv tool install tandem-cli   # or: pip install tandem-cli
@@ -44,6 +46,13 @@ facing:
 
 ```
 claude ● │ codex ○   ^] flips
+```
+
+With opencode installed too, the session is three-way and **Ctrl-]**
+cycles through all of them in order:
+
+```
+claude ● │ codex ○ │ opencode ○   ^] flips
 ```
 
 Pressed mid-turn, the flip arms and fires the moment the model finishes
@@ -114,8 +123,8 @@ one problem, native harnesses, instant switching, privacy:
   between.
 - Everything stays local: the CLIs' own session files plus a small
   SQLite database in `~/.tandem`. No cloud sync, no telemetry.
-- Uninstall tandem tomorrow and both sessions still resume natively
-  with `claude --resume` and `codex resume`.
+- Uninstall tandem tomorrow and every side still resumes natively with
+  `claude --resume`, `codex resume`, and `opencode -s`.
 
 Full mechanics — sync engine, crash safety, compatibility ranges:
 [How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md).
@@ -150,7 +159,8 @@ sync-mcp` (share MCP server configs between the tools).
 - [Developing tandem](https://github.com/Bhavya6187/tandem/blob/main/docs/development.md) —
   dev setup and the converter adapter interface
 - [Observed session formats](https://github.com/Bhavya6187/tandem/blob/main/docs/formats.md) —
-  the claude/codex transcript details tandem is pinned against
+  the claude/codex/opencode session-storage details tandem is pinned
+  against
 
 ## License
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -110,3 +110,38 @@ home), `TANDEM_HOME` (tandem state).
    raw entry quarantined at {path}]`
    with the raw source entry written to
    `~/.tandem/quarantine/<tandem-id>/<source>-line-<n>.json`.
+
+## opencode session storage (opencode 1.18.15)
+
+- Storage: one WAL-mode SQLite DB for everything — `opencode db path`
+  (channel-suffixed filename; `$OPENCODE_DB` overrides). No per-session
+  files. Tables: `session`, `message`, `part`; JSON payloads in `data`
+  minus the id/fk columns. FKs cascade part -> message -> session -> project.
+- Ordering: messages by `(time_created, id)`; parts by part id ONLY.
+- IDs: `<prefix>_` + 12 hex chars (48-bit `ms*4096+counter`) + 14 random
+  base62. `ses_` NOTs the value (descending); `msg_`/`prt_` ascending.
+  Live-verified: msg @ ms=1786577389138 ctr=1 -> `ff84f8652001`.
+- Threading is flat: assistant `parentID` = the turn's user message id.
+- Spelling trap: session-row `model` JSON uses `{id, providerID}`; message
+  payloads use `{modelID, providerID}`. Session-level `agent`/`model` are
+  optional; MESSAGE-level are required on user messages. Session-level
+  `slug` is REQUIRED by import's decoder (oracle-verified: the payload is
+  rejected `at ["slug"]` without it) but carries no uniqueness constraint —
+  opencode mints adjective-noun pairs; tandem seeds `tandem-pair`.
+- Tool parts mutate in place (pending -> running -> completed): tandem reads
+  whole completed turns only (last assistant has `time.completed` + terminal
+  `finish`).
+- External writes: the `opencode import` recipe (plain INSERT, conflict-
+  ignore). Tandem's shadow birth delegates to `opencode import`; incremental
+  sync writes rows directly with pre-minted ids (idempotent replay).
+- Tandem attribution: `providerID: "tandem"`, `modelID: "<synced>"` — marks
+  echoes for the parser and makes opencode degrade replay metadata instead
+  of re-sending forged provider signatures.
+- Hazards: a running TUI never sees external rows for an already-synced
+  session (writes land while opencode is closed; flips relaunch it); a
+  session whose last message is not a completed assistant renders as
+  perpetually "working"; the session list window is 30 days by
+  `time_updated`; always open the DB read-write (WAL).
+- Resume: `opencode -s <id>` (id must exist; no directory match);
+  one-off: `opencode run -s <id> "<prompt>"`. No per-invocation
+  turn-complete hook — tandem fs-watches the `-wal` file.

--- a/src/tandem/doctor.py
+++ b/src/tandem/doctor.py
@@ -75,6 +75,9 @@ def run_doctor(store, session, live: bool = False) -> DoctorReport:
             )
         else:
             report.ok(f"{adapter.display_name}: {v}")
+            ok, reason = adapter.runtime_ready()
+            if not ok:
+                report.warn(f"{adapter.display_name}: installed but unusable — {reason}")
 
     if session is None:
         report.fail("no tandem session for this directory (run `tandem` to start one)")

--- a/src/tandem/harness/__init__.py
+++ b/src/tandem/harness/__init__.py
@@ -1,10 +1,12 @@
 from .base import HarnessAdapter
 from .claude_code import ClaudeCodeAdapter
 from .codex import CodexAdapter
+from .opencode import OpencodeAdapter
 
 ADAPTERS: dict[str, HarnessAdapter] = {
     "claude": ClaudeCodeAdapter(),
     "codex": CodexAdapter(),
+    "opencode": OpencodeAdapter(),
 }
 
 

--- a/src/tandem/harness/base.py
+++ b/src/tandem/harness/base.py
@@ -15,6 +15,25 @@ from typing import Any
 from ..events import NormalizedEvent, SessionContext
 
 
+class JsonlSourceReader:
+    """Default source reader: the existing byte-offset JSONL tailer."""
+
+    def __init__(self, path: Path, cursor):
+        from ..tailer import JsonlTailer
+
+        self.tailer = JsonlTailer(
+            path, start_offset=cursor.byte_offset, start_line=cursor.line_index
+        )
+
+    def poll(self):
+        return self.tailer.poll()
+
+
+class ShadowBusy(RuntimeError):
+    """Shadow store locked beyond busy_timeout. The append transaction
+    rolled back — nothing landed — so the tailer retries next tick."""
+
+
 class HarnessAdapter(ABC):
     id: str          # 'claude' | 'codex'
     display_name: str
@@ -110,6 +129,58 @@ class HarnessAdapter(ABC):
     @abstractmethod
     def render_placeholder(self, text: str, ctx: SessionContext) -> list[dict[str, Any]]:
         """Native entries for an untranslatable-turn placeholder."""
+
+    # -- storage capabilities (file-backed defaults; opencode overrides) -----
+
+    def make_source_reader(self, session, cursor, transcript: Path):
+        return JsonlSourceReader(transcript, cursor)
+
+    def watch_paths(self, session, transcript: Path) -> list[Path]:
+        return [transcript]
+
+    def shadow_append(self, ref: Path, entries: list[dict]) -> None:
+        from ..util import append_jsonl_fsync
+
+        append_jsonl_fsync(ref, entries)
+
+    def shadow_intent(self, ref: Path, entries: list[dict]) -> dict:
+        return {"pre_size": ref.stat().st_size}
+
+    def intent_landed(self, ref: Path, intent: dict) -> bool:
+        try:
+            return ref.stat().st_size > int(intent["pre_size"])
+        except (OSError, KeyError, ValueError):
+            return False
+
+    def fast_forward_cursor(self, session, cursor) -> None:
+        """Mark everything currently in this SOURCE's store as consumed."""
+        sid = session.native_id(self.id)
+        path = self.transcript_path(session.cwd, sid) if sid else None
+        if path is None:
+            cursor.byte_offset = 0
+            cursor.line_index = 0
+            return
+        data = path.read_bytes()
+        cursor.byte_offset = len(data)
+        cursor.line_index = data.count(b"\n")
+
+    def pending_units(self, session, cursor) -> int:
+        sid = session.native_id(self.id)
+        path = self.transcript_path(session.cwd, sid) if sid else None
+        if path is None:
+            return 0
+        try:
+            data = path.read_bytes()
+        except OSError:
+            return 0
+        if len(data) <= cursor.byte_offset:
+            return 0
+        return data[cursor.byte_offset:].count(b"\n")
+
+    def prepare_shadow(self, ref, ctx) -> None:
+        """Re-anchor renderer state to what is actually in the shadow store.
+        Called before the first append of a sync run and after a crash-skip
+        re-append. Default: nothing."""
 
 
 def _parse_jsonl_entries(path: Path):

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -436,3 +436,15 @@ class ClaudeCodeAdapter(HarnessAdapter):
             if m and m != "<synced>":
                 model = m
         return model
+
+    def prepare_shadow(self, ref, ctx) -> None:
+        """The claude file may have grown since tandem last wrote (its own
+        CLI appends while claude is active): chain onto the real leaf and
+        pick up the model claude last used for rendered entries."""
+        st = ctx.state_for("claude")
+        leaf = self.derive_leaf_uuid(ref)
+        if leaf:
+            st["leaf_uuid"] = leaf
+        model = self.derive_last_model(ref)
+        if model:
+            st["model"] = model

--- a/src/tandem/harness/codex.py
+++ b/src/tandem/harness/codex.py
@@ -5,13 +5,6 @@ Session format observed on codex-cli 0.145.0 (docs/formats.md):
 - each line {timestamp, type, payload}; model-facing history is the
   response_item lines, UI history is the event_msg lines
 - first line is session_meta; ~/.codex/session_index.jsonl indexes threads
-
-KNOWN BREAK — codex 0.147.0 moved session storage to sqlite
-(~/.codex/state_5.sqlite, thread_sections et al.): a live session holds no
-rollout JSONL open and a fresh session writes none, so the tailer/sync see
-nothing from codex. `codex resume` of a tandem-seeded rollout still
-launches (2026-08-09, live-validated), but appends nothing back. Needs a
-storage-aware adapter pass; tracked in the frame plan's validation results.
 """
 
 from __future__ import annotations

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -332,10 +332,206 @@ class OpencodeAdapter(HarnessAdapter):
                     events.append(sysev(f"part:{ptype}"))
         return events
 
-    # -- temporary stubs (replaced by Tasks 11-13) ---------------------------
+    # -- session files -------------------------------------------------------
 
     def transcript_path(self, cwd: str, session_id: str) -> Path | None:
-        raise NotImplementedError
+        """Opencode has no per-session file; the "transcript" is the DB, and
+        it exists for a session exactly when the session row does."""
+        db = db_path()
+        if db is None or not session_id:
+            return None
+        try:
+            with connect(db) as conn:
+                row = conn.execute("SELECT 1 FROM session WHERE id = ?",
+                                   (session_id,)).fetchone()
+        except sqlite3.Error:
+            return None
+        return db if row is not None else None
+
+    # -- rendering (shadow append) -------------------------------------------
+
+    def _message_entry(self, sid: str, msg_id: str, data: dict, ms: int) -> dict:
+        return {"table": "message", "id": msg_id, "session_id": sid,
+                "time": ms, "data": data}
+
+    def _part_entry(self, sid: str, msg_id: str, data: dict, ms: int) -> dict:
+        return {"table": "part", "id": mint_id("prt"), "session_id": sid,
+                "message_id": msg_id, "time": ms, "data": data}
+
+    def _open_user(self, out: list, st: dict, sid: str, text: str, ms: int) -> None:
+        uid = mint_id("msg")
+        st["turn_user_id"] = uid
+        st["assistant_id"] = None
+        out.append(self._message_entry(sid, uid, {
+            "role": "user", "time": {"created": ms}, "agent": "build",
+            "model": {"providerID": SENTINEL_PROVIDER,
+                      "modelID": SENTINEL_MODEL},
+        }, ms))
+        out.append(self._part_entry(sid, uid, {"type": "text", "text": text}, ms))
+
+    def _ensure_assistant(self, out: list, st: dict, sid: str, ctx,
+                          ms: int, model: str | None) -> str:
+        if st.get("assistant_id"):
+            if model:
+                # the turn's assistant row was opened by a tool pair (no
+                # model); a later text event carries the real one — upgrade
+                # the still-in-flight row so display shows the source model
+                for e in reversed(out):
+                    if e["table"] == "message" and e["id"] == st["assistant_id"]:
+                        if e["data"].get("modelID") == SENTINEL_MODEL:
+                            e["data"]["modelID"] = model
+                        break
+            return st["assistant_id"]
+        if not st.get("turn_user_id"):
+            # assistant content with no turn open (first sync after seed):
+            # a context row keeps parentID valid
+            self._open_user(out, st, sid, "[tandem] (context sync)", ms)
+        aid = mint_id("msg")
+        st["assistant_id"] = aid
+        out.append(self._message_entry(sid, aid, {
+            "parentID": st["turn_user_id"], "role": "assistant",
+            "mode": "build", "agent": "build",
+            "path": {"cwd": ctx.cwd, "root": ctx.cwd},
+            "cost": 0,
+            "tokens": {"input": 0, "output": 0, "reasoning": 0,
+                       "cache": {"read": 0, "write": 0}},
+            "modelID": model or SENTINEL_MODEL,
+            "providerID": SENTINEL_PROVIDER,
+            "time": {"created": ms, "completed": ms},
+            "finish": "stop",
+        }, ms))
+        return aid
+
+    def render_events(
+        self, events: list[NormalizedEvent], ctx: SessionContext
+    ) -> list[dict[str, Any]]:
+        """Normalized events -> row-op entries. One user row per turn; one
+        (closed) assistant row per turn carrying text and tool parts. The
+        converter emits ToolCall/ToolResult adjacent, so pairing is local;
+        a call that somehow arrives without its result closes as an error
+        part rather than dangling (opencode's replay rejects dangles)."""
+        sid = ctx.target_session_id
+        st = ctx.state_for("opencode")
+        out: list[dict[str, Any]] = []
+        pending_call: ToolCall | None = None
+
+        def flush_dangle(ms: int) -> None:
+            nonlocal pending_call
+            if pending_call is None:
+                return
+            aid = self._ensure_assistant(out, st, sid, ctx, ms, None)
+            out.append(self._part_entry(sid, aid, self._tool_part(
+                pending_call, output="(tool result not recorded)",
+                is_error=True), ms))
+            pending_call = None
+
+        for ev in events:
+            ms = _now_ms()
+            if ev.kind == "user_message":
+                flush_dangle(ms)
+                self._open_user(out, st, sid, ev.text, ms)
+            elif ev.kind == "assistant_message":
+                flush_dangle(ms)
+                aid = self._ensure_assistant(out, st, sid, ctx, ms, ev.model)
+                out.append(self._part_entry(
+                    sid, aid, {"type": "text", "text": ev.text}, ms))
+            elif ev.kind == "tool_call":
+                flush_dangle(ms)
+                pending_call = ev
+            elif ev.kind == "tool_result":
+                if pending_call is None:
+                    continue   # converter never emits an orphan result natively
+                aid = self._ensure_assistant(out, st, sid, ctx, ms, None)
+                out.append(self._part_entry(sid, aid, self._tool_part(
+                    pending_call, output=ev.output, is_error=ev.is_error), ms))
+                pending_call = None
+            # thinking/system: dropped (no reasoning parts by spec)
+        flush_dangle(_now_ms())
+        return out
+
+    def _tool_part(self, call: ToolCall, output: str, is_error: bool) -> dict:
+        ms = _now_ms()
+        return {
+            "type": "tool", "tool": call.tool, "callID": call.call_id,
+            "state": {
+                "status": "error" if is_error else "completed",
+                "input": call.arguments if isinstance(call.arguments, dict)
+                         else {"input": call.arguments},
+                **({"error": output} if is_error else {"output": output}),
+                "title": "", "metadata": {},
+                "time": {"start": ms, "end": ms},
+            },
+        }
+
+    def render_placeholder(self, text: str, ctx: SessionContext) -> list[dict[str, Any]]:
+        sid = ctx.target_session_id
+        st = ctx.state_for("opencode")
+        out: list[dict[str, Any]] = []
+        ms = _now_ms()
+        self._open_user(out, st, sid, text, ms)
+        self._ensure_assistant(out, st, sid, ctx, ms, None)
+        aid = st["assistant_id"]
+        out.append(self._part_entry(
+            sid, aid, {"type": "text", "text": "[tandem] (turn recorded as a"
+                       " placeholder; see the note above)"}, ms))
+        return out
+
+    # -- shadow append (transactional, idempotent) ----------------------------
+
+    def shadow_append(self, ref: Path, entries: list[dict]) -> None:
+        """One transaction per synced unit. A lock outlasting busy_timeout
+        raises ShadowBusy — the transaction rolled back, nothing landed, and
+        the tailer retries the whole unit next tick (spec: error handling)."""
+        from .base import ShadowBusy
+
+        if not entries:
+            return
+        conn = connect(ref)
+        try:
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                raise ShadowBusy(str(exc)) from exc
+            for e in entries:
+                if e["table"] == "message":
+                    conn.execute(
+                        "INSERT OR IGNORE INTO message"
+                        " (id, session_id, time_created, time_updated, data)"
+                        " VALUES (?, ?, ?, ?, ?)",
+                        (e["id"], e["session_id"], e["time"], e["time"],
+                         json.dumps(e["data"])))
+                else:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO part"
+                        " (id, message_id, session_id, time_created,"
+                        " time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+                        (e["id"], e["message_id"], e["session_id"], e["time"],
+                         e["time"], json.dumps(e["data"])))
+            conn.execute("UPDATE session SET time_updated = ? WHERE id = ?",
+                         (entries[-1]["time"], entries[0]["session_id"]))
+            conn.commit()
+        finally:
+            conn.close()
+
+    def shadow_intent(self, ref: Path, entries: list[dict]) -> dict:
+        return {"ids": [(e["table"], e["id"]) for e in entries]}
+
+    def intent_landed(self, ref: Path, intent: dict) -> bool:
+        ids = intent.get("ids") or []
+        if not ids:
+            return False
+        table, first = ids[0]
+        if table not in ("message", "part"):
+            return False
+        try:
+            with connect(ref) as conn:
+                row = conn.execute(
+                    f"SELECT 1 FROM {table} WHERE id = ?", (first,)).fetchone()
+        except sqlite3.Error:
+            return False
+        return row is not None
+
+    # -- temporary stubs (replaced by Task 13) -------------------------------
 
     def create_shadow_transcript(
         self, cwd: str, session_id: str, ctx: SessionContext, note: str
@@ -349,12 +545,4 @@ class OpencodeAdapter(HarnessAdapter):
         raise NotImplementedError
 
     def hook_argv_extra(self, sentinel: Path) -> list[str]:
-        raise NotImplementedError
-
-    def render_events(
-        self, events: list[NormalizedEvent], ctx: SessionContext
-    ) -> list[dict[str, Any]]:
-        raise NotImplementedError
-
-    def render_placeholder(self, text: str, ctx: SessionContext) -> list[dict[str, Any]]:
         raise NotImplementedError

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -603,7 +603,11 @@ class OpencodeAdapter(HarnessAdapter):
                 # projectID/directory/path are placeholders: import re-homes
                 # them from its own instance context. agent/model omitted
                 # (optional session-level; opencode's default applies).
+                # slug is schema-required (live-verified: import rejects the
+                # payload `at ["slug"]` without it) but not unique — opencode
+                # mints adjective-noun pairs; tandem's marks provenance.
                 "id": session_id,
+                "slug": "tandem-pair",
                 "projectID": "tandem-import",
                 "directory": cwd,
                 "title": "tandem paired session",

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -205,11 +205,21 @@ class OpencodeAdapter(HarnessAdapter):
             with connect(db) as conn:
                 names = {r[0] for r in conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table'")}
+                missing = {"session", "message", "part"} - names
+                if missing:
+                    return False, f"expected table(s) missing: {sorted(missing)}"
+                mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+                if str(mode).lower() != "wal":
+                    return False, f"journal_mode is {mode!r}, expected wal"
+                # sync writes rows directly; a read-only DB must fail closed
+                # here, not one append at a time later
+                try:
+                    conn.execute("BEGIN IMMEDIATE")
+                    conn.execute("ROLLBACK")
+                except sqlite3.OperationalError as exc:
+                    return False, f"database not writable: {exc}"
         except sqlite3.Error as exc:
             return False, f"database unreadable: {exc}"
-        missing = {"session", "message", "part"} - names
-        if missing:
-            return False, f"expected table(s) missing: {sorted(missing)}"
         return True, ""
 
     def mint_session_id(self) -> str:
@@ -379,6 +389,36 @@ class OpencodeAdapter(HarnessAdapter):
             return None
         return db if row is not None else None
 
+    def prepare_shadow(self, ref, ctx) -> None:
+        """Re-anchor the renderer's turn state to the rows actually in the
+        DB. Crash-skip replay re-renders a unit for its ctx side effects,
+        minting fresh ids the skipped append never inserted; without this
+        the next unit would chain onto a phantom parent (an FK failure
+        under foreign_keys=ON)."""
+        sid = ctx.target_session_id
+        if not sid:
+            return
+        try:
+            with connect(ref) as conn:
+                row = conn.execute(
+                    "SELECT id, data FROM message WHERE session_id = ?"
+                    " ORDER BY time_created DESC, id DESC LIMIT 1",
+                    (sid,)).fetchone()
+        except sqlite3.Error:
+            return   # unreadable store: leave state; the append fails loudly
+        st = ctx.state_for("opencode")
+        if row is None:
+            st["turn_user_id"] = None
+            st["assistant_id"] = None
+            return
+        data = json.loads(row["data"])
+        if data.get("role") == "assistant":
+            st["assistant_id"] = row["id"]
+            st["turn_user_id"] = data.get("parentID")
+        else:
+            st["turn_user_id"] = row["id"]
+            st["assistant_id"] = None
+
     # -- rendering (shadow append) -------------------------------------------
 
     def _message_entry(self, sid: str, msg_id: str, data: dict, ms: int) -> dict:
@@ -412,6 +452,13 @@ class OpencodeAdapter(HarnessAdapter):
                         if e["data"].get("modelID") == SENTINEL_MODEL:
                             e["data"]["modelID"] = model
                         break
+                else:
+                    # the row landed in an earlier synced unit: upgrade it in
+                    # place (strictly sentinel -> real, tandem rows only, so
+                    # replay is idempotent and native rows are untouchable)
+                    out.append({"table": "message_model",
+                                "id": st["assistant_id"], "session_id": sid,
+                                "time": ms, "data": {"modelID": model}})
             return st["assistant_id"]
         if not st.get("turn_user_id"):
             # assistant content with no turn open (first sync after seed):
@@ -522,7 +569,11 @@ class OpencodeAdapter(HarnessAdapter):
             try:
                 conn.execute("BEGIN IMMEDIATE")
             except sqlite3.OperationalError as exc:
-                raise ShadowBusy(str(exc)) from exc
+                # only contention is retryable; a readonly/corrupt store must
+                # surface, not spin as ShadowBusy forever
+                if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                    raise ShadowBusy(str(exc)) from exc
+                raise
             for e in entries:
                 if e["table"] == "message":
                     conn.execute(
@@ -531,6 +582,14 @@ class OpencodeAdapter(HarnessAdapter):
                         " VALUES (?, ?, ?, ?, ?)",
                         (e["id"], e["session_id"], e["time"], e["time"],
                          json.dumps(e["data"])))
+                elif e["table"] == "message_model":
+                    conn.execute(
+                        "UPDATE message SET data = json_set(data,"
+                        " '$.modelID', ?) WHERE id = ?"
+                        " AND json_extract(data, '$.providerID') = ?"
+                        " AND json_extract(data, '$.modelID') = ?",
+                        (e["data"]["modelID"], e["id"],
+                         SENTINEL_PROVIDER, SENTINEL_MODEL))
                 else:
                     conn.execute(
                         "INSERT OR IGNORE INTO part"
@@ -548,12 +607,14 @@ class OpencodeAdapter(HarnessAdapter):
         return {"ids": [(e["table"], e["id"]) for e in entries]}
 
     def intent_landed(self, ref: Path, intent: dict) -> bool:
+        # anchor on the first INSERT op: update ops (message_model) target
+        # rows that pre-exist the append, so their presence proves nothing
         ids = intent.get("ids") or []
-        if not ids:
+        first_insert = next(
+            ((t, i) for t, i in ids if t in ("message", "part")), None)
+        if first_insert is None:
             return False
-        table, first = ids[0]
-        if table not in ("message", "part"):
-            return False
+        table, first = first_insert
         try:
             with connect(ref) as conn:
                 row = conn.execute(

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -1,0 +1,168 @@
+"""Opencode adapter.
+
+Session storage observed on opencode 1.18.15 (docs/formats.md and the spec's
+reference index into the checkout at ~/git/opencode):
+- everything lives in one WAL-mode SQLite DB (`opencode db path`), tables
+  session / message / part with JSON `data` payloads
+- ids: <prefix>_ + 12 hex chars (48-bit ms*4096+counter; sessions bitwise-NOT
+  it so they sort descending) + 14 random base62
+- messages order by (time_created, id); parts by part id alone
+- tool parts mutate IN PLACE (pending -> running -> completed), so reads
+  consume whole completed turns, never raw rows
+- external writes are the `opencode import` recipe: plain INSERTs; a session
+  whose last message is not a completed assistant renders as "working"
+- tandem-authored rows carry providerID "tandem": degrades reasoning replay
+  and marks echoes
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from .. import compat
+from ..events import (
+    AssistantMessage,
+    NormalizedEvent,
+    SessionContext,
+    SystemEvent,
+    Thinking,
+    ToolCall,
+    ToolResult,
+    UserMessage,
+)
+from .base import HarnessAdapter
+
+SENTINEL_PROVIDER = "tandem"
+SENTINEL_MODEL = "<synced>"
+
+# seam for tests (matches ops.py's convention)
+_run = subprocess.run
+
+_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_id_state = {"ms": 0, "counter": 0}
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def mint_id(prefix: str, descending: bool = False) -> str:
+    """Port of opencode's identifier scheme (packages/schema/src/identifier.ts):
+    48-bit big-endian hex of ms*4096+counter (counter resets each ms), NOT'd
+    for descending ids, then 14 random base62 chars."""
+    ms = _now_ms()
+    if ms != _id_state["ms"]:
+        _id_state["ms"] = ms
+        _id_state["counter"] = 0
+    _id_state["counter"] += 1
+    value = (ms * 0x1000 + _id_state["counter"]) & 0xFFFFFFFFFFFF
+    if descending:
+        value = ~value & 0xFFFFFFFFFFFF
+    suffix = "".join(secrets.choice(_ID_ALPHABET) for _ in range(14))
+    return f"{prefix}_{value:012x}{suffix}"
+
+
+_db_cache: dict = {}
+
+
+def _reset_db_cache() -> None:
+    _db_cache.clear()
+
+
+def db_path() -> Path | None:
+    """Opencode's DB. $OPENCODE_DB (opencode's own override flag) wins; else
+    `opencode db path` once per process. None on ANY failure — discovery
+    fails closed (the adapter is dropped from the usable set), never a
+    guessed default path (the filename is channel-suffixed)."""
+    env = os.environ.get("OPENCODE_DB")
+    if env:
+        return Path(env)
+    if "path" in _db_cache:
+        return _db_cache["path"]
+    try:
+        out = _run(["opencode", "db", "path"], capture_output=True, text=True,
+                   timeout=20)
+        line = out.stdout.strip().splitlines()[-1] if out.returncode == 0 and \
+            out.stdout.strip() else ""
+        p = Path(line) if line else None
+        _db_cache["path"] = p if p is not None and p.is_file() else None
+    except (OSError, subprocess.TimeoutExpired):
+        _db_cache["path"] = None
+    return _db_cache["path"]
+
+
+def connect(db: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+class OpencodeAdapter(HarnessAdapter):
+    id = "opencode"
+    display_name = "opencode"
+    binary = "opencode"
+
+    # -- environment ---------------------------------------------------------
+
+    def detect_version(self) -> str | None:
+        return compat.detect_cli_version(self.binary)
+
+    def version_supported(self, version_text: str) -> bool:
+        return compat.version_supported("opencode", version_text)
+
+    def runtime_ready(self) -> tuple[bool, str]:
+        db = db_path()
+        if db is None:
+            return False, "database not discoverable (`opencode db path` failed)"
+        try:
+            with connect(db) as conn:
+                names = {r[0] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'")}
+        except sqlite3.Error as exc:
+            return False, f"database unreadable: {exc}"
+        missing = {"session", "message", "part"} - names
+        if missing:
+            return False, f"expected table(s) missing: {sorted(missing)}"
+        return True, ""
+
+    def mint_session_id(self) -> str:
+        return mint_id("ses", descending=True)
+
+    # -- temporary stubs (replaced by Tasks 11-13) ---------------------------
+
+    def transcript_path(self, cwd: str, session_id: str) -> Path | None:
+        raise NotImplementedError
+
+    def create_shadow_transcript(
+        self, cwd: str, session_id: str, ctx: SessionContext, note: str
+    ) -> Path:
+        raise NotImplementedError
+
+    def interactive_argv(self, session_id: str | None, fresh: bool) -> list[str]:
+        raise NotImplementedError
+
+    def oneoff_argv(self, session_id: str, prompt: str) -> list[str]:
+        raise NotImplementedError
+
+    def hook_argv_extra(self, sentinel: Path) -> list[str]:
+        raise NotImplementedError
+
+    def parse_entry(self, raw: dict[str, Any], ctx: SessionContext) -> list[NormalizedEvent]:
+        raise NotImplementedError
+
+    def render_events(
+        self, events: list[NormalizedEvent], ctx: SessionContext
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def render_placeholder(self, text: str, ctx: SessionContext) -> list[dict[str, Any]]:
+        raise NotImplementedError

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -531,18 +531,100 @@ class OpencodeAdapter(HarnessAdapter):
             return False
         return row is not None
 
-    # -- temporary stubs (replaced by Task 13) -------------------------------
+    # -- launching -----------------------------------------------------------
+
+    def interactive_argv(self, session_id: str | None, fresh: bool) -> list[str]:
+        assert session_id, "opencode sessions are created at pair time"
+        return [self.binary, "-s", session_id]
+
+    def oneoff_argv(self, session_id: str, prompt: str) -> list[str]:
+        return [self.binary, "run", "-s", session_id, prompt]
+
+    def hook_argv_extra(self, sentinel: Path) -> list[str]:
+        # No per-invocation hook flag exists; the tailer's fs-watch on the
+        # -wal file is the wake-up signal (watch_paths).
+        return []
+
+    def quit_keystrokes(self) -> list[bytes]:
+        # LIVE-VERIFY before release (spec item 2): pinned per version like
+        # the claude [^C,^C,^C] recipe; the SIGTERM ladder backstops.
+        return [b"\x03", b"\x03"]
+
+    # -- shadow birth (delegated to `opencode import`) ------------------------
 
     def create_shadow_transcript(
         self, cwd: str, session_id: str, ctx: SessionContext, note: str
     ) -> Path:
-        raise NotImplementedError
+        """Tandem never hand-writes opencode session rows. Mint the ids,
+        write a minimal export-format file, and let `opencode import` run
+        its own schema decoders, project bootstrap, and directory re-homing.
+        One subprocess, once per session, off the sync path."""
+        import tempfile
 
-    def interactive_argv(self, session_id: str | None, fresh: bool) -> list[str]:
-        raise NotImplementedError
-
-    def oneoff_argv(self, session_id: str, prompt: str) -> list[str]:
-        raise NotImplementedError
-
-    def hook_argv_extra(self, sentinel: Path) -> list[str]:
-        raise NotImplementedError
+        now = _now_ms()
+        version = self.detect_version() or "0.0.0"
+        user_id = mint_id("msg")
+        asst_id = mint_id("msg")
+        sentinel_model = {"providerID": SENTINEL_PROVIDER,
+                          "modelID": SENTINEL_MODEL}
+        payload = {
+            "info": {
+                # projectID/directory/path are placeholders: import re-homes
+                # them from its own instance context. agent/model omitted
+                # (optional session-level; opencode's default applies).
+                "id": session_id,
+                "projectID": "tandem-import",
+                "directory": cwd,
+                "title": "tandem paired session",
+                "version": version,
+                "time": {"created": now, "updated": now},
+                "cost": 0,
+                "tokens": {"input": 0, "output": 0, "reasoning": 0,
+                           "cache": {"read": 0, "write": 0}},
+            },
+            "messages": [
+                {"info": {"id": user_id, "sessionID": session_id,
+                          "role": "user", "time": {"created": now},
+                          "agent": "build", "model": sentinel_model},
+                 "parts": [{"id": mint_id("prt"), "sessionID": session_id,
+                            "messageID": user_id, "type": "text",
+                            "text": note}]},
+                {"info": {"id": asst_id, "sessionID": session_id,
+                          "role": "assistant", "parentID": user_id,
+                          "time": {"created": now, "completed": now},
+                          "modelID": SENTINEL_MODEL,
+                          "providerID": SENTINEL_PROVIDER,
+                          "mode": "build", "agent": "build",
+                          "path": {"cwd": cwd, "root": cwd},
+                          "cost": 0, "finish": "stop",
+                          "tokens": {"input": 0, "output": 0, "reasoning": 0,
+                                     "cache": {"read": 0, "write": 0}}},
+                 "parts": [{"id": mint_id("prt"), "sessionID": session_id,
+                            "messageID": asst_id, "type": "text",
+                            "text": "[tandem] Session created; context syncs"
+                                    " in from the paired session."}]},
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", prefix="tandem-oc-seed-", delete=False
+        ) as f:
+            json.dump(payload, f)
+            seed_file = Path(f.name)
+        try:
+            out = _run([self.binary, "import", str(seed_file)], cwd=cwd,
+                       capture_output=True, text=True, timeout=120)
+            if out.returncode != 0:
+                tail = (out.stderr or out.stdout or "").strip().splitlines()
+                raise RuntimeError(
+                    f"opencode import failed ({out.returncode})"
+                    + (f": {tail[-1][:200]}" if tail else ""))
+        finally:
+            seed_file.unlink(missing_ok=True)
+        db = self.transcript_path(cwd, session_id)
+        if db is None:
+            raise RuntimeError(
+                f"opencode import reported success but session {session_id}"
+                " is not in the database")
+        ctx.state_for("opencode")["turn_user_id"] = user_id
+        ctx.state_for("opencode")["assistant_id"] = None
+        return db

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -106,6 +106,84 @@ def connect(db: Path) -> sqlite3.Connection:
     return conn
 
 
+_AFTER_POS_SQL = (
+    "SELECT id, time_created, data FROM message WHERE session_id = ?"
+    " AND (time_created > ? OR (time_created = ? AND id > ?))"
+    " ORDER BY time_created, id"
+)
+
+
+def _parts_for(conn: sqlite3.Connection, message_id: str) -> list[dict]:
+    rows = conn.execute(
+        "SELECT id, data FROM part WHERE message_id = ? ORDER BY id",
+        (message_id,),
+    ).fetchall()
+    return [{**json.loads(r["data"]), "id": r["id"]} for r in rows]
+
+
+def _is_closed(msg_data: dict) -> bool:
+    time_completed = (msg_data.get("time") or {}).get("completed")
+    return bool(time_completed) and msg_data.get("finish") not in (None, "tool-calls")
+
+
+class OpencodeTurnReader:
+    """Yields whole completed turns as single native objects. Tool parts
+    mutate in place while a turn runs, so raw rows never cross this
+    boundary; an incomplete turn is simply not yielded and re-read whole
+    on a later poll."""
+
+    def __init__(self, session_id: str, db: Path, cursor):
+        self.session_id = session_id
+        self.db = db
+        self.cursor = cursor
+
+    def poll(self):
+        from ..tailer import TailedLine
+
+        pos = self.cursor.pending.get("source_pos") or {"time": 0, "id": ""}
+        out = []
+        with connect(self.db) as conn:
+            rows = conn.execute(
+                _AFTER_POS_SQL,
+                (self.session_id, pos["time"], pos["time"], pos["id"]),
+            ).fetchall()
+            msgs = [{**json.loads(r["data"]), "id": r["id"],
+                     "_time_created": r["time_created"]} for r in rows]
+            # partition into user-headed turns, in stored order
+            turns: list[dict] = []
+            for m in msgs:
+                if m.get("role") == "user":
+                    turns.append({"user": m, "assistants": []})
+                elif turns:
+                    turns[-1]["assistants"].append(m)
+                # assistants before any user row: tail of a turn whose user
+                # half was already consumed — cannot happen, because the
+                # cursor only ever advances to a terminal assistant.
+            index = self.cursor.line_index
+            for i, t in enumerate(turns):
+                followed_by_user = i + 1 < len(turns)
+                a = t["assistants"]
+                closed = bool(a) and _is_closed(a[-1])
+                if not (followed_by_user or closed):
+                    break   # incomplete turn; nothing after it is ready either
+                turn_obj = {
+                    "user": {"message": t["user"],
+                             "parts": _parts_for(conn, t["user"]["id"])},
+                    "assistants": [
+                        {"message": m, "parts": _parts_for(conn, m["id"])}
+                        for m in a
+                    ],
+                }
+                last = a[-1] if a else t["user"]
+                out.append(TailedLine(
+                    line_index=index, end_offset=0, raw=turn_obj,
+                    text=f"opencode turn {index}",
+                    pos={"time": last["_time_created"], "id": last["id"]},
+                ))
+                index += 1
+        return out
+
+
 class OpencodeAdapter(HarnessAdapter):
     id = "opencode"
     display_name = "opencode"
@@ -137,6 +215,123 @@ class OpencodeAdapter(HarnessAdapter):
     def mint_session_id(self) -> str:
         return mint_id("ses", descending=True)
 
+    # -- storage capabilities -------------------------------------------------
+
+    def make_source_reader(self, session, cursor, transcript):
+        return OpencodeTurnReader(session.native_id("opencode"), db_path(), cursor)
+
+    def watch_paths(self, session, transcript) -> list[Path]:
+        db = db_path()
+        if db is None:
+            return []
+        return [db, db.with_name(db.name + "-wal")]
+
+    def fast_forward_cursor(self, session, cursor) -> None:
+        db = db_path()
+        sid = session.native_id("opencode")
+        if db is None or not sid:
+            return
+        with connect(db) as conn:
+            row = conn.execute(
+                "SELECT id, time_created FROM message WHERE session_id = ?"
+                " ORDER BY time_created DESC, id DESC LIMIT 1", (sid,)
+            ).fetchone()
+        if row is not None:
+            cursor.pending["source_pos"] = {"time": row["time_created"],
+                                            "id": row["id"]}
+
+    def pending_units(self, session, cursor) -> int:
+        """Approximation: message rows past the cursor (a live turn's rows
+        count until it closes) — good enough for status/doctor reporting."""
+        db = db_path()
+        sid = session.native_id("opencode")
+        if db is None or not sid:
+            return 0
+        pos = cursor.pending.get("source_pos") or {"time": 0, "id": ""}
+        with connect(db) as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM message WHERE session_id = ?"
+                " AND (time_created > ? OR (time_created = ? AND id > ?))",
+                (sid, pos["time"], pos["time"], pos["id"])).fetchone()
+        return int(row[0])
+
+    # -- flip gate ------------------------------------------------------------
+
+    def session_status(self, session_id: str) -> str | None:
+        """Busy iff the last message is a user prompt (turn starting) or an
+        assistant still streaming (no time.completed / tool-calls finish)."""
+        db = db_path()
+        if db is None or not session_id:
+            return None
+        try:
+            with connect(db) as conn:
+                row = conn.execute(
+                    "SELECT data FROM message WHERE session_id = ?"
+                    " ORDER BY time_created DESC, id DESC LIMIT 1",
+                    (session_id,)).fetchone()
+        except sqlite3.Error:
+            return None
+        if row is None:
+            return "waiting"
+        data = json.loads(row["data"])
+        if data.get("role") == "user":
+            return "busy"
+        return "waiting" if _is_closed(data) else "busy"
+
+    # -- parsing --------------------------------------------------------------
+
+    def parse_entry(self, raw: dict[str, Any], ctx: SessionContext) -> list[NormalizedEvent]:
+        """One completed-turn object -> normalized events. Never raises on
+        shape surprises; anything unrecognized degrades to a SystemEvent."""
+        def sysev(subtype: str, text: str = "") -> SystemEvent:
+            return SystemEvent(source="opencode", turn_index=ctx.turn_index,
+                               subtype=subtype, text=text)
+
+        if "user" not in raw or "assistants" not in raw:
+            return [sysev(f"opencode:{raw.get('type', '?')}")]
+
+        user_model = (raw["user"].get("message") or {}).get("model") or {}
+        if user_model.get("providerID") == SENTINEL_PROVIDER:
+            return [sysev("tandem_echo")]
+
+        events: list[NormalizedEvent] = []
+        ctx.turn_index += 1
+        text = "\n".join(p.get("text", "") for p in raw["user"].get("parts", [])
+                         if p.get("type") == "text")
+        events.append(UserMessage(source="user", turn_index=ctx.turn_index,
+                                  text=text))
+        for a in raw["assistants"]:
+            model = (a.get("message") or {}).get("modelID")
+            for p in a.get("parts", []):
+                ptype = p.get("type")
+                if ptype == "text":
+                    events.append(AssistantMessage(
+                        source="opencode", turn_index=ctx.turn_index,
+                        text=p.get("text", ""), model=model))
+                elif ptype == "reasoning":
+                    events.append(Thinking(source="opencode",
+                                           turn_index=ctx.turn_index))
+                elif ptype == "tool":
+                    state = p.get("state") or {}
+                    call_id = p.get("callID", "")
+                    args = state.get("input")
+                    events.append(ToolCall(
+                        source="opencode", turn_index=ctx.turn_index,
+                        call_id=call_id, tool=p.get("tool", ""),
+                        arguments=args if isinstance(args, (dict, str)) else {}))
+                    output = state.get("output", "")
+                    if state.get("status") == "error":
+                        output = str(state.get("error", output))
+                    events.append(ToolResult(
+                        source="opencode", turn_index=ctx.turn_index,
+                        call_id=call_id,
+                        output=output if isinstance(output, str) else str(output),
+                        is_error=state.get("status") == "error"))
+                else:
+                    # step-start, step-finish, snapshot, patch, file, unknown
+                    events.append(sysev(f"part:{ptype}"))
+        return events
+
     # -- temporary stubs (replaced by Tasks 11-13) ---------------------------
 
     def transcript_path(self, cwd: str, session_id: str) -> Path | None:
@@ -154,9 +349,6 @@ class OpencodeAdapter(HarnessAdapter):
         raise NotImplementedError
 
     def hook_argv_extra(self, sentinel: Path) -> list[str]:
-        raise NotImplementedError
-
-    def parse_entry(self, raw: dict[str, Any], ctx: SessionContext) -> list[NormalizedEvent]:
         raise NotImplementedError
 
     def render_events(

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -215,6 +215,37 @@ class OpencodeAdapter(HarnessAdapter):
     def mint_session_id(self) -> str:
         return mint_id("ses", descending=True)
 
+    # -- doctor ---------------------------------------------------------------
+
+    def validate_transcript(self, path: Path, session_id: str | None) -> list[str]:
+        """Structural dry-resume for a DB-backed session. `path` is the DB."""
+        problems: list[str] = []
+        try:
+            with connect(path) as conn:
+                if session_id is not None:
+                    row = conn.execute("SELECT 1 FROM session WHERE id = ?",
+                                       (session_id,)).fetchone()
+                    if row is None:
+                        return [f"session {session_id} not in the opencode database"]
+                mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+                if str(mode).lower() != "wal":
+                    problems.append(f"journal_mode is {mode!r}, expected wal")
+                last = conn.execute(
+                    "SELECT data FROM message WHERE session_id = ?"
+                    " ORDER BY time_created DESC, id DESC LIMIT 1",
+                    (session_id,)).fetchone()
+        except sqlite3.Error as exc:
+            return [f"cannot read opencode database: {exc}"]
+        if last is None:
+            problems.append("no messages (session would render empty)")
+            return problems
+        data = json.loads(last["data"])
+        if data.get("role") != "assistant" or not _is_closed(data):
+            problems.append(
+                "last message is not a completed assistant — the opencode TUI"
+                " would show this session as perpetually working")
+        return problems
+
     # -- storage capabilities -------------------------------------------------
 
     def make_source_reader(self, session, cursor, transcript):

--- a/src/tandem/memory_sync.py
+++ b/src/tandem/memory_sync.py
@@ -34,6 +34,8 @@ _BLOCK_RE = re.compile(
     re.escape(BEGIN) + r"\n?(.*?)\n?" + re.escape(END), re.S
 )
 
+# opencode reads AGENTS.md natively, same as codex — it shares codex's side
+# of the merge, so this map deliberately stays two-file.
 FILES = {"claude": "CLAUDE.md", "codex": "AGENTS.md"}
 
 

--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -75,15 +75,8 @@ def fast_forward(store: StateStore, session: PairedSession, source: str,
                  target: str) -> None:
     """Mark everything currently in `source`'s store as already-synced for
     the (source -> target) direction."""
-    transcript = source_transcript(session, source)
     cursor = store.get_cursor(session.tandem_id, source, target)
-    if transcript is None:
-        cursor.byte_offset = 0
-        cursor.line_index = 0
-    else:
-        data = transcript.read_bytes()
-        cursor.byte_offset = len(data)
-        cursor.line_index = data.count(b"\n")
+    get_adapter(source).fast_forward_cursor(session, cursor)
     cursor.pending.pop("intent", None)
     store.save_cursor(cursor)
 
@@ -98,17 +91,8 @@ def fast_forward_all(store: StateStore, session: PairedSession, source: str) -> 
 
 def unsynced_lines(session: PairedSession, store: StateStore, source: str,
                    target: str) -> int:
-    transcript = source_transcript(session, source)
-    if transcript is None:
-        return 0
     cursor = store.get_cursor(session.tandem_id, source, target)
-    try:
-        data = transcript.read_bytes()
-    except OSError:
-        return 0
-    if len(data) <= cursor.byte_offset:
-        return 0
-    return data[cursor.byte_offset :].count(b"\n")
+    return get_adapter(source).pending_units(session, cursor)
 
 
 def switch_session(store: StateStore, session: PairedSession,

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -24,7 +24,7 @@ from .events import SessionContext
 from .harness import get_adapter
 from .ptyrun import FrameIO, PtyControl, _winsize, run_in_pty
 from .state import PairedSession, StateStore, SyncCursor
-from .tailer import JsonlTailer, TailedLine, TranscriptTruncated, TranscriptWatcher
+from .tailer import TailedLine, TranscriptTruncated, TranscriptWatcher
 from .util import json_line
 from .warm import WarmChild, _shadow_size, build_launch, spawn_hidden
 
@@ -402,30 +402,43 @@ class TailLoop:
         self.source = source
         self.target = target
         self.sink = sink
+        self.transcript = transcript
         self.cursor = store.get_cursor(session.tandem_id, source, target)
         self.ctx = ctx_from_cursor(session, self.cursor)
-        self.tailer = JsonlTailer(
-            transcript, start_offset=self.cursor.byte_offset,
-            start_line=self.cursor.line_index,
+        self.reader = get_adapter(source).make_source_reader(
+            session, self.cursor, transcript
         )
         self.errors: list[str] = []
 
     def drain(self) -> int:
-        """Process everything new; returns number of lines consumed."""
+        """Process everything new; returns number of units consumed."""
+        from .harness.base import ShadowBusy
+
         try:
-            lines = self.tailer.poll()
+            lines = self.reader.poll()
         except TranscriptTruncated as exc:
             self.errors.append(str(exc))
             return 0
+        consumed = 0
         for line in lines:
-            self.sink.handle(line, self.ctx, self.cursor)
-            self.cursor.byte_offset = line.end_offset
-            self.cursor.line_index = line.line_index + 1
+            try:
+                self.sink.handle(line, self.ctx, self.cursor)
+            except ShadowBusy:
+                # transactional append rolled back; rebuild context from the
+                # durable cursor and let the next wake-up retry the unit
+                self.cursor = self.store.get_cursor(
+                    self.session.tandem_id, self.source, self.target)
+                self.ctx = ctx_from_cursor(self.session, self.cursor)
+                self.reader = get_adapter(self.source).make_source_reader(
+                    self.session, self.cursor, self.transcript)
+                break
+            line.advance(self.cursor)
             ctx_to_cursor(self.ctx, self.cursor)
-        if lines:
+            consumed += 1
+        if consumed:
             self.store.save_cursor(self.cursor)
             self.store.touch_sync(self.session.tandem_id)
-        return len(lines)
+        return consumed
 
 
 # Rollouts tandem wrote itself: "tandem" heads a seeded shadow (codex
@@ -731,7 +744,8 @@ class InteractiveRunner:
                         s.close()
                     return
                 watcher = TranscriptWatcher()
-                watcher.watch(path)
+                for p in get_adapter(active).watch_paths(current, path):
+                    watcher.watch(p)
                 watcher.watch(sentinel)
                 watcher.start()
                 # `tandem sub --context full` drains these same cursor rows

--- a/src/tandem/sync.py
+++ b/src/tandem/sync.py
@@ -28,7 +28,7 @@ from .harness import get_adapter
 from .runner import ctx_to_cursor
 from .state import PairedSession, StateStore, SyncCursor
 from .tailer import TailedLine
-from .util import append_jsonl_fsync, write_file_atomic
+from .util import write_file_atomic
 
 
 class SyncSetupError(RuntimeError):
@@ -78,10 +78,7 @@ class SyncEngine:
         self._prepared = True
         intent = cursor.pending.get("intent")
         if intent:
-            try:
-                grew = self.shadow_path.stat().st_size > int(intent["pre_size"])
-            except OSError:
-                grew = False
+            grew = self.target.intent_landed(self.shadow_path, intent)
             if int(intent["line"]) == _FLUSH_LINE:
                 if grew:
                     # the flush landed before the crash; its calls are closed
@@ -93,17 +90,7 @@ class SyncEngine:
                 # The append for this line landed before the crash; skip the
                 # re-append but still re-run translation for ctx effects.
                 self._skip_append_line = int(intent["line"])
-        if self.target_id == "claude":
-            # The claude file may have grown since we last wrote (its own CLI
-            # appends while claude is active); chain onto the real leaf and
-            # pick up the model claude last used for rendered entries.
-            adapter = get_adapter("claude")
-            leaf = adapter.derive_leaf_uuid(self.shadow_path)
-            if leaf:
-                ctx.state_for("claude")["leaf_uuid"] = leaf
-            model = adapter.derive_last_model(self.shadow_path)
-            if model:
-                ctx.state_for("claude")["model"] = model
+        self.target.prepare_shadow(self.shadow_path, ctx)
 
     # -- sink interface ------------------------------------------------------
 
@@ -146,10 +133,10 @@ class SyncEngine:
             ctx_to_cursor(ctx, cursor)
             self.store.save_cursor(cursor)
             return 0
-        pre_size = self.shadow_path.stat().st_size
-        cursor.pending["intent"] = {"line": _FLUSH_LINE, "pre_size": pre_size}
+        intent = self.target.shadow_intent(self.shadow_path, entries)
+        cursor.pending["intent"] = {"line": _FLUSH_LINE, **intent}
         self.store.save_cursor(cursor)
-        append_jsonl_fsync(self.shadow_path, entries)
+        self.target.shadow_append(self.shadow_path, entries)
         cursor.pending.pop("intent", None)
         ctx_to_cursor(ctx, cursor)
         self.store.save_cursor(cursor)
@@ -163,21 +150,17 @@ class SyncEngine:
         skip_append = self._skip_append_line == line.line_index
         if skip_append:
             self._skip_append_line = None
-            if self.target_id == "claude":
-                # the crashed run appended entries with uuids we no longer
-                # know; re-derive the chain tip from the file
-                leaf = get_adapter("claude").derive_leaf_uuid(self.shadow_path)
-                if leaf:
-                    ctx.state_for("claude")["leaf_uuid"] = leaf
+            # the crashed run appended entries with renderer state we no
+            # longer know; re-anchor to what is actually in the shadow
+            self.target.prepare_shadow(self.shadow_path, ctx)
         else:
-            pre_size = self.shadow_path.stat().st_size
-            cursor.pending["intent"] = {"line": line.line_index, "pre_size": pre_size}
+            intent = self.target.shadow_intent(self.shadow_path, entries)
+            cursor.pending["intent"] = {"line": line.line_index, **intent}
             self.store.save_cursor(cursor)
-            append_jsonl_fsync(self.shadow_path, entries)
+            self.target.shadow_append(self.shadow_path, entries)
 
         cursor.pending.pop("intent", None)
-        cursor.byte_offset = line.end_offset
-        cursor.line_index = line.line_index + 1
+        line.advance(cursor)
         ctx_to_cursor(ctx, cursor)
         self.store.save_cursor(cursor)
 
@@ -191,8 +174,7 @@ class SyncEngine:
         # At most one placeholder per source turn; further failures in the
         # same turn only quarantine.
         if cursor.pending.get("last_placeholder_turn") == ctx.turn_index:
-            cursor.byte_offset = line.end_offset
-            cursor.line_index = line.line_index + 1
+            line.advance(cursor)
             ctx_to_cursor(ctx, cursor)
             self.store.save_cursor(cursor)
             return

--- a/src/tandem/tailer.py
+++ b/src/tandem/tailer.py
@@ -22,10 +22,19 @@ from watchdog.observers.polling import PollingObserver
 
 @dataclass
 class TailedLine:
-    line_index: int      # 0-based index in the file
-    end_offset: int      # byte offset just past this line's newline
-    raw: dict | None     # parsed JSON, None if the line was not valid JSON
+    line_index: int      # 0-based index in the file (or turn ordinal)
+    end_offset: int      # byte offset just past this line's newline (0 for DB units)
+    raw: dict | None     # parsed JSON / native unit, None if not valid JSON
     text: str
+    pos: dict | None = None   # storage-adapter cursor coords (opencode turns)
+
+    def advance(self, cursor) -> None:
+        """The one place a consumed unit moves the durable cursor. File units
+        move byte/line; DB units additionally record their native position."""
+        cursor.byte_offset = self.end_offset
+        cursor.line_index = self.line_index + 1
+        if self.pos is not None:
+            cursor.pending["source_pos"] = self.pos
 
 
 class JsonlTailer:

--- a/src/tandem/toolmap.py
+++ b/src/tandem/toolmap.py
@@ -41,13 +41,16 @@ def parse_exec_output(raw: str) -> tuple[str | None, str]:
     return exit_code, raw[m.end():] if m else raw
 
 
+_MAPPERS: dict[str, dict] = {}   # filled after the mapper tables below
+
+
 def map_pair(
     call: ToolCall, result: ToolResult, target: str
 ) -> tuple[ToolCall, ToolResult]:
-    """One completed source-native pair -> one target-native pair."""
+    """One completed source-native pair -> one target-native pair. Targets
+    without a Tier-1 table (opencode, any future harness) pass through."""
     try:
-        mapper = _TO_CODEX if target == "codex" else _TO_CLAUDE
-        fn = mapper.get(call.tool)
+        fn = _MAPPERS.get(target, {}).get(call.tool)
         if fn is not None:
             mapped = fn(call, result)
             if mapped is not None:
@@ -305,3 +308,5 @@ _TO_CLAUDE = {
     "apply_patch": _patch_to_edit,
     "update_plan": _plan_to_todos,
 }
+
+_MAPPERS.update({"codex": _TO_CODEX, "claude": _TO_CLAUDE})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,10 +147,14 @@ class Env:
         )
 
 
-class FakeOpencodeAdapter:
+from tandem.harness.base import HarnessAdapter
+
+
+class FakeOpencodeAdapter(HarnessAdapter):
     """Minimal file-backed stand-in registered as 'opencode' for core tests.
     Replaced by the real adapter's tests in Phase 2; core tests keep using
-    the fake so they stay hermetic."""
+    the fake so they stay hermetic. Subclasses HarnessAdapter so it inherits
+    the file-backed storage-capability defaults."""
     id = "opencode"
     display_name = "opencode"
     binary = "opencode"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,12 +83,16 @@ class Env:
         from tandem.compat import COMPAT
         from tandem.harness.claude_code import ClaudeCodeAdapter
         from tandem.harness.codex import CodexAdapter
+        from tandem.harness.opencode import OpencodeAdapter
 
         monkeypatch.setattr(
             ClaudeCodeAdapter, "detect_version", lambda self: COMPAT["claude"].tested
         )
         monkeypatch.setattr(
             CodexAdapter, "detect_version", lambda self: COMPAT["codex"].tested
+        )
+        monkeypatch.setattr(
+            OpencodeAdapter, "detect_version", lambda self: COMPAT["opencode"].tested
         )
         self.cwd = str(tmp_path / "proj")
         Path(self.cwd).mkdir()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,25 @@ class Env:
         monkeypatch.setattr(
             OpencodeAdapter, "detect_version", lambda self: COMPAT["opencode"].tested
         )
+        # hermetic opencode storage: with detect_version pinned, doctor's
+        # runtime_ready probe would otherwise shell out to the real
+        # `opencode db path` (and read the user's real DB where one exists)
+        import sqlite3
+
+        from tandem.harness import opencode as _oc
+
+        oc_db = tmp_path / ".opencode" / "opencode.db"
+        oc_db.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(oc_db)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.executescript(
+            "CREATE TABLE IF NOT EXISTS session (id TEXT PRIMARY KEY);"
+            "CREATE TABLE IF NOT EXISTS message (id TEXT PRIMARY KEY);"
+            "CREATE TABLE IF NOT EXISTS part (id TEXT PRIMARY KEY);"
+        )
+        conn.close()
+        monkeypatch.setenv("OPENCODE_DB", str(oc_db))
+        _oc._reset_db_cache()
         self.cwd = str(tmp_path / "proj")
         Path(self.cwd).mkdir()
         self.store = StateStore(db_path=tmp_path / ".tandem" / "state.db")

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -431,3 +431,99 @@ def test_validate_transcript_missing_session(mini_db):
     problems = opencode.OpencodeAdapter().validate_transcript(
         mini_db, "ses_nope")
     assert any("not in the opencode database" in p for p in problems)
+
+
+def test_prepare_shadow_reanchors_after_crash_skip(mini_db):
+    """Crash-skip replay re-renders the unit, minting fresh ids that were
+    never inserted; prepare_shadow must re-anchor the renderer state to the
+    rows actually in the DB or the next unit dangles off a phantom parent."""
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    ctx = _render_ctx(sid)
+    adapter.shadow_append(mini_db, adapter.render_events(_events_turn(), ctx))
+    landed_user = ctx.state_for("opencode")["turn_user_id"]
+    landed_asst = ctx.state_for("opencode")["assistant_id"]
+
+    # replay after the crash: a fresh ctx re-renders the same unit (skip path
+    # discards the entries), leaving phantom ids in the renderer state
+    ctx2 = _render_ctx(sid)
+    adapter.render_events(_events_turn(), ctx2)
+    assert ctx2.state_for("opencode")["turn_user_id"] != landed_user
+
+    adapter.prepare_shadow(mini_db, ctx2)
+    st = ctx2.state_for("opencode")
+    assert st["turn_user_id"] == landed_user
+    assert st["assistant_id"] == landed_asst
+
+
+def test_model_attribution_survives_split_units(mini_db):
+    """A tool pair opens (and commits) the turn's assistant before the text
+    unit carries the real model; the later unit must still upgrade the
+    stored row's sentinel modelID."""
+    from tandem.events import AssistantMessage, ToolCall, ToolResult, UserMessage
+
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    ctx = _render_ctx(sid)
+    adapter.shadow_append(mini_db, adapter.render_events([
+        UserMessage(source="user", turn_index=1, text="hi"),
+        ToolCall(source="claude", turn_index=1, call_id="c1", tool="Bash",
+                 arguments={"command": "ls"}),
+        ToolResult(source="claude", turn_index=1, call_id="c1", output="ok"),
+    ], ctx))
+    adapter.shadow_append(mini_db, adapter.render_events([
+        AssistantMessage(source="claude", turn_index=1, text="done",
+                         model="claude-fable-5"),
+    ], ctx))
+    with sqlite3.connect(mini_db) as conn:
+        rows = [json.loads(r[0]) for r in conn.execute(
+            "SELECT data FROM message WHERE session_id = ?", (sid,))]
+    asst = [d for d in rows if d.get("role") == "assistant"]
+    assert len(asst) == 1
+    assert asst[0]["modelID"] == "claude-fable-5"
+
+
+def test_runtime_ready_rejects_non_wal(tmp_path, monkeypatch):
+    db = tmp_path / "rollback.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(MINI_SCHEMA)   # journal_mode stays delete
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("OPENCODE_DB", str(db))
+    opencode._reset_db_cache()
+    ok, reason = opencode.OpencodeAdapter().runtime_ready()
+    assert not ok and "journal_mode" in reason
+
+
+def test_runtime_ready_rejects_unwritable(mini_db):
+    """A readonly main file alone is still writable in WAL mode (sqlite
+    creates writable -wal/-shm sidecars); the unusable state is the whole
+    directory being unwritable."""
+    import os
+    os.chmod(mini_db, 0o444)
+    os.chmod(mini_db.parent, 0o555)
+    try:
+        ok, reason = opencode.OpencodeAdapter().runtime_ready()
+    finally:
+        os.chmod(mini_db.parent, 0o755)
+        os.chmod(mini_db, 0o644)
+    assert not ok
+
+
+def test_shadow_append_readonly_raises_not_busy(mini_db):
+    """A permanently unwritable DB must surface, not loop as ShadowBusy."""
+    import os
+
+    from tandem.harness.base import ShadowBusy
+
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    entries = adapter.render_events(_events_turn(), _render_ctx(sid))
+    os.chmod(mini_db, 0o444)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            adapter.shadow_append(mini_db, entries)
+    except ShadowBusy:
+        pytest.fail("readonly error was mislabelled ShadowBusy")
+    finally:
+        os.chmod(mini_db, 0o644)

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -228,3 +228,104 @@ def test_session_status_probe(mini_db):
             " '$.time.completed', 2500, '$.finish', 'stop')"
             " WHERE id = 'msg_ab0000000001x'")
     assert adapter.session_status(sid) == "waiting"
+
+
+def _render_ctx(sid="ses_00test0000000000000000000"):
+    from tandem.events import SessionContext
+    return SessionContext(tandem_id="t", cwd="/proj",
+                          direction="claude->opencode",
+                          target_session_id=sid)
+
+
+def _events_turn():
+    from tandem.events import AssistantMessage, ToolCall, ToolResult, UserMessage
+    return [
+        UserMessage(source="user", turn_index=1, text="[via claude-code] hi"),
+        ToolCall(source="claude", turn_index=1, call_id="c1", tool="Bash",
+                 arguments={"command": "ls"}),
+        ToolResult(source="claude", turn_index=1, call_id="c1", output="file.txt"),
+        AssistantMessage(source="claude", turn_index=1,
+                         text="[via claude-code] done", model="claude-fable-5"),
+    ]
+
+
+def test_render_and_append_turn(mini_db):
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    ctx = _render_ctx(sid)
+    entries = adapter.render_events(_events_turn(), ctx)
+    adapter.shadow_append(mini_db, entries)
+    with sqlite3.connect(mini_db) as conn:
+        conn.row_factory = sqlite3.Row
+        msgs = conn.execute(
+            "SELECT id, data FROM message WHERE session_id = ?"
+            " ORDER BY time_created, id", (sid,)).fetchall()
+    datas = [json.loads(m["data"]) for m in msgs]
+    assert [d["role"] for d in datas] == ["user", "assistant"]
+    assert datas[0]["agent"] and datas[0]["model"]          # schema-required
+    assert datas[1]["providerID"] == "tandem"               # sentinel
+    assert datas[1]["modelID"] == "claude-fable-5"
+    assert datas[1]["time"]["completed"] and datas[1]["finish"] == "stop"
+    with sqlite3.connect(mini_db) as conn:
+        parts = conn.execute(
+            "SELECT data FROM part WHERE message_id = ? ORDER BY id",
+            (msgs[1]["id"],)).fetchall()
+    pdatas = [json.loads(p[0]) for p in parts]
+    assert [p["type"] for p in pdatas] == ["tool", "text"]
+    assert pdatas[0]["state"]["status"] == "completed"
+    assert pdatas[0]["callID"] == "c1"
+
+
+def test_append_is_idempotent_by_ids(mini_db):
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    entries = adapter.render_events(_events_turn(), _render_ctx(sid))
+    adapter.shadow_append(mini_db, entries)
+    adapter.shadow_append(mini_db, entries)      # crash replay
+    with sqlite3.connect(mini_db) as conn:
+        n = conn.execute("SELECT COUNT(*) FROM message WHERE session_id = ?",
+                         (sid,)).fetchone()[0]
+    assert n == 2                                # not 4
+
+
+def test_intent_landed_checks_ids(mini_db):
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    entries = adapter.render_events(_events_turn(), _render_ctx(sid))
+    intent = adapter.shadow_intent(mini_db, entries)
+    assert not adapter.intent_landed(mini_db, intent)
+    adapter.shadow_append(mini_db, entries)
+    assert adapter.intent_landed(mini_db, intent)
+
+
+def test_written_turn_reads_back_as_echo(mini_db):
+    """The sentinel closes the loop: what tandem writes, the reader skips."""
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    adapter.shadow_append(
+        mini_db, adapter.render_events(_events_turn(), _render_ctx(sid)))
+    reader = opencode.OpencodeTurnReader(sid, mini_db, _cursor())
+    lines = reader.poll()
+    assert len(lines) == 1
+    from tandem.events import SessionContext
+    ctx = SessionContext(tandem_id="t", cwd="/proj",
+                         direction="opencode->claude")
+    events = adapter.parse_entry(lines[0].raw, ctx)
+    assert [e.kind for e in events] == ["system"]
+    assert events[0].subtype == "tandem_echo"
+
+
+def test_placeholder_renders_closed(mini_db):
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    entries = adapter.render_placeholder("[tandem: turn 3 could not be"
+                                         " translated]", _render_ctx(sid))
+    adapter.shadow_append(mini_db, entries)
+    assert adapter.session_status(sid) == "waiting"   # never stuck "working"
+
+
+def test_transcript_path_requires_session_row(mini_db):
+    adapter = opencode.OpencodeAdapter()
+    assert adapter.transcript_path("/proj", "ses_missing") is None
+    sid = _insert_session(mini_db)
+    assert adapter.transcript_path("/proj", sid) == mini_db

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -40,6 +40,7 @@ CREATE TABLE part (
 def mini_db(tmp_path, monkeypatch):
     db = tmp_path / "opencode.db"
     conn = sqlite3.connect(db)
+    conn.execute("PRAGMA journal_mode=WAL")
     conn.executescript(MINI_SCHEMA)
     conn.commit()
     conn.close()
@@ -410,3 +411,23 @@ def test_launch_surface():
         ["opencode", "run", "-s", "ses_x", "hi"]
     assert adapter.hook_argv_extra(Path("/tmp/s")) == []
     assert adapter.quit_keystrokes() == [b"\x03", b"\x03"]
+
+
+def test_validate_transcript_healthy(mini_db):
+    sid = _insert_session(mini_db)
+    _seed_turn(mini_db, sid, complete=True)
+    adapter = opencode.OpencodeAdapter()
+    assert adapter.validate_transcript(mini_db, sid) == []
+
+
+def test_validate_transcript_flags_open_turn(mini_db):
+    sid = _insert_session(mini_db)
+    _seed_turn(mini_db, sid, complete=False)
+    problems = opencode.OpencodeAdapter().validate_transcript(mini_db, sid)
+    assert any("completed" in p for p in problems)
+
+
+def test_validate_transcript_missing_session(mini_db):
+    problems = opencode.OpencodeAdapter().validate_transcript(
+        mini_db, "ses_nope")
+    assert any("not in the opencode database" in p for p in problems)

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -1,5 +1,6 @@
 """Opencode adapter units against a hermetic mini-DB (no binary needed)."""
 
+import json
 import sqlite3
 
 import pytest
@@ -94,3 +95,136 @@ def test_runtime_ready_fails_closed_without_tables(tmp_path, monkeypatch):
 def test_registered_in_adapters():
     from tandem.harness import get_adapter
     assert get_adapter("opencode").id == "opencode"
+
+
+def _insert_session(db, sid="ses_00test0000000000000000000", cwd="/proj"):
+    with sqlite3.connect(db) as conn:
+        conn.execute("INSERT INTO project VALUES ('p1', ?)", (cwd,))
+        conn.execute(
+            "INSERT INTO session (id, project_id, slug, directory, path, title,"
+            " version, time_created, time_updated) VALUES (?, 'p1', 's', ?, '',"
+            " 't', '1.18.15', 1, 1)", (sid, cwd))
+    return sid
+
+
+def _insert_message(db, sid, msg_id, data, t):
+    with sqlite3.connect(db) as conn:
+        conn.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)",
+                     (msg_id, sid, t, t, json.dumps(data)))
+
+
+def _insert_part(db, sid, msg_id, part_id, data, t=1):
+    with sqlite3.connect(db) as conn:
+        conn.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)",
+                     (part_id, msg_id, sid, t, t, json.dumps(data)))
+
+
+def _seed_turn(db, sid, complete=True, provider="openai"):
+    """user('is the readme updated?') + assistant(reasoning, text, tool,
+    step parts) — shapes lifted from the operator's real 1.18.15 session."""
+    _insert_message(db, sid, "msg_aa0000000001x", {
+        "role": "user", "time": {"created": 1000}, "agent": "build",
+        "model": {"providerID": provider, "modelID": "gpt-5.6-sol"}}, 1000)
+    _insert_part(db, sid, "msg_aa0000000001x", "prt_aa0000000001x",
+                 {"type": "text", "text": "is the readme updated?"})
+    adata = {
+        "parentID": "msg_aa0000000001x", "role": "assistant", "mode": "build",
+        "agent": "build", "path": {"cwd": "/proj", "root": "/proj"}, "cost": 0,
+        "tokens": {"total": 1, "input": 1, "output": 1, "reasoning": 0,
+                   "cache": {"write": 0, "read": 0}},
+        "modelID": "gpt-5.6-sol", "providerID": provider,
+        "time": {"created": 2000},
+    }
+    if complete:
+        adata["time"]["completed"] = 2500
+        adata["finish"] = "stop"
+    _insert_message(db, sid, "msg_ab0000000001x", adata, 2000)
+    for pid, pdata in [
+        ("prt_ab0000000001x", {"type": "step-start", "snapshot": "abc"}),
+        ("prt_ab0000000002x", {"type": "reasoning",
+                               "text": "**Inspecting git state**"}),
+        ("prt_ab0000000003x", {"type": "tool", "tool": "bash",
+                               "callID": "call_1",
+                               "state": {"status": "completed",
+                                         "input": {"command": "git status"},
+                                         "output": "(no output)",
+                                         "metadata": {}, "title": "git status",
+                                         "time": {"start": 1, "end": 2}}}),
+        ("prt_ab0000000004x", {"type": "text", "text": "Yes, it is current."}),
+        ("prt_ab0000000005x", {"type": "step-finish", "reason": "stop",
+                               "tokens": {}, "cost": 0}),
+    ]:
+        _insert_part(db, sid, "msg_ab0000000001x", pid, pdata)
+
+
+def _cursor():
+    from tandem.state import SyncCursor
+    return SyncCursor(tandem_id="t", source="opencode", target="claude")
+
+
+def test_reader_yields_completed_turn(mini_db):
+    sid = _insert_session(mini_db)
+    _seed_turn(mini_db, sid, complete=True)
+    cur = _cursor()
+    reader = opencode.OpencodeTurnReader(sid, mini_db, cur)
+    lines = reader.poll()
+    assert len(lines) == 1
+    turn = lines[0].raw
+    assert turn["user"]["parts"][0]["text"] == "is the readme updated?"
+    assert len(turn["assistants"]) == 1
+    assert lines[0].pos == {"time": 2000, "id": "msg_ab0000000001x"}
+    # committing the pos means a second poll yields nothing
+    lines[0].advance(cur)
+    assert opencode.OpencodeTurnReader(sid, mini_db, cur).poll() == []
+
+
+def test_reader_holds_incomplete_turn(mini_db):
+    sid = _insert_session(mini_db)
+    _seed_turn(mini_db, sid, complete=False)
+    reader = opencode.OpencodeTurnReader(sid, mini_db, _cursor())
+    assert reader.poll() == []
+
+
+def test_parse_entry_maps_part_types(mini_db):
+    sid = _insert_session(mini_db)
+    _seed_turn(mini_db, sid, complete=True)
+    reader = opencode.OpencodeTurnReader(sid, mini_db, _cursor())
+    turn = reader.poll()[0].raw
+    from tandem.events import SessionContext
+    ctx = SessionContext(tandem_id="t", cwd="/proj",
+                         direction="opencode->claude")
+    events = opencode.OpencodeAdapter().parse_entry(turn, ctx)
+    kinds = [e.kind for e in events]
+    assert kinds == ["user_message", "system", "thinking", "tool_call",
+                     "tool_result", "assistant_message", "system"]
+    call = events[3]
+    result = events[4]
+    assert call.tool == "bash" and call.call_id == "call_1"
+    assert result.output == "(no output)" and result.call_id == "call_1"
+    assert events[0].turn_index == 1        # user message bumps the turn
+
+
+def test_parse_entry_skips_tandem_echo(mini_db):
+    sid = _insert_session(mini_db)
+    _seed_turn(mini_db, sid, complete=True, provider="tandem")
+    reader = opencode.OpencodeTurnReader(sid, mini_db, _cursor())
+    turn = reader.poll()[0].raw
+    from tandem.events import SessionContext
+    ctx = SessionContext(tandem_id="t", cwd="/proj",
+                         direction="opencode->claude")
+    events = opencode.OpencodeAdapter().parse_entry(turn, ctx)
+    assert [e.kind for e in events] == ["system"]
+    assert events[0].subtype == "tandem_echo"
+
+
+def test_session_status_probe(mini_db):
+    sid = _insert_session(mini_db)
+    adapter = opencode.OpencodeAdapter()
+    _seed_turn(mini_db, sid, complete=False)
+    assert adapter.session_status(sid) == "busy"
+    with sqlite3.connect(mini_db) as conn:
+        conn.execute(
+            "UPDATE message SET data = json_set(data,"
+            " '$.time.completed', 2500, '$.finish', 'stop')"
+            " WHERE id = 'msg_ab0000000001x'")
+    assert adapter.session_status(sid) == "waiting"

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -329,3 +330,83 @@ def test_transcript_path_requires_session_row(mini_db):
     assert adapter.transcript_path("/proj", "ses_missing") is None
     sid = _insert_session(mini_db)
     assert adapter.transcript_path("/proj", sid) == mini_db
+
+
+def test_create_shadow_via_import(mini_db, tmp_path, monkeypatch):
+    """The import subprocess is simulated: assert the payload shape, then
+    perform the inserts import would do."""
+    adapter = opencode.OpencodeAdapter()
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        assert argv[:3] == ["opencode", "import", argv[2]]
+        payload = json.loads(Path(argv[2]).read_text())
+        captured["payload"] = payload
+        info = payload["info"]
+        with sqlite3.connect(mini_db) as conn:
+            conn.execute("INSERT OR IGNORE INTO project VALUES ('p1', ?)",
+                         (kwargs.get("cwd"),))
+            conn.execute(
+                "INSERT INTO session (id, project_id, slug, directory, path,"
+                " title, version, time_created, time_updated)"
+                " VALUES (?, 'p1', 'slug', ?, '', ?, ?, ?, ?)",
+                (info["id"], kwargs.get("cwd"), info["title"],
+                 info["version"], info["time"]["created"],
+                 info["time"]["updated"]))
+            for m in payload["messages"]:
+                mi = m["info"]
+                conn.execute(
+                    "INSERT INTO message VALUES (?, ?, ?, ?, ?)",
+                    (mi["id"], info["id"], mi["time"]["created"],
+                     mi["time"]["created"],
+                     json.dumps({k: v for k, v in mi.items()
+                                 if k not in ("id", "sessionID")})))
+                for p in m["parts"]:
+                    conn.execute(
+                        "INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)",
+                        (p["id"], mi["id"], info["id"], 1, 1,
+                         json.dumps({k: v for k, v in p.items()
+                                     if k not in ("id", "sessionID",
+                                                  "messageID")})))
+        import subprocess
+        return subprocess.CompletedProcess(argv, 0, stdout="Imported", stderr="")
+
+    monkeypatch.setattr(opencode, "_run", fake_run)
+    sid = adapter.mint_session_id()
+    ctx = _render_ctx(sid)
+    path = adapter.create_shadow_transcript(str(tmp_path), sid, ctx,
+                                            "[tandem] seed note")
+    assert path == mini_db
+    payload = captured["payload"]
+    info = payload["info"]
+    assert info["id"] == sid
+    assert "agent" not in info and "model" not in info     # session-level omitted
+    user, assistant = (m["info"] for m in payload["messages"])
+    assert user["agent"] == "build"                        # message-level REQUIRED
+    assert user["model"] == {"providerID": "tandem", "modelID": "<synced>"}
+    assert assistant["providerID"] == "tandem"
+    assert assistant["time"]["completed"] and assistant["finish"] == "stop"
+    assert ctx.state_for("opencode")["turn_user_id"] == user["id"]
+    assert adapter.session_status(sid) == "waiting"        # lists as idle
+
+
+def test_create_shadow_raises_on_import_failure(mini_db, tmp_path, monkeypatch):
+    import subprocess
+    monkeypatch.setattr(
+        opencode, "_run",
+        lambda argv, **k: subprocess.CompletedProcess(argv, 1, stdout="",
+                                                      stderr="boom"))
+    adapter = opencode.OpencodeAdapter()
+    with pytest.raises(RuntimeError, match="boom"):
+        adapter.create_shadow_transcript(str(tmp_path), adapter.mint_session_id(),
+                                         _render_ctx(), "[tandem] seed")
+
+
+def test_launch_surface():
+    adapter = opencode.OpencodeAdapter()
+    assert adapter.interactive_argv("ses_x", fresh=False) == \
+        ["opencode", "-s", "ses_x"]
+    assert adapter.oneoff_argv("ses_x", "hi") == \
+        ["opencode", "run", "-s", "ses_x", "hi"]
+    assert adapter.hook_argv_extra(Path("/tmp/s")) == []
+    assert adapter.quit_keystrokes() == [b"\x03", b"\x03"]

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -1,0 +1,96 @@
+"""Opencode adapter units against a hermetic mini-DB (no binary needed)."""
+
+import sqlite3
+
+import pytest
+
+from tandem.harness import opencode
+
+MINI_SCHEMA = """
+CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL);
+CREATE TABLE session (
+    id TEXT PRIMARY KEY, project_id TEXT NOT NULL, slug TEXT NOT NULL,
+    directory TEXT NOT NULL, path TEXT, title TEXT NOT NULL,
+    version TEXT NOT NULL, cost REAL NOT NULL DEFAULT 0,
+    tokens_input INTEGER NOT NULL DEFAULT 0,
+    tokens_output INTEGER NOT NULL DEFAULT 0,
+    tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+    tokens_cache_read INTEGER NOT NULL DEFAULT 0,
+    tokens_cache_write INTEGER NOT NULL DEFAULT 0,
+    parent_id TEXT, agent TEXT, model TEXT,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+    time_archived INTEGER
+);
+CREATE TABLE message (
+    id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+    data TEXT NOT NULL
+);
+CREATE TABLE part (
+    id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+    data TEXT NOT NULL
+);
+"""
+
+
+@pytest.fixture
+def mini_db(tmp_path, monkeypatch):
+    db = tmp_path / "opencode.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(MINI_SCHEMA)
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("OPENCODE_DB", str(db))
+    opencode._reset_db_cache()
+    return db
+
+
+def test_mint_id_format_and_order(monkeypatch):
+    ms = [1786577389138]
+    monkeypatch.setattr(opencode, "_now_ms", lambda: ms[0])
+    a = opencode.mint_id("msg")
+    b = opencode.mint_id("msg")
+    assert a[:16] == "msg_ff84f8652001"          # verified against a live id
+    assert a < b                                  # ascending within the ms
+    assert len(a) == 4 + 12 + 14
+
+
+def test_mint_id_descending_sessions(monkeypatch):
+    monkeypatch.setattr(opencode, "_now_ms", lambda: 1786577389117)
+    s = opencode.mint_id("ses", descending=True)
+    assert s[:16] == "ses_007b079c2ffe"          # ~(ms*4096+1), live-verified
+    monkeypatch.setattr(opencode, "_now_ms", lambda: 1786577389117 + 5000)
+    later = opencode.mint_id("ses", descending=True)
+    assert later < s                              # newer sorts smaller
+
+
+def test_db_path_env_override(mini_db):
+    assert opencode.db_path() == mini_db
+
+
+def test_db_path_none_when_undiscoverable(monkeypatch):
+    monkeypatch.delenv("OPENCODE_DB", raising=False)
+    opencode._reset_db_cache()
+    monkeypatch.setattr(opencode, "_run",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no binary")))
+    assert opencode.db_path() is None
+
+
+def test_runtime_ready_ok(mini_db):
+    ok, reason = opencode.OpencodeAdapter().runtime_ready()
+    assert ok, reason
+
+
+def test_runtime_ready_fails_closed_without_tables(tmp_path, monkeypatch):
+    db = tmp_path / "empty.db"
+    sqlite3.connect(db).close()
+    monkeypatch.setenv("OPENCODE_DB", str(db))
+    opencode._reset_db_cache()
+    ok, reason = opencode.OpencodeAdapter().runtime_ready()
+    assert not ok and "table" in reason
+
+
+def test_registered_in_adapters():
+    from tandem.harness import get_adapter
+    assert get_adapter("opencode").id == "opencode"

--- a/tests/test_opencode_oracle.py
+++ b/tests/test_opencode_oracle.py
@@ -1,0 +1,100 @@
+"""Round-trips through the REAL opencode binary (skip-if-missing).
+
+Isolated via OPENCODE_DB -> a temp database that opencode migrates into
+existence on first run; the operator's real DB is never touched.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from tandem import compat
+from tandem.harness import opencode
+
+_version = compat.detect_cli_version("opencode")
+pytestmark = pytest.mark.skipif(
+    shutil.which("opencode") is None
+    or _version is None
+    or not compat.version_supported("opencode", _version),
+    reason="no supported opencode binary on PATH",
+)
+
+
+@pytest.fixture
+def oracle_env(tmp_path, monkeypatch):
+    db = tmp_path / "oracle.db"
+    monkeypatch.setenv("OPENCODE_DB", str(db))
+    opencode._reset_db_cache()
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=cwd, check=True)
+    env = dict(os.environ, OPENCODE_DB=str(db))
+    return db, str(cwd), env
+
+
+def _export(sid, cwd, env):
+    out = subprocess.run(["opencode", "export", sid], cwd=cwd, env=env,
+                         capture_output=True, text=True, timeout=120)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+def test_import_birth_roundtrips_through_export(oracle_env):
+    db, cwd, env = oracle_env
+    adapter = opencode.OpencodeAdapter()
+    from tandem.events import SessionContext
+    sid = adapter.mint_session_id()
+    ctx = SessionContext(tandem_id="t", cwd=cwd,
+                         direction="claude->opencode",
+                         target_session_id=sid)
+    path = adapter.create_shadow_transcript(cwd, sid, ctx, "[tandem] oracle seed")
+    assert path == db
+    data = _export(sid, cwd, env)
+    assert data["info"]["id"] == sid
+    texts = [p.get("text", "") for m in data["messages"] for p in m["parts"]]
+    assert any("oracle seed" in t for t in texts)
+
+
+def test_synced_turn_survives_export(oracle_env):
+    db, cwd, env = oracle_env
+    adapter = opencode.OpencodeAdapter()
+    from tandem.events import (AssistantMessage, SessionContext, ToolCall,
+                               ToolResult, UserMessage)
+    sid = adapter.mint_session_id()
+    ctx = SessionContext(tandem_id="t", cwd=cwd,
+                         direction="claude->opencode",
+                         target_session_id=sid)
+    adapter.create_shadow_transcript(cwd, sid, ctx, "[tandem] oracle seed")
+    events = [
+        UserMessage(source="user", turn_index=1, text="[via claude-code] hello"),
+        ToolCall(source="claude", turn_index=1, call_id="c1", tool="Bash",
+                 arguments={"command": "true"}),
+        ToolResult(source="claude", turn_index=1, call_id="c1", output="ok"),
+        AssistantMessage(source="claude", turn_index=1,
+                         text="[via claude-code] done", model="claude-fable-5"),
+    ]
+    adapter.shadow_append(db, adapter.render_events(events, ctx))
+    data = _export(sid, cwd, env)
+    texts = [p.get("text", "") for m in data["messages"] for p in m["parts"]]
+    assert any("hello" in t for t in texts)
+    assert any("done" in t for t in texts)
+    roles = [m["info"]["role"] for m in data["messages"]]
+    assert roles[-1] == "assistant"
+
+
+def test_session_listed(oracle_env):
+    db, cwd, env = oracle_env
+    adapter = opencode.OpencodeAdapter()
+    from tandem.events import SessionContext
+    sid = adapter.mint_session_id()
+    ctx = SessionContext(tandem_id="t", cwd=cwd,
+                         direction="claude->opencode",
+                         target_session_id=sid)
+    adapter.create_shadow_transcript(cwd, sid, ctx, "[tandem] oracle seed")
+    out = subprocess.run(["opencode", "session", "list"], cwd=cwd, env=env,
+                         capture_output=True, text=True, timeout=120)
+    assert out.returncode == 0, out.stderr
+    assert sid in out.stdout

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -187,3 +187,25 @@ class TestSyncCodexToClaude:
         entries = read_jsonl(env.claude_shadow)
         synced_user = next(e for e in entries if e.get("type") == "user" and "codex" in str(e.get("message")))
         assert synced_user["parentUuid"] == "claude-own-leaf"
+
+
+def test_shadow_busy_retries_without_advancing(env_factory, monkeypatch):
+    env = env_factory()
+    from tandem.harness import get_adapter
+    from tandem.harness.base import ShadowBusy
+
+    write_line(env.claude_shadow, claude_user("busy test"))
+    calls = {"n": 0}
+    real_append = type(get_adapter("codex")).shadow_append
+
+    def flaky_append(self, ref, entries):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ShadowBusy("locked")
+        return real_append(self, ref, entries)
+
+    monkeypatch.setattr(type(get_adapter("codex")), "shadow_append", flaky_append)
+    loop, _ = env.loop(source="claude", transcript=env.claude_shadow)
+    assert loop.drain() == 0                       # busy: nothing consumed
+    assert loop.drain() >= 1                       # retried clean
+    assert any("busy test" in t for t in shadow_texts(env.codex_shadow))

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -152,3 +152,31 @@ class TestTailLoop:
                 f.write('age": {"role": "user", "content": "later"}}\n')
             assert loop.drain() == 1
             assert sink.events[-1].text == "later"
+
+
+def test_tailedline_advance_updates_cursor(tmp_path):
+    from tandem.state import SyncCursor
+    from tandem.tailer import TailedLine
+
+    cur = SyncCursor(tandem_id="t", source="claude", target="codex")
+    line = TailedLine(line_index=4, end_offset=100, raw={}, text="{}")
+    line.advance(cur)
+    assert (cur.byte_offset, cur.line_index) == (100, 5)
+    assert "source_pos" not in cur.pending
+
+    line2 = TailedLine(line_index=5, end_offset=0, raw={}, text="{}",
+                       pos={"time": 9, "id": "msg_x"})
+    line2.advance(cur)
+    assert cur.pending["source_pos"] == {"time": 9, "id": "msg_x"}
+
+
+def test_default_reader_matches_jsonl_tailer(tmp_path):
+    from tandem.harness import get_adapter
+    from tandem.state import SyncCursor
+
+    p = tmp_path / "t.jsonl"
+    p.write_text('{"a": 1}\n{"b": 2}\n')
+    cur = SyncCursor(tandem_id="t", source="claude", target="codex")
+    reader = get_adapter("claude").make_source_reader(None, cur, p)
+    lines = reader.poll()
+    assert [l.raw for l in lines] == [{"a": 1}, {"b": 2}]

--- a/tests/test_toolmap.py
+++ b/tests/test_toolmap.py
@@ -609,3 +609,14 @@ class TestDangleFlush:
         reread = env.store.get_cursor(env.session.tandem_id, "claude", "codex")
         assert reread.pending["pending_calls"] == {}
         assert "intent" not in reread.pending
+
+
+def test_map_pair_unknown_target_passthrough():
+    from tandem.events import ToolCall, ToolResult
+    from tandem.toolmap import map_pair
+    call = ToolCall(source="claude", call_id="c", tool="Bash",
+                    arguments={"command": "ls"})
+    result = ToolResult(source="claude", call_id="c", output="ok")
+    mc, mr = map_pair(call, result, "opencode")
+    assert mc.tool == "Bash" and mc.arguments == {"command": "ls"}
+    assert mr.output == "ok"


### PR DESCRIPTION
## Summary

PR 2 of the opencode workstream (spec: `docs/specs/2026-08-13-opencode-harness-design.md`, plan: `docs/plans/2026-08-13-pr2-opencode-adapter.md`, tasks 9–15). Builds on the N-harness core (#41) and ships `src/tandem/harness/opencode.py` — opencode as a full peer harness: SQLite-backed transcript sync both ways, session birth via `opencode import`, launch/resume/one-off, doctor checks, and oracle tests against the real binary.

- **Task 9 — storage-capability seams**: `HarnessAdapter` grows file-backed-default hooks (`make_source_reader`, `watch_paths`, `shadow_append`/`shadow_intent`/`intent_landed`, `fast_forward_cursor`, `pending_units`, `prepare_shadow`) plus `ShadowBusy`; `TailedLine.advance(cursor)` becomes the one place a consumed unit moves the durable cursor; claude leaf-repair moves out of `sync.py` into a `ClaudeCodeAdapter.prepare_shadow` override; busy-shadow appends retry next tick. claude/codex behavior byte-for-byte unchanged.
- **Task 10 — module skeleton**: opencode's id scheme ported (48-bit `ms*4096+counter`, NOT'd descending for `ses_`, live-verified encodings), DB discovery via `$OPENCODE_DB` else `opencode db path` (fail-closed), WAL-safe `connect` pragmas, fail-closed `runtime_ready`.
- **Task 11 — read path**: `OpencodeTurnReader` yields whole completed turns (tool parts mutate in place, so raw rows never cross the adapter boundary); `parse_entry` maps part types to normalized events; sentinel-attributed turns parse to `tandem_echo`; `session_status` probes the flip gate from the DB.
- **Task 12 — write path**: renderer emits row-op entries with pre-minted ids; one `BEGIN IMMEDIATE` transaction per synced unit with `INSERT OR IGNORE` (idempotent crash replay); every assistant row written closed (`time.completed` + `finish: "stop"`) so the TUI never shows a synced session as "working"; sentinel `providerID: "tandem"` / `modelID: "<synced>"` attribution.
- **Task 13 — shadow birth + launch**: `create_shadow_transcript` delegates to `opencode import` (tandem never hand-writes session rows); `opencode -s` / `opencode run -s` launch surface; `toolmap` gains a target-keyed `_MAPPERS` registry with passthrough default (opencode is Tier-2 in v1).
- **Task 14 — doctor**: full `validate_transcript` override (session row, WAL mode, completed-assistant invariant); `run_doctor` reports installed-but-unusable via `runtime_ready`.
- **Task 15 — oracle + docs**: `tests/test_opencode_oracle.py` round-trips through the real binary (skip-if-missing, isolated via `OPENCODE_DB`); `docs/formats.md` gains the opencode section; README mentions the third harness.

## Live findings recorded

- `opencode import` requires session-level `slug` (rejected `at ["slug"]` without it); non-unique, so tandem seeds `tandem-pair`. Recorded in `docs/formats.md`.
- Quit recipe `[^C,^C]` live-verified on opencode 1.18.15: the flip ladder exits the TUI with `how=soft`, exit code 0, ~0.26s arm-to-teardown (spec live-verify item 2).
- Flip-gate DB probe answers in <1ms while opencode is active (item 5); the WAL fs-watch picked up the completed turn within the normal poll window (item 4).

## Merge gate: real three-way flip session (PASS)

Driven end-to-end on this machine (tmux-scripted, real model turns, real stores — opencode 1.18.15, claude 2.1.232, codex 0.147.0). All 17 checks passed:

- claude turn → landed in the opencode DB and codex rollout
- Ctrl-] → codex; its turn → landed in the opencode DB and claude transcript
- Ctrl-] → opencode: the TUI **rendered both prior synced turns** (item 3: sentinel display, no "working" state), its own turn → landed in the claude transcript and codex rollout (live read path)
- Ctrl-] → back to claude; clean exit

## Test plan

- `python -m pytest tests/ -q` — full suite green (631 passed).
- `python -m pytest tests/test_opencode_oracle.py -q` — 3 oracle round-trips green against opencode 1.18.15.
- Live three-way flip session — GATE: PASS (17/17 checks, above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
