### PR TITLE
Remove the always-warm standby: revert to fire-at-flip pipelining

### DIFF
--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -87,7 +87,7 @@ def load_harness_args(harness: str) -> list[str]:
 class FrameConfig:
     flip_byte: int = 0x1D   # Ctrl-]
     bar: bool = True
-    warm: bool = True       # keep the other harness booted on a hidden PTY
+    warm: bool = True       # boot the other harness during the flip's teardown
 
 
 def _parse_flip_key(value: str) -> int | None:

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -588,8 +588,12 @@ class InteractiveRunner:
             status_probe=status_probe_fn if hasattr(adapter, "session_status") else None,
         )
         # Fired at most once, on the monitor thread, between the flip
-        # decision and the ladder. It starts a worker and returns immediately,
-        # so a slow fork/exec cannot hold up teardown of the outgoing harness.
+        # decision and the ladder. It does only the in-memory eligibility
+        # checks there and starts a worker for everything else — the shadow
+        # stat, the recipe build (config.toml reads, the sentinel mkdir) and
+        # the fork/exec are all unbounded filesystem work, and any of it on
+        # the monitor thread would hold up teardown of the outgoing harness:
+        # the ladder starts only when this returns.
         # The finally below closes the handoff slot after the ladder: a child
         # that has landed by then is adopted, while a worker that lands later
         # sees the closed slot and kills its child instead of stranding it.
@@ -608,17 +612,18 @@ class InteractiveRunner:
                 # before the final drain would cache the session pre-drain and
                 # never show the last turn. Opencode-bound flips run cold.
                 return
-            size = _shadow_size(session, shadow)
-            if size is None:
-                return   # no shadow file yet: switch_session's late-create
-                         # + a cold spawn own that flip; never fresh-mint
-            # not `recipe`: that name is taken by the *active* side's launch,
-            # which this closure must never rebuild or shadow
-            shadow_recipe = build_launch(session, shadow)
-            dims = _winsize(sys.stdin.fileno())
 
             def spawn() -> None:
                 try:
+                    size = _shadow_size(session, shadow)
+                    if size is None:
+                        return   # no shadow file yet: switch_session's
+                                 # late-create + a cold spawn own that flip;
+                                 # never fresh-mint
+                    # not `recipe`: that name is taken by the *active* side's
+                    # launch, which this closure must never rebuild or shadow
+                    shadow_recipe = build_launch(session, shadow)
+                    dims = _winsize(sys.stdin.fileno())
                     child = spawn_hidden(shadow_recipe, dims, size)
                 except Exception:
                     return   # a failed fire means a cold flip

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -273,8 +273,8 @@ class FlipMonitor:
     entirely — see `wait_until_safe`.
 
     `on_flip_decided` fires once, on this thread, in the gap between the
-    decision and the ladder — the runner makes a final freshness check on the
-    resident incoming harness there. It is
+    decision and the ladder — the runner starts the incoming harness's launch
+    worker there, so its boot overlaps the outgoing one's teardown. It is
     called with the flag already set (`flip_requested` is what makes the flip
     inevitable, and a callback must not be able to take it back) and its
     exceptions are swallowed: a failed hook costs a cold flip, never the flip
@@ -495,8 +495,8 @@ class InteractiveRunner:
         # set here too so the attributes exist even if run() raises early
         self._released = False
         self.flip_requested = False
-        # The resident standby this run surrenders to the flip loop's carry.
-        # A normal exit reaps it instead of publishing it here.
+        # The harness this run fired at its flip decision, surrendered to the
+        # flip loop's carry. Only a flip can fill it: no flip, no fire.
         self.warm_child: WarmChild | None = None
         # Formatted, ready-to-print report lines for the session that just
         # ran. `run()` prints them itself on a normal exit; on a flip it does
@@ -587,21 +587,19 @@ class InteractiveRunner:
             # mid-turn.
             status_probe=status_probe_fn if hasattr(adapter, "session_status") else None,
         )
