### PR TITLE
fix: seed a zero-turn claude's shadow when leaving it, not only on flip-back

### DIFF
--- a/src/tandem/ops.py
+++ b/src/tandem/ops.py
@@ -117,11 +117,15 @@ def switch_session(store: StateStore, session: PairedSession,
 
     # If claude never ran, its file does not exist either: claude's CLI
     # creates the transcript on the first turn, not at launch, so a flip
-    # away from a zero-turn claude leaves its recorded id with no file and
-    # the drain below no target to append to. Seed it now — but only when
-    # tandem has never consumed a byte of it; a consumed-then-missing file
-    # is data loss, and the drain's hard error is the right answer there.
-    if new_active == "claude" and session.native_id("claude"):
+    # away from a zero-turn claude leaves its recorded id with no file. That
+    # bites whichever way this flip goes: leaving claude makes it a fileless
+    # TARGET of every other side's drain (the runner's ->claude engine and
+    # every later flip's drain refuse to start on a missing shadow), and
+    # flipping back into it leaves the drain below no file to append to.
+    # Seed it now — but only when tandem has never consumed a byte of it; a
+    # consumed-then-missing file is data loss, and the drain's hard error is
+    # the right answer there.
+    if session.native_id("claude"):
         expected = get_adapter("claude").expected_transcript_path(
             session.cwd, session.native_id("claude")
         )
@@ -130,7 +134,8 @@ def switch_session(store: StateStore, session: PairedSession,
             for t in session.targets_for("claude")
         )
         if not expected.exists() and never_ran:
-            _create_claude_shadow_late(store, session)
+            other = new_active if old_active == "claude" else old_active
+            _create_claude_shadow_late(store, session, other)
 
     drain_source(store, session, old_active, flush_dangling=True)
     fast_forward_all(store, session, new_active)
@@ -154,20 +159,23 @@ def switch_session(store: StateStore, session: PairedSession,
     return new_active, problems, memory_report
 
 
-def _create_claude_shadow_late(store: StateStore, session: PairedSession) -> None:
+def _create_claude_shadow_late(store: StateStore, session: PairedSession,
+                               other: str) -> None:
+    """Seed claude's transcript after the fact. `other` is the harness whose
+    turns will flow into it next (the side being left when claude is the
+    incoming active, the side being entered when claude is the outgoing
+    one): the ctx belongs to the (other -> claude) direction."""
     from .constants import SEED_NOTE
     from .runner import ctx_from_cursor
 
     adapter = get_adapter("claude")
-    # only ever called with new_active == "claude": the ctx belongs to the
-    # (active -> claude) direction
-    cursor = store.get_cursor(session.tandem_id, session.active, "claude")
+    cursor = store.get_cursor(session.tandem_id, other, "claude")
     ctx = ctx_from_cursor(session, cursor)
     # Any leaf uuid the cursor still holds points into the missing file;
     # the seed is the new file's root, so it must not chain onto it.
     ctx.state_for("claude")["leaf_uuid"] = None
     note = SEED_NOTE.format(
-        tandem_id=session.tandem_id, other=get_adapter(session.active).display_name
+        tandem_id=session.tandem_id, other=get_adapter(other).display_name
     )
     adapter.create_shadow_transcript(session.cwd, session.native_id("claude"), ctx, note)
     cursor.pending.setdefault("harness_state", {}).setdefault("claude", {})[

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -366,3 +366,31 @@ class TestFanOut:
         env = Env3(tmp_path, monkeypatch)          # active=claude
         new_active, _, _ = ops.switch_session(env.store, env.session)
         assert new_active == "codex"
+
+    def test_leaving_zero_turn_claude_seeds_its_shadow(self, tmp_path, monkeypatch):
+        """claude -> codex -> opencode with no claude turn. claude's CLI
+        writes its transcript on the first turn, so leaving a zero-turn
+        claude leaves its recorded id with no file. From then on claude is a
+        TARGET of every codex drain (the runner's codex->claude engine and
+        the codex->opencode flip's drain), which must not die on a missing
+        shadow: the leave-claude flip seeds it."""
+        from conftest import Env3
+        from tandem.sync import SyncEngine
+
+        env = Env3(tmp_path, monkeypatch)          # active=claude
+        env.claude_shadow.unlink()
+
+        new_active, _, _ = ops.switch_session(env.store, env.session)
+        assert new_active == "codex"
+        session = env.refresh()
+        # what the runner's codex tail thread builds next: must not raise
+        SyncEngine(env.store, session, "codex", "claude")
+
+        for obj in codex_turn("hello from codex", "Hi!"):
+            write_line(env.codex_shadow, obj)
+        new_active, problems, _ = ops.switch_session(env.store, session)
+        assert new_active == "opencode"
+        assert problems == []
+        contents = [json.dumps(e) for e in read_jsonl(env.claude_shadow)]
+        assert any("[via codex] hello from codex" in c for c in contents)
+        assert any("[via codex] Hi!" in c for c in contents)


### PR DESCRIPTION
## Bug

Pair claude-active, flip to codex before any claude turn, flip to opencode:

```
tandem: sync error: sync disabled: shadow transcript missing for claude (1dda6d8a-…)
switch failed: SyncSetupError: shadow transcript missing for claude (1dda6d8a-…)
```

## Root cause

claude's CLI writes its transcript on the **first turn**, not at launch, and pairing never seeds the active side's file. `0b271f4` seeded the missing file only when claude was the *incoming* active (flip-back). Once you leave a zero-turn claude it is a fileless *target*: `SyncEngine.__init__` hard-errors on a missing target file, so

1. the runner's tail thread dies while codex is active (all directions, incl. codex→opencode), and
2. the codex→opencode flip's `drain_source(codex)` dies building `SyncEngine(codex→claude)`.

Two-harness pairs only looked fine because the flip-back seed + catch-up drain hid it (sync was still disabled during the codex phase).

## Fix

`switch_session` seeds claude's shadow on **any** flip where claude has an id, no file, and no `claude→*` cursor has consumed bytes (consumed-then-missing still hard-errors as data loss). `_create_claude_shadow_late` takes an explicit `other` — the harness whose turns flow into claude next (`new_active` when leaving claude, `old_active` otherwise).

## Test

`TestFanOut::test_leaving_zero_turn_claude_seeds_its_shadow` reproduces the exact claude→codex→opencode sequence: failed with the exact live error before, passes after. Full suite 680 green.

Existing broken sessions heal on their next flip once this is installed (codex's backlog drains from its cursor into both claude and opencode).

Follow-up worth its own issue: the runner disables *all* sync when *one* target engine fails to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
