### PR TITLE
Onboarding: default --active to first usable harness, add install hints

### DIFF
--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -97,6 +97,14 @@ def _resolve_participants(warn_only: bool = False) -> tuple[list[str], dict[str,
             click.secho(f"warning: {msg}", fg="yellow", err=True)
         else:
             click.secho(f"error: {msg}", fg="red", err=True)
+            # Absent CLIs get an install line; installed-but-unusable ones
+            # already explained themselves in the warnings above.
+            for hid in missing:
+                if hid in ADAPTERS and versions.get(hid) is None:
+                    adapter = get_adapter(hid)
+                    click.echo(
+                        f"  install {adapter.display_name}: "
+                        f"{adapter.install_hint}", err=True)
             sys.exit(1)
     return usable, versions
 
@@ -129,9 +137,9 @@ def _narrow_participants(store: StateStore, session: PairedSession) -> PairedSes
 @click.option(
     "--active",
     type=click.Choice(["claude", "codex", "opencode"]),
-    default="claude",
-    show_default=True,
-    help="Initially active harness for the fresh session.",
+    default=None,
+    help="Initially active harness for the fresh session "
+         "[default: first usable harness]",
 )
 @click.pass_context
 def main(ctx: click.Context, active: str) -> None:
@@ -668,10 +676,14 @@ def plugin_install_cmd() -> None:
     sys.exit(0 if install_plugin() else 1)
 
 
-def _interactive(active: str) -> None:
+def _interactive(active: str | None) -> None:
     cwd = _cwd()
     usable, _ = _resolve_participants()
-    if active not in usable:
+    if active is None:
+        # No preference stated: first usable in configured order, so claude
+        # users see no change and a claude-less machine still just works.
+        active = usable[0]
+    elif active not in usable:
         click.secho(f"error: --active {active} is not usable here "
                     f"(usable: {', '.join(usable)}).", fg="red", err=True)
         sys.exit(1)

--- a/src/tandem/harness/base.py
+++ b/src/tandem/harness/base.py
@@ -38,6 +38,7 @@ class HarnessAdapter(ABC):
     id: str          # 'claude' | 'codex'
     display_name: str
     binary: str      # executable name on PATH
+    install_hint: str  # one-line install command, shown when the CLI is absent
 
     # -- environment ---------------------------------------------------------
 

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -78,6 +78,7 @@ class ClaudeCodeAdapter(HarnessAdapter):
     id = "claude"
     display_name = "Claude Code"
     binary = "claude"
+    install_hint = "npm install -g @anthropic-ai/claude-code"
 
     # -- environment ---------------------------------------------------------
 

--- a/src/tandem/harness/codex.py
+++ b/src/tandem/harness/codex.py
@@ -39,6 +39,7 @@ class CodexAdapter(HarnessAdapter):
     id = "codex"
     display_name = "Codex CLI"
     binary = "codex"
+    install_hint = "npm install -g @openai/codex"
 
     # -- environment ---------------------------------------------------------
 

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -188,6 +188,7 @@ class OpencodeAdapter(HarnessAdapter):
     id = "opencode"
     display_name = "opencode"
     binary = "opencode"
+    install_hint = "npm install -g opencode-ai"
 
     # -- environment ---------------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,7 @@ class FakeOpencodeAdapter(HarnessAdapter):
     id = "opencode"
     display_name = "opencode"
     binary = "opencode"
+    install_hint = "npm install -g opencode-ai"
 
     def __init__(self, root: Path):
         self.root = root

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,9 +62,31 @@ def test_active_codex_flips_roles(homes, ok_versions, entered):
     assert "codex active, claude shadow" in r.output
 
 
+def test_bare_tandem_defaults_to_first_usable(homes, entered, monkeypatch):
+    """No --active given: drop into the first usable harness in configured
+    order rather than assuming claude is installed."""
+    monkeypatch.setattr(
+        cli, "_resolve_participants",
+        lambda warn_only=False: (["codex", "claude"],
+                                 {"claude": "2.1.220", "codex": "0.145.0"}),
+    )
+    r = click.testing.CliRunner().invoke(cli.main, [])
+    assert r.exit_code == 0
+    assert entered[0].active == "codex"
+    assert "codex active, claude shadow" in r.output
+
+
+def test_explicit_active_not_usable_still_errors(homes, ok_versions, entered):
+    r = click.testing.CliRunner().invoke(cli.main, ["--active", "opencode"])
+    assert r.exit_code == 1
+    assert "not usable" in r.stderr
+    assert entered == []
+
+
 class _NoBin:
     display_name = "Claude Code"
     binary = "claude"
+    install_hint = "npm install -g @anthropic-ai/claude-code"
 
     def detect_version(self):
         return None

--- a/tests/test_participants.py
+++ b/tests/test_participants.py
@@ -61,6 +61,32 @@ def test_resolution_fewer_than_two_errors(tmp_path, monkeypatch):
         _resolve_participants()
 
 
+def test_resolution_error_includes_install_hints(tmp_path, monkeypatch, capsys):
+    """The <2-usable error tells a new user how to get a second harness:
+    one install line per not-installed harness."""
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path))
+    _fake_versions(monkeypatch, {"claude": "2.1.220", "codex": None,
+                                 "opencode": None})
+    with pytest.raises(SystemExit):
+        _resolve_participants()
+    err = capsys.readouterr().err
+    assert "npm install -g @openai/codex" in err
+    assert "npm install -g opencode-ai" in err
+
+
+def test_resolution_no_hint_for_installed_but_unusable(tmp_path, monkeypatch, capsys):
+    """A below-floor codex already got its own exclusion warning; the
+    install hint is only for harnesses that are absent altogether."""
+    monkeypatch.setenv("TANDEM_HOME", str(tmp_path))
+    _fake_versions(monkeypatch, {"claude": "2.1.220", "codex": "0.100.0",
+                                 "opencode": None})
+    with pytest.raises(SystemExit):
+        _resolve_participants()
+    err = capsys.readouterr().err
+    assert "npm install -g @openai/codex" not in err
+    assert "npm install -g opencode-ai" in err
+
+
 def test_resume_narrows_and_persists(tmp_path, monkeypatch):
     """A stored 3-way session resumed with opencode gone drops it for good."""
     env = Env3(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary

Two rough edges in the first-run experience, found while auditing onboarding. No config file is written; launch-time detection (`_resolve_participants`) stays the single source of truth for who participates.

- **`tandem` no longer assumes claude is installed.** The `--active` default changes from hard-coded `"claude"` to *first usable harness in configured order*. A codex+opencode machine now drops into codex instead of erroring with `--active claude is not usable here`. Claude-first users see identical behavior (claude leads the default order), and an explicit `--active X` that isn't usable still errors — that path is pinned by a test.

- **The `<2 usable harnesses` error is now actionable.** Each adapter carries an `install_hint` (package names verified against the npm registry), and the fatal error appends one install line per *absent* CLI. Installed-but-unusable harnesses keep their existing specific warnings and are not repeated:

  ```
  error: tandem needs at least two usable harnesses; usable: none, unavailable: ['claude', 'codex', 'opencode'].
    install Claude Code: npm install -g @anthropic-ai/claude-code
    install Codex CLI: npm install -g @openai/codex
    install opencode: npm install -g opencode-ai
  ```

## Test plan

- 4 new tests (TDD, watched red first): bare `tandem` picks first usable when claude isn't first; explicit `--active` on an unusable harness still errors; error output includes hints for absent CLIs; installed-but-unusable CLIs get no install hint.
- Full suite: 638 passed.
- Live smoke: `--help` shows the new default text; running with a bare `PATH` produces the error block above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)