-        # Keeps one shadow harness resident. It starts at runner entry and is
-        # refreshed after a tail drain changes the shadow transcript; the flip
-        # monitor calls it once more between the decision and the ladder as a
-        # final freshness check. Spawn and stale-child teardown stay off the
-        # caller, so neither the PTY pump nor transcript tailing blocks on them.
+        # Fired at most once, on the monitor thread, between the flip
+        # decision and the ladder. It starts a worker and returns immediately,
+        # so a slow fork/exec cannot hold up teardown of the outgoing harness.
         # The finally below closes the handoff slot after the ladder: a child
         # that has landed by then is adopted, while a worker that lands later
         # sees the closed slot and kills its child instead of stranding it.
-        # The non-tty path cannot adopt a standby, so a spawn there could only
-        # leak a hidden harness. The gate takes both the [frame] `warm` flag
-        # and a real stdin tty.
-        fired: dict = {"child": None, "closed": False, "spawning": False}
+        # The non-tty path cannot adopt a fired child, so a spawn there could
+        # only leak a hidden harness: the gate is read at fire time, and takes
+        # both the [frame] `warm` flag and a real stdin tty.
+        fired: dict = {"child": None, "closed": False}
         fired_lock = threading.Lock()
 
-        def ensure_warm() -> None:
+        def fire_warm() -> None:
             if not (frame_cfg.warm and _stdin_tty()):
                 return
             shadow = session.next_active(session.active)
@@ -616,72 +614,36 @@ class InteractiveRunner:
                          # + a cold spawn own that flip; never fresh-mint
             # not `recipe`: that name is taken by the *active* side's launch,
             # which this closure must never rebuild or shadow
-            with fired_lock:
-                current = fired["child"]
-                if (
-                    current is not None
-                    and current.alive()
-                    and current.shadow_size == size
-                ):
-                    return
-                if fired["closed"] or fired["spawning"]:
-                    return
-                fired["spawning"] = True
-
-            try:
-                shadow_recipe = build_launch(session, shadow)
-                dims = _winsize(sys.stdin.fileno())
-            except Exception:
-                with fired_lock:
-                    fired["spawning"] = False
-                return   # standby setup must never cost the active harness
+            shadow_recipe = build_launch(session, shadow)
+            dims = _winsize(sys.stdin.fileno())
 
             def spawn() -> None:
                 try:
                     child = spawn_hidden(shadow_recipe, dims, size)
                 except Exception:
-                    with fired_lock:
-                        fired["spawning"] = False
                     return   # a failed fire means a cold flip
                 _flip_debug(
                     f"warm-spawned side={shadow}"
                     f" child={getattr(getattr(child, 'child', None), 'pid', '?')}"
                     f" shadow_size={size}"
                 )
-                displaced = None
                 with fired_lock:
-                    fired["spawning"] = False
                     if not fired["closed"]:
-                        displaced = fired["child"]
                         fired["child"] = child
-                    else:
-                        displaced = child
-                if displaced is not None:
-                    threading.Thread(
-                        target=lambda: _kill_warm(displaced),
-                        name="tandem-warm-replace", daemon=True,
-                    ).start()
-                # The shadow may have grown while this process was booting.
-                # The tail-side refresh saw `spawning` and deliberately did
-                # not start a duplicate worker, so the landing worker owns the
-                # follow-up that closes that race.
-                if _shadow_size(session, shadow) != size:
-                    ensure_warm()
+                        return
+                try:
+                    child.kill()   # the runner already read the slot and left
+                except Exception:
+                    pass
 
             threading.Thread(
                 target=spawn, name="tandem-warm-fire", daemon=True
             ).start()
 
-        def _kill_warm(child: WarmChild) -> None:
-            try:
-                child.kill()
-            except Exception:
-                pass
-
         # The monitor exists before the closure does, so the hook is wired by
         # assignment — `monitor.start()` is called far below, which is what
         # makes a plain write safe: the thread has not run yet.
