### PR TITLE
Status bar: split token totals into input/output arrows

### DIFF
--- a/src/tandem/harness/base.py
+++ b/src/tandem/harness/base.py
@@ -28,22 +28,26 @@ def _fmt_tokens(n: int) -> str:
 class UsageSnapshot:
     """What a usage meter knows right now. `ctx_percent` only when the
     harness reports its own context window (codex does; claude's transcript
-    never records the window size, so its slot shows raw tokens)."""
+    never records the window size, so its slot shows raw tokens).
+    `input_tokens` is the whole prompt side as billed — fresh input plus
+    cache reads and writes; `output_tokens` includes reasoning."""
 
     ctx_tokens: int | None = None
     ctx_percent: int | None = None
-    total_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def bar_text(self) -> str:
-        # `·` is East_Asian_Width A like the bar's ● │ ○ — one cell outside
-        # CJK-wide terminal configs (frame.StatusBar.line's width rule).
+        # `·` `↑` `↓` are East_Asian_Width A like the bar's ● │ ○ — one cell
+        # outside CJK-wide terminal configs (frame.StatusBar.line's width rule).
         parts = []
         if self.ctx_percent is not None:
             parts.append(f"{self.ctx_percent}% ctx")
         elif self.ctx_tokens is not None:
             parts.append(f"{_fmt_tokens(self.ctx_tokens)} ctx")
-        if self.total_tokens:
-            parts.append(f"{_fmt_tokens(self.total_tokens)} tot")
+        if self.input_tokens or self.output_tokens:
+            parts.append(f"{_fmt_tokens(self.input_tokens)}↑"
+                         f" {_fmt_tokens(self.output_tokens)}↓")
         return " · ".join(parts)
 
 

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -41,8 +41,9 @@ class _ClaudeUsageMeter(UsageMeter):
     toward the total and never move ctx."""
 
     def __init__(self):
-        self._by_id: dict[str, int] = {}
-        self._total = 0
+        self._by_id: dict[str, tuple[int, int]] = {}
+        self._input = 0
+        self._output = 0
         self._ctx: int | None = None
 
     def feed(self, raw: Any) -> None:
@@ -59,18 +60,23 @@ class _ClaudeUsageMeter(UsageMeter):
 
         prompt = (n("input_tokens") + n("cache_read_input_tokens")
                   + n("cache_creation_input_tokens"))
-        entry_total = prompt + n("output_tokens")
+        out = n("output_tokens")
         mid = msg.get("id")
         if isinstance(mid, str):
-            self._total += entry_total - self._by_id.get(mid, 0)
-            self._by_id[mid] = entry_total
+            seen_prompt, seen_out = self._by_id.get(mid, (0, 0))
+            self._input += prompt - seen_prompt
+            self._output += out - seen_out
+            self._by_id[mid] = (prompt, out)
         else:
-            self._total += entry_total
+            self._input += prompt
+            self._output += out
         if not raw.get("isSidechain"):
             self._ctx = prompt
 
     def snapshot(self) -> UsageSnapshot:
-        return UsageSnapshot(ctx_tokens=self._ctx, total_tokens=self._total)
+        return UsageSnapshot(ctx_tokens=self._ctx,
+                             input_tokens=self._input,
+                             output_tokens=self._output)
 
 
 def _stringify_block_content(content: Any) -> str:

