### PR TITLE
Add `tandem sessions`: list the 10 most recent paired sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Full mechanics — sync engine, crash safety, compatibility ranges:
 | `tandem` | Start a fresh paired session (Claude active; `--active codex` to flip) |
 | `Ctrl-]` | Flip to the other harness from inside a running session (rebindable in `[frame]`) |
 | `tandem resume [id]` | Continue the most recent (or a specific) session |
+| `tandem sessions` | List your 10 most recent paired sessions across directories (`-n` for more) |
 | `tandem run --on codex "…"` | One-off prompt to the *other* agent, with full context |
 | `tandem sub "…"` | Run one delegated task on a codex model (what GPT subagents use under the hood) |
 | `tandem status` | Show pairing, roles, and sync position |

--- a/src/tandem/cli.py
+++ b/src/tandem/cli.py
@@ -6,6 +6,7 @@ import json
 import re
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
@@ -275,7 +276,8 @@ def status() -> None:
 def resume(tandem_id: str | None) -> None:
     """Resume a paired session (most recent for this directory by default).
 
-    The id is printed when you leave a session, and shown by `tandem status`.
+    The id is printed when you leave a session, and shown by `tandem status`
+    and `tandem sessions`.
     """
     cwd = _cwd()
     with StateStore() as store:
@@ -303,6 +305,70 @@ def resume(tandem_id: str | None) -> None:
         store.touch_used(session.tandem_id)
         session = _narrow_participants(store, session)
     sys.exit(_enter_session(session))
+
+
+def _ago(stamp: str | None, now: datetime | None = None) -> str:
+    """Coarse relative age of an ISO timestamp: `just now`, `Nm ago`,
+    `Nh ago`, `Nd ago`. Unparseable or missing input renders as `?` —
+    a listing must never traceback on one bad row."""
+    if not stamp:
+        return "?"
+    try:
+        then = datetime.fromisoformat(stamp)
+    except (TypeError, ValueError):
+        return "?"
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    secs = max(0, int((now - then).total_seconds()))
+    if secs < 60:
+        return "just now"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    return f"{secs // 86400}d ago"
+
+
+def _short_dir(cwd: str) -> str:
+    """`~`-collapse the home prefix; tag directories that no longer exist."""
+    path = Path(cwd)
+    home = Path.home()
+    try:
+        shown = "~/" + str(path.relative_to(home)) if path != home else "~"
+    except ValueError:
+        shown = cwd
+    if not path.is_dir():
+        shown += " (missing)"
+    return shown
+
+
+@main.command()
+@click.option("-n", "--limit", default=10, show_default=True, type=click.IntRange(min=1),
+              help="How many sessions to show.")
+def sessions(limit: int) -> None:
+    """List your most recent paired sessions, newest first.
+
+    Sessions in the current directory are marked with `*`; resume any of
+    them with `tandem resume <id>` from its directory.
+    """
+    cwd = _cwd()
+    with StateStore() as store:
+        rows = store.list_sessions(limit=limit)
+    if not rows:
+        click.echo("No tandem sessions yet. Run `tandem` to start one.")
+        return
+    click.echo(f"  {'ID':<12}  {'LAST USED':<9}  {'ACTIVE':<8}  "
+               f"{'PARTICIPANTS':<22}  DIRECTORY")
+    for s in rows:
+        mark = "*" if s.cwd == cwd else " "
+        click.echo(
+            f"{mark} {s.tandem_id:<12}  {_ago(s.last_used_at or s.created_at):<9}  "
+            f"{s.active:<8}  {'+'.join(s.participants):<22}  {_short_dir(s.cwd)}"
+        )
+    click.echo()
+    click.echo("Rows marked * are in this directory. Continue one with "
+               "`tandem resume <id>` from its directory.")
 
 
 def _default_sink_factory(store, session, source, target):

--- a/src/tandem/state.py
+++ b/src/tandem/state.py
@@ -175,6 +175,18 @@ class StateStore:
         ).fetchone()
         return self._row_to_session(row) if row else None
 