-        monitor.on_flip_decided = ensure_warm
+        monitor.on_flip_decided = fire_warm
         frame = FrameIO(
             flip_byte=frame_cfg.flip_byte,
             on_flip=monitor.flip_pressed,
@@ -759,12 +721,9 @@ class InteractiveRunner:
                 from . import ops
                 try:
                     while not stop.is_set():
-                        drained = 0
                         with ops._sub_lock():
                             for loop in loops:
-                                drained += loop.drain()
-                        if drained:
-                            ensure_warm()
+                                loop.drain()
                         watcher.wait()
                     # final drain after the CLI exits
                     with ops._sub_lock():
@@ -780,7 +739,6 @@ class InteractiveRunner:
         thread = threading.Thread(target=tail_thread, name="tandem-tail", daemon=True)
         thread.start()
         monitor.start()   # before the try: stop() on an unstarted thread raises
-        ensure_warm()
         try:
             # A release that returns None means the discard reader still owns
             # the fd, so there is nothing safe to hand over: run_in_pty spawns

--- a/src/tandem/warm.py
+++ b/src/tandem/warm.py
@@ -1,10 +1,11 @@
-"""Process warmup: keep the incoming harness booted on a hidden PTY.
+"""Process warmup: the incoming harness boots while the outgoing one dies.
 
-Nothing here runs on its own schedule. The runner calls `spawn_hidden` at
-entry and refreshes the standby when transcript sync grows the shadow;
-whether that child is still usable by the time the flip lands is flip.py's
-freshness gate to decide, and this module only hands it the evidence (the
-recipe, the shadow-size snapshot).
+Nothing here runs on its own schedule. The runner fires `spawn_hidden`
+from the monitor thread the moment a flip is decided, so the child boots
+through the outgoing harness's teardown; whether that child is still
+usable by the time the flip lands is flip.py's freshness gate to decide,
+and this module only hands it the evidence (the recipe, the shadow-size
+snapshot).
 
 `LaunchRecipe` is the frozen record of how a harness invocation was (or
 will be) launched. It exists because config is read per call

--- a/src/tandem/warm.py
+++ b/src/tandem/warm.py
@@ -1,11 +1,11 @@
 """Process warmup: the incoming harness boots while the outgoing one dies.
 
-Nothing here runs on its own schedule. The runner fires `spawn_hidden`
-from the monitor thread the moment a flip is decided, so the child boots
-through the outgoing harness's teardown; whether that child is still
-usable by the time the flip lands is flip.py's freshness gate to decide,
-and this module only hands it the evidence (the recipe, the shadow-size
-snapshot).
+Nothing here runs on its own schedule. The moment a flip is decided the
+runner starts a launch worker, which sizes the shadow, builds the recipe
+and calls `spawn_hidden`, so the child boots through the outgoing
+harness's teardown; whether that child is still usable by the time the
+flip lands is flip.py's freshness gate to decide, and this module only
+hands it the evidence (the recipe, the shadow-size snapshot).
 
 `LaunchRecipe` is the frozen record of how a harness invocation was (or
 will be) launched. It exists because config is read per call

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -451,9 +451,11 @@ def _fire_and_join(control, hook, tmp_path):
 
 
 def test_monitor_fires_the_flip_hook_before_the_ladder(tmp_path):
-    # The hook is the resident standby's final freshness check. It must run
-    # before teardown so a replacement, when needed, boots in parallel with
-    # the outgoing harness's quit ladder. The order is the contract.
+    # The hook is where the incoming harness is spawned, and the whole point
+    # of firing it from here is that the boot overlaps the outgoing harness's
+    # teardown. Run after `control.terminate` it would still spawn, still
+    # hand over, still pass every runner test — and serialize precisely what
+    # this pipelines. So the order is the contract.
     order = []
     m = _fire_and_join(_OrderingControl(order), lambda: order.append("fired"),
                        tmp_path)
@@ -1010,7 +1012,7 @@ def test_runner_probe_swallows_raising_session_status(env_factory, monkeypatch):
     assert made["kw"]["status_probe"]() is None
 
 
-# -- resident warm spawn --------------------------------------------------
+# -- the fire-at-flip warm spawn ------------------------------------------
 
 
 class _StdinWithFileno:
@@ -1178,10 +1180,7 @@ def test_a_slow_fire_does_not_delay_the_termination_ladder(env_factory,
         release_spawn.wait(timeout=1)
         order.append("spawn-done")
         spawn_done.set()
-        child = _DeadChild()
-        child.shadow_size = args[2]
-        child.alive = lambda: True
-        return child
+        return _DeadChild()
 
     def terminate(self, soft, **kwargs):
         order.append("ladder")
@@ -1202,182 +1201,28 @@ def test_a_slow_fire_does_not_delay_the_termination_ladder(env_factory,
     assert order.index("ladder") < order.index("spawn-done")
 
 
-def test_warm_starts_before_flip_and_normal_exit_reaps_it(env_factory, monkeypatch):
+def test_no_flip_leaves_no_fire_spawn(env_factory, monkeypatch):
     env = env_factory(active="claude")
     import tandem.runner as runner_mod
     spawns = []
-
-    class FakeChild:
-        def __init__(self, shadow_size):
-            self.shadow_size = shadow_size
-            self.killed = False
-
-        def alive(self):
-            return True
-
-        def kill(self):
-            self.killed = True
-
-    def fake_spawn_hidden(recipe, dims, shadow_size):
-        spawns.append(FakeChild(shadow_size))
-        return spawns[-1]
-
-    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
+    monkeypatch.setattr(runner_mod, "spawn_hidden",
+                        lambda *a, **kw: spawns.append(1))
     monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
     monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
-    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
-
-    def fake_run_in_pty(*args, **kwargs):
-        deadline = time.time() + 3
-        while not spawns and time.time() < deadline:
-            time.sleep(0.02)
-        return 0
-
-    monkeypatch.setattr(runner_mod, "run_in_pty", fake_run_in_pty)
+    monkeypatch.setattr(runner_mod, "run_in_pty", lambda *a, **kw: 0)
     r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
     r.run()
-    assert not r.flip_requested
-    assert len(spawns) == 1 and spawns[0].killed
-    assert r.warm_child is None
+    assert not r.flip_requested and spawns == [] and r.warm_child is None
 
 
-def test_sync_growth_replaces_the_resident_warm_child(env_factory, monkeypatch):
-    env = env_factory(active="claude")
-    import tandem.runner as runner_mod
-
-    with open(env.claude_shadow, "a") as fh:
-        fh.write(json.dumps({
-            "type": "user",
-            "uuid": "warm-refresh-user",
-            "message": {"role": "user", "content": "refresh warm child"},
-        }) + "\n")
-
-    spawns = []
-    first_spawned = threading.Event()
-
-    class FakeChild:
-        def __init__(self, shadow_size):
-            self.shadow_size = shadow_size
-            self.killed = False
-
-        def alive(self):
-            return True
-
-        def kill(self):
-            self.killed = True
-
-    def fake_spawn_hidden(recipe, dims, shadow_size):
-        child = FakeChild(shadow_size)
-        spawns.append(child)
-        first_spawned.set()
-        return child
-
-    class GrowingSink(_Sink):
-        def handle(self, line, ctx, cursor):
-            assert first_spawned.wait(3)
-            with open(env.codex_shadow, "ab") as fh:
-                fh.write(b'{"synced":true}\n')
-
-    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
-    monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
-    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
-    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
-
-    def fake_run_in_pty(*args, **kwargs):
-        deadline = time.time() + 3
-        while len(spawns) < 2 and time.time() < deadline:
-            time.sleep(0.02)
-        return 0
-
-    monkeypatch.setattr(runner_mod, "run_in_pty", fake_run_in_pty)
-    r = runner_mod.InteractiveRunner(
-        env.session, sink_factory=lambda *args: GrowingSink()
-    )
-    r.run()
-
-    assert len(spawns) == 2
-    assert spawns[0].shadow_size < spawns[1].shadow_size
-    assert spawns[0].killed and spawns[1].killed
-
-
-def test_sync_growth_during_spawn_gets_a_followup_warm_child(env_factory,
-                                                            monkeypatch):
-    env = env_factory(active="claude")
-    import tandem.runner as runner_mod
-
-    with open(env.claude_shadow, "a") as fh:
-        fh.write(json.dumps({
-            "type": "user", "uuid": "warm-race-user",
-            "message": {"role": "user", "content": "race warm spawn"},
-        }) + "\n")
-
-    spawn_started = threading.Event()
-    shadow_grew = threading.Event()
-    drain_cycle_done = threading.Event()
-    release_spawn = threading.Event()
-    spawns = []
-
-    class FakeChild:
-        def __init__(self, shadow_size):
-            self.shadow_size = shadow_size
-            self.killed = False
-
-        def alive(self):
-            return True
-
-        def kill(self):
-            self.killed = True
-
-    def fake_spawn_hidden(recipe, dims, shadow_size):
-        if not spawns:
-            spawn_started.set()
-            assert release_spawn.wait(3)
-        child = FakeChild(shadow_size)
-        spawns.append(child)
-        return child
-
-    class GrowingSink(_Sink):
-        def handle(self, line, ctx, cursor):
-            assert spawn_started.wait(3)
-            with open(env.codex_shadow, "ab") as fh:
-                fh.write(b'{"synced":"during-spawn"}\n')
-            shadow_grew.set()
-
-    class SignalingWatcher(_QuietWatcher):
-        def wait(self):
-            drain_cycle_done.set()
-            super().wait()
-
-    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
-    monkeypatch.setattr(runner_mod, "TranscriptWatcher", SignalingWatcher)
-    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
-    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
-
-    def fake_run_in_pty(*args, **kwargs):
-        assert shadow_grew.wait(3)
-        assert drain_cycle_done.wait(3)
-        release_spawn.set()
-        deadline = time.time() + 3
-        while len(spawns) < 2 and time.time() < deadline:
-            time.sleep(0.02)
-        return 0
-
-    monkeypatch.setattr(runner_mod, "run_in_pty", fake_run_in_pty)
-    runner_mod.InteractiveRunner(
-        env.session, sink_factory=lambda *args: GrowingSink()
-    ).run()
-
-    assert len(spawns) == 2
-    assert spawns[0].shadow_size < spawns[1].shadow_size
-    assert spawns[0].killed and spawns[1].killed
-
-
-def test_a_closed_slot_rejects_a_refire(env_factory, monkeypatch):
-    # ensure_warm called after the run ended (a monitor join that expired
-    # mid-flip can leave the hook to fire this late) must not boot anything:
-    # the slot is closed for good, and a child spawned now would have nobody
-    # left to adopt or reap it. Driven by calling the hook once run() has
-    # returned.
+def test_fire_kills_its_child_when_the_slot_is_already_closed(env_factory,
+                                                             monkeypatch):
+    # The one case monitor.stop()'s join cannot cover: its timeout expires
+    # with a spawn still in flight, so the runner's finally reads and closes
+    # the slot first and the fire lands after. Driven by calling the fire
+    # hook once run() has returned — the slot is then closed for good, which
+    # is exactly the state an expired join leaves behind. The child must be
+    # killed by the fire itself; nothing else is left to reap it.
     import tandem.runner as runner_mod
     env = env_factory(active="claude")
     monitors = []
@@ -1388,12 +1233,8 @@ def test_a_closed_slot_rejects_a_refire(env_factory, monkeypatch):
             monitors.append(self)
 
     class FakeChild:
-        def __init__(self, shadow_size):
-            self.shadow_size = shadow_size
+        def __init__(self):
             self.killed = False
-
-        def alive(self):
-            return True
 
         def kill(self):
             self.killed = True
@@ -1401,7 +1242,7 @@ def test_a_closed_slot_rejects_a_refire(env_factory, monkeypatch):
     spawns = []
 
     def fake_spawn_hidden(recipe, dims, shadow_size):
-        spawns.append(FakeChild(shadow_size))
+        spawns.append(FakeChild())
         return spawns[-1]
 
     monkeypatch.setattr(runner_mod, "FlipMonitor", CapturingMonitor)
@@ -1412,55 +1253,14 @@ def test_a_closed_slot_rejects_a_refire(env_factory, monkeypatch):
     monkeypatch.setattr(runner_mod, "run_in_pty", lambda *a, **kw: 0)
     r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
     r.run()
-    assert len(spawns) == 1 and spawns[0].killed
-    assert r.warm_child is None
+    assert spawns == [] and r.warm_child is None   # nothing fired during the run
 
-    monitors[0].on_flip_decided()                  # fires against a closed slot
-    time.sleep(0.05)
-    assert len(spawns) == 1 and spawns[0].killed   # no second spawn
+    monitors[0].on_flip_decided()                  # the in-flight spawn lands
+    deadline = time.time() + 3
+    while not (spawns and spawns[0].killed) and time.time() < deadline:
+        time.sleep(0.02)
+    assert len(spawns) == 1 and spawns[0].killed   # reaped, not stranded
     assert r.warm_child is None                    # and never adopted
-
-
-def test_a_spawn_landing_after_close_kills_its_child(env_factory, monkeypatch):
-    # The startup fire is still in flight when the run ends: the finally
-    # closes the slot with the worker blocked inside spawn_hidden, so nothing
-    # was published to adopt. The landing worker must see the closed slot and
-    # kill the child it just booted — nothing else holds a reference to it.
-    import tandem.runner as runner_mod
-    env = env_factory(active="claude")
-    release_spawn = threading.Event()
-    reaped = threading.Event()
-    spawns = []
-
-    class FakeChild:
-        def __init__(self, shadow_size):
-            self.shadow_size = shadow_size
-            self.killed = False
-
-        def alive(self):
-            return True
-
-        def kill(self):
-            self.killed = True
-            reaped.set()
-
-    def fake_spawn_hidden(recipe, dims, shadow_size):
-        assert release_spawn.wait(3)
-        spawns.append(FakeChild(shadow_size))
-        return spawns[-1]
-
-    monkeypatch.setattr(runner_mod, "spawn_hidden", fake_spawn_hidden)
-    monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
-    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
-    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
-    monkeypatch.setattr(runner_mod, "run_in_pty", lambda *a, **kw: 0)
-    r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
-    r.run()
-    assert spawns == []          # the worker never landed during the run
-    release_spawn.set()          # now it lands on a closed slot
-    assert reaped.wait(3)
-    assert len(spawns) == 1 and spawns[0].killed
-    assert r.warm_child is None
 
 
 def test_runner_adopts_a_live_child(env_factory, monkeypatch):
@@ -1693,7 +1493,7 @@ def test_tail_thread_drains_all_directions(tmp_path, monkeypatch):
 
 
 def test_warm_skips_opencode_target(tmp_path, monkeypatch):
-    """ensure_warm never spawns when next-in-cycle is opencode (v1 carve-out):
+    """fire_warm never spawns when next-in-cycle is opencode (v1 carve-out):
     an opencode TUI booted pre-drain would cache the session pre-drain and
     never show the last turn, so opencode-bound flips run cold."""
     from conftest import Env3

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1201,6 +1201,49 @@ def test_a_slow_fire_does_not_delay_the_termination_ladder(env_factory,
     assert order.index("ladder") < order.index("spawn-done")
 
 
+def test_a_slow_recipe_build_does_not_delay_the_termination_ladder(
+        env_factory, monkeypatch):
+    # The fire's filesystem setup — the shadow stat, build_launch's config
+    # reads, the sentinel mkdir — belongs to the launch worker: run on the
+    # monitor thread it would sit between the flip decision and the ladder,
+    # delaying the very teardown the fire exists to overlap.
+    import tandem.runner as runner_mod
+    env = env_factory(active="claude")
+    order = []
+    release_build = threading.Event()
+    build_done = threading.Event()
+    real_build = runner_mod.build_launch
+
+    def slow_build(session, side):
+        if side != "codex":
+            return real_build(session, side)   # the active side's own launch
+        order.append("build-start")
+        release_build.wait(timeout=1)
+        order.append("build-done")
+        build_done.set()
+        return real_build(session, side)
+
+    def terminate(self, soft, **kwargs):
+        order.append("ladder")
+        release_build.set()
+        return "soft"
+
+    monkeypatch.setattr(runner_mod, "build_launch", slow_build)
+    monkeypatch.setattr(runner_mod, "spawn_hidden",
+                        lambda *a, **kw: _DeadChild())
+    monkeypatch.setattr(runner_mod, "TranscriptWatcher", _QuietWatcher)
+    monkeypatch.setattr(runner_mod.PtyControl, "terminate", terminate)
+    monkeypatch.setattr(runner_mod, "_stdin_tty", lambda: True)
+    monkeypatch.setattr(sys, "stdin", _StdinWithFileno())
+    monkeypatch.setattr(runner_mod, "run_in_pty", _flip_driver(env))
+    r = runner_mod.InteractiveRunner(env.session, sink_factory=_null_sink)
+    r.run()
+
+    assert r.flip_requested
+    assert build_done.wait(3)
+    assert order.index("ladder") < order.index("build-done")
+
+
 def test_no_flip_leaves_no_fire_spawn(env_factory, monkeypatch):
     env = env_factory(active="claude")
     import tandem.runner as runner_mod


### PR DESCRIPTION
## Summary

Removes the resident always-warm standby (#40's feature half) — it proved more trouble than help — while keeping the flip-time concurrency: the incoming harness still boots **while** the outgoing one shuts down.

**Why remove it:**
- Respawn churn during streaming turns (6× in 30s observed live) — every sync drain that grew the shadow killed and re-booted the hidden harness.
- Every clean exit paid the hidden standby's kill ladder (~7s measured).
- The standby-fork bug: a resumed resident standby autonomously starts a turn on Claude Code's orphan-task scan; the respawn kill then interrupts it mid-turn and forks the transcript (live session `9954ac32`).

**What this restores** — PR #39's documented shape (docs/configuration.md needed *zero* edits; it always described warm as pipelining, never as a background service):
- `fire_warm` fires exactly once, from `on_flip_decided`, spawning the incoming harness on the `tandem-warm-fire` worker concurrently with the outgoing harness's quit ladder.
- The entry-time spawn, drain-triggered refresh, `spawning` flag, and displaced-child replacement/re-fire logic are deleted (−84 net lines in runner.py).
- Between flips a tandem session is exactly one harness process again.

**What stays:**
- The carry → freshness gate → adoption handover in flip.py/warm.py (it's how the fired child rides across the flip).
- #40's latency fixes: the triple-^C claude quit recipe and `WarmChild.kill` draining the pty through the ladder.
- The `[frame] warm` flag (gates the pipelining) and the flip-debug logging.
- N-harness generalization (#41) and the opencode cold-flip carve-out (#44).

## Tests

- Restored #39's fire-at-flip test section: `test_no_flip_leaves_no_fire_spawn`, `test_fire_kills_its_child_when_the_slot_is_already_closed` (now polls for the kill rather than just the spawn landing — the fire worker's flip-debug write sits between the two).
- Deleted the three resident-standby tests; kept `expect_spawn` in `_drive_flip` for the opencode carve-out test.
- Full suite: **633 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)