--- a/src/tandem/harness/codex.py
+++ b/src/tandem/harness/codex.py
@@ -33,10 +33,13 @@ class _CodexUsageMeter(UsageMeter):
     """Codex precomputes both numbers in event_msg/token_count: cumulative
     (total_token_usage), the last request (≈ current context), and — unlike
     claude — the model's context window, so the bar can show an exact
-    percent. `info` is null on rate-limit-only events."""
+    percent. `info` is null on rate-limit-only events. input_tokens already
+    includes cached_input_tokens (live: total = input + output exactly) and
+    reasoning is a subset of output_tokens, so both sides read straight."""
 
     def __init__(self):
-        self._total = 0
+        self._input = 0
+        self._output = 0
         self._ctx: int | None = None
         self._pct: int | None = None
 
@@ -47,9 +50,12 @@ class _CodexUsageMeter(UsageMeter):
         if payload.get("type") != "token_count":
             return
         info = payload.get("info") or {}
-        total = (info.get("total_token_usage") or {}).get("total_tokens")
-        if isinstance(total, int):
-            self._total = total
+        total = info.get("total_token_usage") or {}
+        inp, out = total.get("input_tokens"), total.get("output_tokens")
+        if isinstance(inp, int):
+            self._input = inp
+        if isinstance(out, int):
+            self._output = out
         last = (info.get("last_token_usage") or {}).get("total_tokens")
         if isinstance(last, int):
             self._ctx = last
@@ -62,7 +68,8 @@ class _CodexUsageMeter(UsageMeter):
 
     def snapshot(self) -> UsageSnapshot:
         return UsageSnapshot(
-            ctx_tokens=self._ctx, ctx_percent=self._pct, total_tokens=self._total
+            ctx_tokens=self._ctx, ctx_percent=self._pct,
+            input_tokens=self._input, output_tokens=self._output,
         )
 
 

--- a/src/tandem/harness/opencode.py
+++ b/src/tandem/harness/opencode.py
@@ -44,10 +44,13 @@ class _OpencodeUsageMeter(UsageMeter):
     """Fed whole turn units (OpencodeTurnReader yields each exactly once):
     every assistant row carries its request's tokens block. Rows tandem
     seeded are all zeros — skipped whole, so a synced shadow turn never
-    blanks a real context reading."""
+    blanks a real context reading. Reasoning is its own field here but a
+    subset of output in codex's — folded into output so ↓ means the same
+    thing on both slots."""
 
     def __init__(self):
-        self._total = 0
+        self._input = 0
+        self._output = 0
         self._ctx: int | None = None
 
     def feed(self, raw: Any) -> None:
@@ -65,14 +68,18 @@ class _OpencodeUsageMeter(UsageMeter):
             cache = tokens.get("cache") or {}
             read = cache.get("read") if isinstance(cache.get("read"), int) else 0
             write = cache.get("write") if isinstance(cache.get("write"), int) else 0
-            row_total = n("input") + n("output") + n("reasoning") + read + write
-            if row_total == 0:
+            row_input = n("input") + read + write
+            row_output = n("output") + n("reasoning")
+            if row_input + row_output == 0:
                 continue
-            self._total += row_total
+            self._input += row_input
+            self._output += row_output
             self._ctx = n("input") + read
 
     def snapshot(self) -> UsageSnapshot:
-        return UsageSnapshot(ctx_tokens=self._ctx, total_tokens=self._total)
+        return UsageSnapshot(ctx_tokens=self._ctx,
+                             input_tokens=self._input,
+                             output_tokens=self._output)
 
 SENTINEL_PROVIDER = "tandem"
 SENTINEL_MODEL = "<synced>"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -4,6 +4,12 @@ Fixture shapes mirror docs/formats.md and live transcripts: claude repeats
 one message's usage across its per-content-block entries (output still
 growing), codex precomputes both totals in token_count events, opencode
 carries a tokens block per assistant row.