+    def list_sessions(self, limit: int = 10) -> list[PairedSession]:
+        """Most recently used paired sessions across every working
+        directory, newest first (same NULL-immune ordering as
+        latest_session_for_cwd)."""
+        rows = self._conn.execute(
+            "SELECT * FROM sessions"
+            " ORDER BY COALESCE(last_used_at, created_at) DESC, created_at DESC"
+            " LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
     def touch_used(self, tandem_id: str) -> None:
         with self._conn:
             self._conn.execute(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,3 +242,106 @@ def test_run_on_nonparticipant_is_a_clean_error(homes, ok_versions, monkeypatch)
     assert r.exit_code == 1
     assert "not a participant" in r.stderr
     assert r.exception is None or isinstance(r.exception, SystemExit)
+
+
+# -- tandem sessions ---------------------------------------------------------
+
+
+def test_sessions_empty_store_hints_tandem(homes):
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions"])
+    assert r.exit_code == 0
+    assert "No tandem sessions yet" in r.output
+    assert "Run `tandem` to start one" in r.output
+
+
+def test_sessions_lists_newest_first_across_directories(homes, tmp_path):
+    other = tmp_path / "other"
+    other.mkdir()
+    s1 = _mk_session(homes, n=1)
+    s2 = _mk_session(other, active="codex", n=2)
+    s3 = _mk_session(homes, n=3)
+    with StateStore() as store:
+        store.touch_used(s1.tandem_id)
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions"])
+    assert r.exit_code == 0
+    lines = [ln for ln in r.output.splitlines() if ln.strip()]
+    rows = [ln for ln in lines if any(s.tandem_id in ln for s in (s1, s2, s3))]
+    # column 0 is the this-directory marker; the id is the first field after it
+    ids = [ln[1:].split()[0] for ln in rows]
+    assert ids == [s1.tandem_id, s3.tandem_id, s2.tandem_id]
+    by_id = dict(zip(ids, rows))
+    assert by_id[s1.tandem_id][0] == "*"
+    assert by_id[s3.tandem_id][0] == "*"
+    assert by_id[s2.tandem_id][0] == " "
+    # active harness, participants and directory are all visible
+    fields = by_id[s2.tandem_id].split()
+    assert "codex" in fields and fields.index("codex") < fields.index("claude+codex")
+    assert str(other) in by_id[s2.tandem_id]
+    assert "tandem resume" in r.output
+
+
+def test_sessions_defaults_to_ten_and_honours_limit(homes):
+    for i in range(12):
+        _mk_session(homes, n=i)
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions"])
+    assert r.exit_code == 0
+    assert sum(ln.startswith("*") for ln in r.output.splitlines()) == 10
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions", "-n", "3"])
+    assert r.exit_code == 0
+    assert sum(ln.startswith("*") for ln in r.output.splitlines()) == 3
+
+
+def test_sessions_marks_missing_directories(homes, tmp_path):
+    gone = tmp_path / "gone"
+    gone.mkdir()
+    s = _mk_session(gone, n=1)
+    gone.rmdir()
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions"])
+    row = next(ln for ln in r.output.splitlines() if s.tandem_id in ln)
+    assert "(missing)" in row
+
+
+def test_sessions_shortens_home_to_tilde(homes, monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / "work").mkdir(parents=True)
+    monkeypatch.setattr(cli.Path, "home", classmethod(lambda cls: home))
+    s = _mk_session(home / "work", n=1)
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions"])
+    row = next(ln for ln in r.output.splitlines() if s.tandem_id in ln)
+    assert "~/work" in row
+    assert str(home) not in row
+
+
+def test_sessions_shows_relative_last_used(homes):
+    from datetime import datetime, timedelta, timezone
+
+    s = _mk_session(homes, n=1)
+    last_used = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+    with StateStore() as store:
+        store._conn.execute(
+            "UPDATE sessions SET last_used_at = ? WHERE tandem_id = ?",
+            (last_used, s.tandem_id),
+        )
+        store._conn.commit()
+    r = click.testing.CliRunner().invoke(cli.main, ["sessions"])
+    row = next(ln for ln in r.output.splitlines() if s.tandem_id in ln)
+    assert "40d ago" in row
+    assert last_used not in row
+
+
+@pytest.mark.parametrize(
+    "delta_s, expected",
+    [(5, "just now"), (90, "1m ago"), (3 * 3600 + 5, "3h ago"),
+     (2 * 86400 + 3600, "2d ago"), (40 * 86400, "40d ago")],
+)
+def test_ago_buckets(delta_s, expected):
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
+    then = (now - timedelta(seconds=delta_s)).isoformat()
+    assert cli._ago(then, now=now) == expected
+
+
+def test_ago_tolerates_garbage():
+    assert cli._ago(None) == "?"
+    assert cli._ago("not-a-date") == "?"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -183,3 +183,52 @@ def test_old_schema_recreated_over_existing_backup(tmp_path):
     with StateStore(db_path=db) as store:
         assert store.get_session("old") is None
     assert (tmp_path / "s.db.old").read_bytes() != b"earlier backup"  # replaced
+
+
+def test_list_sessions_most_recent_first_across_cwds(tmp_path):
+    with make_store(tmp_path) as store:
+        s1 = store.create_session("/a", "claude", ["claude", "codex"],
+                                  {"claude": "c-1", "codex": "x-1"})
+        s2 = store.create_session("/b", "codex", ["claude", "codex"],
+                                  {"claude": "c-2", "codex": "x-2"})
+        s3 = store.create_session("/a", "claude", ["claude", "codex"],
+                                  {"claude": "c-3", "codex": "x-3"})
+        store.touch_used(s1.tandem_id)
+        ids = [s.tandem_id for s in store.list_sessions()]
+        assert ids == [s1.tandem_id, s3.tandem_id, s2.tandem_id]
+
+
+def test_list_sessions_honours_limit(tmp_path):
+    with make_store(tmp_path) as store:
+        for i in range(4):
+            store.create_session("/proj", "claude", ["claude", "codex"],
+                                 {"claude": f"c-{i}", "codex": f"x-{i}"})
+        assert len(store.list_sessions(limit=2)) == 2
+        assert len(store.list_sessions(limit=10)) == 4
+
+
+def test_list_sessions_empty_store(tmp_path):
+    with make_store(tmp_path) as store:
+        assert store.list_sessions() == []
+
+
+def test_list_sessions_is_immune_to_null_last_used(tmp_path):
+    with make_store(tmp_path) as store:
+        older = store.create_session("/proj", "claude", ["claude", "codex"],
+                                     {"claude": "c-1", "codex": "x-1"})
+        newer = store.create_session("/proj", "claude", ["claude", "codex"],
+                                     {"claude": "c-2", "codex": "x-2"})
+        store._conn.execute(
+            "UPDATE sessions SET last_used_at = ?, created_at = ?"
+            " WHERE tandem_id = ?",
+            ("2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00",
+             older.tandem_id),
+        )
+        store._conn.execute(
+            "UPDATE sessions SET last_used_at = NULL, created_at = ?"
+            " WHERE tandem_id = ?",
+            ("2026-06-01T00:00:00+00:00", newer.tandem_id),
+        )
+        store._conn.commit()
+        ids = [s.tandem_id for s in store.list_sessions()]
+        assert ids == [newer.tandem_id, older.tandem_id]


### PR DESCRIPTION
## Summary

New subcommand **`tandem sessions [-n N]`** — lists your paired sessions across every working directory, most recently used first (default 10).

```
  ID            LAST USED  ACTIVE    PARTICIPANTS            DIRECTORY
* f38253b49df3  3m ago     claude    claude+codex+opencode   ~/git/tandem
* 7d9b87fe992e  3m ago     claude    claude+codex+opencode   ~/git/tandem
  b2e6204640f8  20m ago    claude    claude+codex+opencode   ~/git/gdoc-plugin
  18be3fd6c7ee  4h ago     claude    claude+codex+opencode   /private/tmp/tandem-live-gate/proj6

Rows marked * are in this directory. Continue one with `tandem resume <id>` from its directory.
```

- `*` marks sessions belonging to the current directory (the ones `tandem resume <id>` accepts from here)
- coarse relative age (`just now` / `Nm` / `Nh` / `Nd ago`), home collapsed to `~`, `(missing)` tag when the directory is gone
- empty store → `No tandem sessions yet. Run `tandem` to start one.` (exit 0)
- `-n/--limit` (min 1) to show more/fewer

## Changes

- `src/tandem/state.py` — `StateStore.list_sessions(limit=10)`, same NULL-immune `COALESCE(last_used_at, created_at)` ordering as `latest_session_for_cwd`
- `src/tandem/cli.py` — `sessions` command + `_ago` / `_short_dir` helpers; `resume` help now also points at `tandem sessions`
- `README.md` — cheat-sheet row
- `tests/test_state.py` (+4), `tests/test_cli.py` (+13): cross-cwd ordering, limit, empty store, NULL `last_used_at`, marker column, `~` shortening, missing dir, relative time (clock-independent), `_ago` buckets + garbage input

## Review trail

Authored on claude (TDD, red→green per test), reviewed on codex (one finding: relative-time test hardcoded a date against the real clock), fix applied on opencode (timestamp now derived from `datetime.now(UTC) - 40d`), final pass on claude.

## Test plan

- [x] `uv run pytest -q` → 679 passed
- [x] `uv run tandem sessions` / `-n 3` / `--help` against the real `~/.tandem/state.db` (output above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