+
+"Input" throughout means the whole prompt side as sent over the wire —
+fresh input plus cache reads and cache writes. Codex's input_tokens
+already includes cached_input_tokens (live rollouts: total = input +
+output exactly); claude and opencode report cache fields separately, so
+their meters fold them in.
 """
 
 import json
@@ -31,10 +37,17 @@ def _claude_entry(mid, inp=0, cr=0, cc=0, out=0, sidechain=False):
     return e
 
 
-def _token_count(total=None, last=None, window=None):
+def _token_count(total=None, last=None, window=None, inp=None, out=None):
     info = {}
-    if total is not None:
-        info["total_token_usage"] = {"total_tokens": total}
+    if total is not None or inp is not None:
+        usage = {}
+        if total is not None:
+            usage["total_tokens"] = total
+        if inp is not None:
+            usage["input_tokens"] = inp
+        if out is not None:
+            usage["output_tokens"] = out
+        info["total_token_usage"] = usage
     if last is not None:
         info["last_token_usage"] = {"total_tokens": last}
     if window is not None:
@@ -59,14 +72,25 @@ def test_claude_meter_ctx_tracks_latest_usage():
     assert m.snapshot().ctx_tokens == 2 + 60_000 + 2_000
 
 
+def test_claude_meter_splits_input_and_output():
+    m = get_adapter("claude").make_usage_meter()
+    m.feed(_claude_entry("m1", inp=2, cr=50_000, cc=1_000, out=300))
+    m.feed(_claude_entry("m2", inp=2, cr=60_000, cc=2_000, out=500))
+    snap = m.snapshot()
+    assert snap.input_tokens == (2 + 50_000 + 1_000) + (2 + 60_000 + 2_000)
+    assert snap.output_tokens == 300 + 500
+
+
 def test_claude_meter_dedups_entries_sharing_a_message_id():
     m = get_adapter("claude").make_usage_meter()
     m.feed(_claude_entry("m1", inp=2, cr=1_000, out=100))
     m.feed(_claude_entry("m1", inp=2, cr=1_000, out=250))  # later block, same msg
-    assert m.snapshot().total_tokens == 2 + 1_000 + 250
+    snap = m.snapshot()
+    assert snap.input_tokens == 2 + 1_000
+    assert snap.output_tokens == 250
 
 
-def test_claude_meter_counts_sidechains_in_total_but_not_ctx():
+def test_claude_meter_counts_sidechains_in_totals_but_not_ctx():
     # Parallel Task subagents interleave sidechain entries with the main
     # chain; they are real spend but a different context window.
     m = get_adapter("claude").make_usage_meter()
@@ -74,7 +98,8 @@ def test_claude_meter_counts_sidechains_in_total_but_not_ctx():
     m.feed(_claude_entry("side1", inp=500, out=50, sidechain=True))
     m.feed(_claude_entry("main1", inp=2, cr=1_000, out=200))
     snap = m.snapshot()
-    assert snap.total_tokens == (2 + 1_000 + 200) + (500 + 50)
+    assert snap.input_tokens == (2 + 1_000) + 500
+    assert snap.output_tokens == 200 + 50
     assert snap.ctx_tokens == 2 + 1_000
 
 
@@ -89,17 +114,30 @@ def test_claude_meter_ignores_entries_without_usage():
 # -- codex -------------------------------------------------------------------
 
 
-def test_codex_meter_reads_percent_and_total():
+def test_codex_meter_reads_percent_and_split():
     m = get_adapter("codex").make_usage_meter()
-    m.feed(_token_count(total=75_118, last=75_118, window=258_400))
+    m.feed(_token_count(total=75_118, last=75_118, window=258_400,
+                        inp=75_043, out=75))
     snap = m.snapshot()
     assert snap.ctx_percent == 29
-    assert snap.total_tokens == 75_118
+    assert snap.input_tokens == 75_043
+    assert snap.output_tokens == 75
+
+
+def test_codex_meter_split_is_cumulative_not_summed():
+    # total_token_usage is already cumulative — later events replace,
+    # never add
+    m = get_adapter("codex").make_usage_meter()
+    m.feed(_token_count(total=10_000, last=10_000, inp=9_900, out=100))
+    m.feed(_token_count(total=25_000, last=15_000, inp=24_600, out=400))
+    snap = m.snapshot()
+    assert snap.input_tokens == 24_600
+    assert snap.output_tokens == 400
 
 
 def test_codex_meter_without_window_falls_back_to_tokens():
     m = get_adapter("codex").make_usage_meter()
-    m.feed(_token_count(total=75_118, last=75_118))
+    m.feed(_token_count(total=75_118, last=75_118, inp=75_043, out=75))
     snap = m.snapshot()
     assert snap.ctx_percent is None
     assert snap.ctx_tokens == 75_118
@@ -123,7 +161,10 @@ def test_codex_meter_ignores_other_entries():
 # -- opencode ----------------------------------------------------------------
 
 
-def test_opencode_meter_sums_turns_and_tracks_last_context():
+def test_opencode_meter_splits_turns_and_tracks_last_context():
+    # reasoning tokens are separate in opencode's block but a subset of
+    # output in codex's — folding them into output makes ↓ mean the same
+    # thing on both slots
     m = get_adapter("opencode").make_usage_meter()
     a1 = {"id": "a1", "tokens": {"input": 100, "output": 50, "reasoning": 10,
                                  "cache": {"read": 400, "write": 20}}}
@@ -132,7 +173,8 @@ def test_opencode_meter_sums_turns_and_tracks_last_context():
     m.feed(_oc_turn([a1]))
     m.feed(_oc_turn([a2]))
     snap = m.snapshot()
-    assert snap.total_tokens == (100 + 50 + 10 + 400 + 20) + (200 + 80 + 900)
+    assert snap.input_tokens == (100 + 400 + 20) + (200 + 900)
+    assert snap.output_tokens == (50 + 10) + 80
     assert snap.ctx_tokens == 200 + 900
 
 
@@ -154,25 +196,35 @@ def test_opencode_meter_ignores_all_zero_sentinel_rows():
     m.feed(_oc_turn([sentinel]))
     snap = m.snapshot()
     assert snap.ctx_tokens == 100 + 400
-    assert snap.total_tokens == 100 + 50 + 400
+    assert snap.input_tokens == 100 + 400
+    assert snap.output_tokens == 50
 
 
 # -- snapshot formatting -------------------------------------------------------
 
 
-def test_bar_text_formats_tokens_and_totals():
-    snap = UsageSnapshot(ctx_tokens=142_512, total_tokens=1_234_000)
-    assert snap.bar_text() == "142k ctx · 1.2M tot"
+def test_bar_text_formats_tokens_and_split():
+    snap = UsageSnapshot(ctx_tokens=142_512,
+                         input_tokens=7_600_000, output_tokens=312_000)
+    assert snap.bar_text() == "142k ctx · 7.6M↑ 312k↓"
 
 
 def test_bar_text_prefers_percent_when_known():
-    snap = UsageSnapshot(ctx_tokens=75_118, ctx_percent=29, total_tokens=75_118)
-    assert snap.bar_text() == "29% ctx · 75k tot"
+    snap = UsageSnapshot(ctx_tokens=75_118, ctx_percent=29,
+                         input_tokens=75_043, output_tokens=75)
+    assert snap.bar_text() == "29% ctx · 75k↑ 75↓"
 
 
 def test_bar_text_small_counts_stay_exact():
-    snap = UsageSnapshot(ctx_tokens=950, total_tokens=950)
-    assert snap.bar_text() == "950 ctx · 950 tot"
+    snap = UsageSnapshot(ctx_tokens=950, input_tokens=900, output_tokens=50)
+    assert snap.bar_text() == "950 ctx · 900↑ 50↓"
+
+
+def test_bar_text_shows_split_when_only_one_side_moved():
+    # first turn of a session: prompt side counted, no output yet — the
+    # pair still renders as a unit
+    snap = UsageSnapshot(ctx_tokens=950, input_tokens=950)
+    assert snap.bar_text() == "950 ctx · 950↑ 0↓"
 
 
 def test_bar_text_empty_without_data():
@@ -198,7 +250,7 @@ def test_usage_feed_tails_the_transcript_into_state(tmp_path):
     state = {"text": ""}
     feed = UsageFeed(get_adapter("claude"), _Session(), p, state)
     feed.poll()
-    assert state["text"] == "142k ctx · 142k tot"
+    assert state["text"] == "142k ctx · 142k↑ 300↓"
     _write_jsonl(p, [_claude_entry("m2", inp=2, cr=150_000, cc=0, out=1_000)])
     feed.poll()
     assert state["text"].startswith("150k ctx")


### PR DESCRIPTION
The active slot's cumulative figure becomes a pair, e.g. ` claude ● 144k ctx · 7.6M↑ 312k↓ │ codex ○   ^] flips`.

**Definition:** "input" is the whole prompt side as billed — fresh input plus cache reads and writes; output includes reasoning.

- **claude**: dedup-by-message-id map keeps a `(prompt, output)` pair so later content-block entries delta each side independently. Sidechains still count into both sides, never into ctx.
- **codex**: `total_token_usage.input_tokens/output_tokens` are cumulative and precomputed; `input_tokens` already includes `cached_input_tokens` (verified on live rollouts: `total = input + output` exactly) and reasoning is a subset of output.
- **opencode**: `input + cache.read + cache.write` vs `output + reasoning` — reasoning is its own field there but a subset of output in codex's, so folding it into ↓ makes it mean the same thing on both slots.

`UsageSnapshot` drops `total_tokens` — `bar_text` was its only consumer, and input↑ + output↓ is the old total. `↑`/`↓` are East_Asian_Width A like the bar's existing glyphs, so one cell under frame's width rule.

Suite: 663 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)