### PR TITLE
docs: refresh release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,164 +2,117 @@
 
 # 🤝 tandem
 
-**One coding session. Two AI agents. Zero lost context.**
+**One coding session. Multiple AI agents. Shared context.**
 
-Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code),
+Use [Claude Code](https://docs.anthropic.com/en/docs/claude-code),
 [OpenAI Codex CLI](https://github.com/openai/codex), and
-[opencode](https://opencode.ai) as a single paired session — each model
-in its own native harness. Work in any one, flip to the next with
-**Ctrl-]**, and pick up exactly where you left off. Only one model runs
-per turn; the others stay in sync through pure local translation.
+[opencode](https://opencode.ai) in one continuous coding session. Work in
+their native interfaces, press **Ctrl-]** to move to the next CLI, and
+continue without copying prompts or rebuilding context by hand.
 
 [![CI](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml/badge.svg)](https://github.com/Bhavya6187/tandem/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/tandem-cli)](https://pypi.org/project/tandem-cli/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://github.com/Bhavya6187/tandem/blob/main/pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/Bhavya6187/tandem/blob/main/LICENSE)
 
-```bash
-uv tool install tandem-cli
-```
-
-![tandem demo — one session relayed across Claude Code, Codex and opencode: Claude builds a feature, Ctrl-] hands the same conversation to Codex for review, opencode applies the fix, Claude opens and merges the PR](https://raw.githubusercontent.com/Bhavya6187/tandem/main/docs/demo.gif)
+![tandem demo — one session relayed across Claude Code, Codex and opencode](https://raw.githubusercontent.com/Bhavya6187/tandem/main/docs/demo.gif)
 
 </div>
 
----
-
 ## Quick start
 
-You'll need Python 3.11+ and at least two of the `claude`, `codex`, and
-`opencode` CLIs on your PATH (any pair works; all three make a
-three-way session).
+You need Python 3.11+ and at least two supported CLIs installed and signed
+in: [Claude Code](https://docs.anthropic.com/en/docs/claude-code),
+[Codex CLI](https://github.com/openai/codex), or
+[opencode](https://opencode.ai).
 
 ```bash
 uv tool install tandem-cli   # or: pip install tandem-cli
 cd your-project
-tandem                       # fresh paired session; drops you into claude
+tandem
 ```
 
-Work normally — that's the real Claude Code TUI. When you want the other
-model, press **Ctrl-]**: tandem closes out the harness at the turn
-boundary and reopens the same conversation in Codex a couple of seconds
-later. Press it again to come back. The bottom row tracks who you're
-facing:
+Work normally in the CLI that opens. Press **Ctrl-]** to continue the same
+session in the next CLI. If you press it while the model is working, tandem
+waits until the response finishes; press it again to cancel the switch.
 
-```
-claude ● │ codex ○   ^] flips
-```
-
-With opencode installed too, the session is three-way and **Ctrl-]**
-cycles through all of them in order:
-
-```
-claude ● │ codex ○ │ opencode ○   ^] flips
-```
-
-Pressed mid-turn, the flip arms and fires the moment the model finishes
-(the bar says so; press again to cancel).
-
-Exit the harness the usual way and you're back at your shell, with the
-session saved and a hint for picking it up again:
-
-```
-to continue this session: tandem resume a1b2c3d4e5f6
-```
-
-Come back anytime:
+Exit normally when you're done. Come back later with:
 
 ```bash
-tandem resume                # most recent session in this directory
-tandem resume a1b2c3d4e5f6   # a specific one (id from the exit hint)
+tandem resume      # resume the latest session in this directory
+tandem sessions    # find recent sessions across directories
 ```
+
+By default, tandem opens the first usable CLI in your configured order. Use
+`tandem --active codex` or `tandem --active opencode` to choose another.
 
 ## Why tandem?
 
-### 🖥️ One CLI, two harnesses, zero ceremony.
+- **Keep going when a model hits its limit.** Move to another CLI and
+  continue with the same files and conversation history.
+- **Bring different models to the same problem.** Ask another CLI for a
+  second opinion without copying a wall of context between terminals.
+- **Keep the native tools you already use.** Claude Code, Codex, and
+  opencode retain their own interfaces, commands, keybindings, and MCP
+  servers.
+- **Work through a single-provider outage.** If another configured CLI is
+  available, switch and continue until the affected provider recovers.
 
-`tandem` is the terminal you live in. It fronts the real Claude Code or
-Codex TUI — pixel-for-pixel native — and **Ctrl-]** flips to the other
-one in a couple of seconds, same conversation, same files, same history.
-A one-line tab bar on the bottom row shows which model you're facing;
-everything above it is the untouched native UI.
-
-### 🆕 0.2 — GPT subagents inside Claude Code
-
-Type "get the code reviewed by gpt" and tandem's plugin hands the task
-to a local codex worker; the verdict lands back in your Claude session,
-and your Claude quota stays on the main thread. Pin any model your
-codex account offers ("ask sol to review it") or set a cheap default
-once. Setup and routing:
+Want GPT subagents inside Claude Code too? See the
 [GPT subagents guide](https://github.com/Bhavya6187/tandem/blob/main/docs/subagents.md).
-
-### ⏳ Hit a usage limit? Just keep going.
-
-Claude runs out of its usage window mid-refactor? Press **Ctrl-]** and
-Codex continues the **same conversation** a second later — same files,
-same history, same plan. Two subscriptions become one long runway.
-
-### 🌩️ Immune to outages.
-
-An Anthropic or OpenAI outage doesn't stop your work: **Ctrl-]**, keep
-going in the other harness, and flip back whenever it clears.
-
-Five more reasons — subscriptions not API bills, two model families on
-one problem, native harnesses, instant switching, privacy:
-[Why tandem?](https://github.com/Bhavya6187/tandem/blob/main/docs/why.md)
+For more use cases, see
+[Why tandem?](https://github.com/Bhavya6187/tandem/blob/main/docs/why.md).
 
 ## How it works
 
-- Only one model runs per turn — the other side is never invoked to
-  "catch up".
-- As you work, tandem translates the growing transcript into the other
-  CLI's native session format — pure local file I/O, no model calls —
-  so the other side is always resume-ready.
-- Each CLI is the real thing running on a PTY: your keybindings, slash
-  commands, and MCP servers all work exactly as they do today — tandem
-  reserves exactly one key (Ctrl-]) and one terminal row (the tab bar).
-- A flip waits for the turn boundary, exits the fronted CLI gracefully,
-  lets the sync settle, and resumes the other side — no stop in
-  between.
-- Everything stays local: the CLIs' own session files plus a small
-  SQLite database in `~/.tandem`. No cloud sync, no telemetry.
-- Uninstall tandem tomorrow and every side still resumes natively with
-  `claude --resume`, `codex resume`, and `opencode -s`.
+```text
+┌──────────────────────────────────────────────┐
+│ Work normally in a native coding CLI         │
+└──────────────────────┬───────────────────────┘
+                       ▼
+┌──────────────────────────────────────────────┐
+│ tandem keeps the other sessions in sync      │
+│ locally — without calling another model      │
+└──────────────────────┬───────────────────────┘
+                       ▼
+┌──────────────────────────────────────────────┐
+│ Press Ctrl-] and continue in the next CLI    │
+└──────────────────────────────────────────────┘
+```
 
-Full mechanics — sync engine, crash safety, compatibility ranges:
-[How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md).
+Only the active model runs. tandem translates its growing conversation into
+the other CLIs' native session formats using local file access, so they are
+ready when you switch. Your session stays in the CLIs' own storage plus a
+small local database in `~/.tandem`; tandem adds no cloud sync or telemetry.
 
-## Command cheat sheet
+See [How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md)
+for transcript translation, switching, crash safety, compatibility, and data
+locations.
+
+## Everyday commands
 
 | Command | What it does |
 | --- | --- |
-| `tandem` | Start a fresh paired session (Claude active; `--active codex` to flip) |
-| `Ctrl-]` | Flip to the other harness from inside a running session (rebindable in `[frame]`) |
-| `tandem resume [id]` | Continue the most recent (or a specific) session |
-| `tandem sessions` | List your 10 most recent paired sessions across directories (`-n` for more) |
-| `tandem run --on codex "…"` | One-off prompt to the *other* agent, with full context |
-| `tandem sub "…"` | Run one delegated task on a codex model (what GPT subagents use under the hood) |
-| `tandem status` | Show pairing, roles, and sync position |
-| `tandem plugin install` | Install the Claude Code plugin (also offered on first `tandem` launch) |
+| `tandem` | Start a new session |
+| `Ctrl-]` | Continue in the next CLI |
+| `tandem resume [id]` | Resume the latest or a specific session in this directory |
+| `tandem sessions [-n N]` | List recent sessions across directories |
+| `tandem run --on codex "…"` | Send one contextual prompt to another CLI (`claude`, `codex`, or `opencode`) |
 
-Three maintenance commands round it out: `tandem doctor` (health
-check), `tandem sync` (manual catch-up translation), and `tandem
-sync-mcp` (share MCP server configs between the tools).
+## Learn more
 
-## Docs
-
-- [GPT subagents](https://github.com/Bhavya6187/tandem/blob/main/docs/subagents.md) —
-  plugin install, worker model, routing modes, sandbox & trust boundary
 - [Why tandem?](https://github.com/Bhavya6187/tandem/blob/main/docs/why.md) —
-  the full pitch, all eight reasons
+  use cases, subscriptions, native tools, token visibility, and privacy
+- [GPT subagents](https://github.com/Bhavya6187/tandem/blob/main/docs/subagents.md) —
+  plugin setup, worker models, routing, and sandboxing
 - [Configuration](https://github.com/Bhavya6187/tandem/blob/main/docs/configuration.md) —
-  the optional `~/.tandem/config.toml`: subagent workers, per-harness
-  startup args, the flip key and tab bar
+  participants, startup arguments, the switch key, and the status bar
 - [How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md) —
-  sync engine, PTY passthrough, compatibility, where your data lives
+  synchronization, switching, compatibility, and local data
 - [Developing tandem](https://github.com/Bhavya6187/tandem/blob/main/docs/development.md) —
-  dev setup and the converter adapter interface
+  development setup and the harness adapter interface
 - [Observed session formats](https://github.com/Bhavya6187/tandem/blob/main/docs/formats.md) —
-  the claude/codex/opencode session-storage details tandem is pinned
-  against
+  Claude Code, Codex, and opencode storage formats
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,32 @@
 # Configuration
 
 tandem reads one optional file: `~/.tandem/config.toml`. No file is
-required; every key has a working default. (Back to the
+required; every key has a working default, and a malformed value falls
+back to it rather than failing a launch. (Back to the
 [README](../README.md).)
+
+## harnesses — who participates, and in what order
+
+A top-level list naming the harnesses a fresh session may include, in
+flip-cycle order. Default: all three, claude first.
+
+```toml
+harnesses = ["claude", "codex", "opencode"]
+```
+
+Naming a harness here is an *intent*, not a requirement: a fresh
+`tandem` session pairs the listed harnesses that are actually installed
+and usable — not-installed ones are skipped silently, ones that are
+installed but unusable warn and drop out, and fewer than two usable is
+an error that prints the install command for each missing CLI. The
+order sets both the **Ctrl-]** cycle and the default starting harness
+(`tandem` enters the first usable one; `--active` overrides that per
+launch).
+Leave a harness off the list to keep it out of new sessions even though
+it's installed — `harnesses = ["claude", "codex"]` gives two-way
+sessions on a machine that also has opencode. Unknown names are
+dropped, duplicates deduped, and anything else malformed falls back to
+all three. Sessions already paired keep their own participant list.
 
 ## [subagents] — GPT subagent workers
 
@@ -18,11 +42,11 @@ context = "match"       # match | task | full
 keep_forks = false      # keep each worker's rollout for debugging
 ```
 
-## [claude] / [codex] — per-harness startup args
+## [claude] / [codex] / [opencode] — per-harness startup args
 
 Optional per-harness tables add flags to every interactive session tandem
-opens (`tandem`, `tandem resume`) — one-off relays (`tandem run`),
-subagent dispatch, and doctor probes are unaffected:
+opens (`tandem`, `tandem resume`, and each flip) — one-off relays
+(`tandem run`), subagent dispatch, and doctor probes are unaffected:
 
 ```toml
 [claude]
@@ -30,10 +54,14 @@ args = ["--dangerously-skip-permissions"]
 
 [codex]
 args = ["--dangerously-bypass-approvals-and-sandbox"]
+
+[opencode]
+args = []   # same mechanism; opencode's own flags go here
 ```
 
-The flags shown disable the harnesses' own permission prompts for
-sessions tandem launches — set them only if that is what you want.
+The claude/codex flags shown disable the harnesses' own permission
+prompts for sessions tandem launches — set them only if that is what you
+want.
 The list is passed to the harness raw: a flag that expects a value can
 swallow the settings tandem appends after it and break turn tracking.
 Malformed values (a non-list, empty or non-string elements) are
@@ -42,8 +70,9 @@ silently ignored rather than failing the launch.
 ## [frame] — the flip key, the tab bar, and warm flips
 
 The frame is tandem's own surface inside a running session: one reserved
-keybind that flips to the other harness, the one-line tab bar on the
-bottom terminal row, and the pipelined boot behind the flip.
+keybind that flips to the next harness in the cycle, the one-line tab
+bar on the bottom terminal row (participants, flip key, and the active
+model's live token stats), and the pipelined boot behind the flip.
 
 ```toml
 [frame]
@@ -55,8 +84,8 @@ warm = true   # boot the incoming harness while the outgoing one shuts down
 | key | default | meaning |
 | --- | --- | --- |
 | `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). The bar relabels itself to match (`ctrl-t` shows `^T flips`). |
-| `bar` | `true` | The one-line tab bar on the bottom terminal row. `false` hides it; the flip still works. |
-| `warm` | `true` | Overlap the two halves of a flip: the incoming harness starts booting the moment the flip fires (a mid-turn press waits for the turn boundary first), while the outgoing one is still shutting down. `false` gives fully serial flips — the boot only begins once the old harness is gone. |
+| `bar` | `true` | The one-line tab bar on the bottom terminal row, including the active slot's token stats. `false` hides it; the flip still works. |
+| `warm` | `true` | Overlap the two halves of a flip: the incoming harness starts booting the moment the flip fires (a mid-turn press waits for the turn boundary first), while the outgoing one is still shutting down. `false` gives fully serial flips — the boot only begins once the old harness is gone. Flips *into* opencode are always serial (its TUI must open after the last turn has landed in its database). |
 
 An unparseable value falls back to the default rather than failing the
 launch. If a terminal can't sustain the bar, tandem drops it for the rest
@@ -75,3 +104,11 @@ speed instead of that plus the shutdown. Nothing exists before you press
 the key and nothing survives the flip — between flips a tandem session is
 exactly one harness process. `warm = false` restores the fully serial
 flip, which is slower but does the same thing.
+
+## Environment variables
+
+Not config keys, but honored everywhere: `TANDEM_HOME` relocates
+tandem's own state (`state.db`, config, quarantine, subagent logs) from
+`~/.tandem`; the harnesses' own overrides — `CLAUDE_CONFIG_DIR`,
+`CODEX_HOME`, `OPENCODE_DB` — are respected when tandem looks for their
+session stores.

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,87 @@
 Dev setup and the extension surface. (Back to the
 [README](../README.md).)
 
+## Development
+
+```bash
+uv sync && uv run pytest
+uv tool install .     # or: pipx install .
+```
+
+Dependencies are deliberately small: `click` (CLI), `pydantic` v2 (event
+schema), `watchdog` (transcript tailing), `pexpect`/ptyprocess (PTY
+passthrough); state is stdlib `sqlite3`.
+
+The suite is hermetic — no harness binaries needed — except
+`tests/test_opencode_oracle.py`, which round-trips through a real
+`opencode` binary against a throwaway database (`OPENCODE_DB`) and skips
+itself when the binary is absent. Two guards worth knowing about:
+`plugin/.claude-plugin/plugin.json`'s `version` must match
+`pyproject.toml` (a drift test fails otherwise — see the
+[plugin README](../plugin/README.md) for why), and CI installs with
+`uv sync --locked`, so a version bump needs `uv lock` in the same
+commit.
+
+## Layout
+
+- `src/tandem/cli.py` — every subcommand; `_resolve_participants` is the
+  one place that decides which harnesses a session gets.
+- `src/tandem/harness/` — one adapter module per CLI (`claude_code.py`,
+  `codex.py`, `opencode.py`) behind `base.HarnessAdapter`; **all**
+  session-format knowledge lives here, so a format change in one tool
+  touches one file. `docs/formats.md` records what each adapter was
+  built against.
+- `src/tandem/sync.py`, `runner.py`, `tailer.py` — the sync engine: one
+  tail loop per (source → target) direction, append-only with a
+  write-ahead intent in the cursor.
+- `src/tandem/events.py`, `converter.py`, `toolmap.py` — the normalized
+  event model, the reference converter, and native tool-call mapping.
+- `src/tandem/flip.py`, `frame.py`, `ptyrun.py`, `warm.py` — the frame:
+  PTY passthrough, the flip key and ladder, the tab bar, pipelined boots.
+- `src/tandem/hookroute.py`, `modelcat.py`, `pinstash.py`,
+  `plugin_setup.py` — GPT subagents: the Claude Code hook, model-name
+  resolution, and plugin install.
+- `src/tandem/state.py`, `compat.py`, `config.py`, `doctor.py` — the
+  SQLite state store, pinned version ranges, `config.toml`, health checks.
+
 ## Extending tandem
+
+### Adding a harness
+
+Every CLI tandem fronts is one `HarnessAdapter` subclass in
+`src/tandem/harness/`, registered in `harness/__init__.py`'s `ADAPTERS`
+and named in `config.SUPPORTED_HARNESSES` and `compat.COMPAT`. The base
+class in `harness/base.py` is the contract; the pieces an adapter
+provides:
+
+- **Detection and readiness** — `detect_version`, `version_supported`
+  (against its `compat.COMPAT` range), `runtime_ready` (fail closed:
+  installed but unusable drops out of the session with a reason), and
+  an `install_hint` for the "fewer than two harnesses" error.
+- **Session identity and storage** — `mint_session_id`,
+  `transcript_path`, `create_shadow_transcript` (how a resume-ready
+  shadow is born), plus the storage-capability hooks that default to
+  file-backed JSONL and that opencode overrides for SQLite:
+  `make_source_reader`, `watch_paths`, `shadow_append` /
+  `shadow_intent` / `intent_landed`, `fast_forward_cursor`,
+  `pending_units`, `prepare_shadow`.
+- **Launch** — `interactive_argv`, `oneoff_argv`, `hook_argv_extra`
+  (the per-invocation turn-complete signal, if the CLI has one),
+  `quit_keystrokes` (the graceful half of the exit ladder), and
+  `session_status` when the CLI can answer "is a turn running?" — that
+  is what lets a mid-turn flip fire at the boundary.
+- **Translation** — `parse_entry` (native record → normalized events)
+  and `render_events` / `render_placeholder` (normalized events → native
+  records), with `toolmap` optionally given a Tier-1 table so common tool
+  calls read as the harness's own; without one, calls pass through
+  verbatim.
+- **Cosmetics** — `make_usage_meter` for the tab bar's token stats.
+
+`tests/` has per-adapter fixtures; an oracle test against the real binary
+(like the opencode one) is the strongest check that shadow sessions
+actually resume.
+
+### Swapping the converter
 
 The sync engine talks to a small adapter interface
 (`tandem.converter.TraceConverter`):
@@ -15,15 +95,4 @@ class TraceConverter(Protocol):
 
 `ReferenceConverter` implements it via a normalized event model
 (`tandem/events.py`) derived from the observed formats. Pass your own
-converter to `SyncEngine(store, session, source, converter=...)`.
-
-## Development
-
-```bash
-uv sync && uv run pytest
-pipx install .        # or: uv tool install .
-```
-
-Dependencies are deliberately small: `click` (CLI), `pydantic` v2 (event
-schema), `watchdog` (transcript tailing), `pexpect`/ptyprocess (PTY
-passthrough); state is stdlib `sqlite3`.
+converter to `SyncEngine(store, session, source, target, converter=...)`.

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,16 +1,17 @@
 # Observed session formats
 
-Everything tandem knows about the two native session formats was observed on
-this machine by creating throwaway sessions and reading the files the CLIs
-wrote. Versions observed:
+Everything tandem knows about the three native session formats was observed
+on this machine by creating throwaway sessions and reading the files (or
+database) the CLIs wrote. Versions observed:
 
 | CLI | version | session storage |
 | --- | --- | --- |
 | Claude Code (`claude`) | 2.1.220 | `~/.claude/projects/<munged-cwd>/<sessionId>.jsonl` |
 | Codex CLI (`codex`) | 0.145.0 | `~/.codex/sessions/YYYY/MM/DD/rollout-<YYYY-MM-DDThh-mm-ss>-<uuidv7>.jsonl` |
+| opencode (`opencode`) | 1.18.15 | one SQLite database, the path `opencode db path` prints (see below) |
 
 Env overrides honored: `CLAUDE_CONFIG_DIR` (claude home), `CODEX_HOME` (codex
-home), `TANDEM_HOME` (tandem state).
+home), `OPENCODE_DB` (opencode database), `TANDEM_HOME` (tandem state).
 
 ## Claude Code transcript (claude 2.1.220)
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,26 +1,42 @@
 # How tandem works
 
-The mechanics behind the pairing: sync engine, PTY passthrough,
-compatibility ranges, and where your data lives. (Back to the
+The mechanics behind the pairing: sync engine, PTY passthrough, the
+flip, compatibility ranges, and where your data lives. (Back to the
 [README](../README.md).)
 
 - **One model per command — always.** Only the active harness's model is
-  ever invoked (or, for `run --on`, the target's). The shadow side is pure
-  local file I/O: tandem tails the active transcript, translates each
-  entry, and appends it to the shadow's session file. The shadow's model
-  is never called to "catch up".
+  ever invoked (or, for `run --on`, the target's). Every shadow side is
+  pure local file I/O: tandem tails the active transcript, translates
+  each entry, and appends it to each shadow's own session store. A
+  shadow's model is never called to "catch up".
+- **Two, or three, participants.** A session's participants are the
+  harnesses that were installed and usable when it was paired — any two
+  of `claude`, `codex`, `opencode`, or all three (the order, and so the
+  flip cycle, is configurable; see the `harnesses` key in
+  [Configuration](configuration.md)). Not installed is a silent skip;
+  installed but unusable — below the compatibility floor, or its runtime
+  isn't ready — warns and drops out; fewer than two usable is an error
+  that names what's missing and how to install it. On `tandem resume`, a
+  member that has since become unusable is dropped from that session for
+  good (the first survivor takes over if it was the active one); there is
+  no dynamic rejoin. Sync fans out per direction: with three
+  participants, each turn on the active side is translated twice, once
+  into each shadow.
 - **Exit means exit.** Leaving the harness — as opposed to flipping out
   of it — prints the resume hint and returns you to your OS shell; the
-  paired session is saved and `tandem resume` re-enters it.
+  paired session is saved and `tandem resume` re-enters it (`tandem
+  sessions` lists recent ones across directories).
   `status` / `sync` / `doctor` / `run --on` / `sync-mcp` run one-shot
   from your shell, targeting the directory's most recently used session.
 - **The frame: flip without leaving.** Ctrl-] (configurable, consumed at
   the PTY layer, ignored inside bracketed paste) flips the screen to the
-  other harness: pressed mid-turn it arms and fires at the turn boundary
-  (press again to cancel — the bar shows the armed state), then
-  tandem exits the fronted CLI gracefully (quit keystrokes, then SIGTERM,
-  then a bounded SIGKILL), lets the incremental sync settle, flips roles,
-  and resumes the other side — with no stop in between.
+  next harness in the cycle: pressed mid-turn it arms and fires at the
+  turn boundary (press again to cancel — the bar shows the armed state),
+  then tandem exits the fronted CLI gracefully (quit keystrokes, then
+  SIGTERM, then a bounded SIGKILL), lets the incremental sync settle,
+  rotates roles, and resumes the next side — with no stop in between. If
+  the next harness refuses to come up, the ladder tries the one after it,
+  and falls back to the one you left as a last resort.
   With claude fronted, the boundary comes from claude's own session
   registry (`~/.claude/sessions/<pid>.json`, the data `claude agents
   --json` prints): `busy` holds the flip, anything else fires it — so an
@@ -29,53 +45,80 @@ compatibility ranges, and where your data lives. (Back to the
   (The registry appeared in claude 2.1.226; on older claudes the probe
   finds nothing and every armed flip fires at once, mid-turn included —
   the deliberate single-tier trade: no silent valve, breakage is loud.)
-  With codex fronted the
+  With opencode fronted, the boundary is read from its session database:
+  busy while the last message is a user prompt or a still-streaming
+  assistant, otherwise the flip fires. With codex fronted the
   transcript-marker rules stand: where no marker could be wired (codex
   with a `notify` handler of your own, which tandem won't clobber) ~2s of
   transcript quiescence stands in; where one was wired, a 120s valve
   covers a marker that never arrives — far above any plausible tool-call
   silence, because firing early kills a live turn while firing late only
-  costs a wait (and Ctrl-] cancels). The
-  bottom terminal row is tandem's one drawn pixel: the child is told the
-  terminal is a row shorter, a scroll region keeps output above the bar,
-  and a targeted watcher reasserts it after child screen resets. If a
-  terminal can't sustain the bar it drops for the session (the flip keeps
-  working) and `tandem doctor` says so until you delete the marker file it
-  names; shrinking the window below the bar's row floor drops it just as
-  permanently, but silently — that one isn't a conflict to fix.
+  costs a wait (and Ctrl-] cancels).
+- **Pipelined flips.** The moment a flip fires, the incoming harness
+  starts booting *while* the outgoing one is torn down, so the flip lands
+  at about the incoming harness's own start-up speed rather than that
+  plus the shutdown. Nothing exists before you press the key and nothing
+  survives the flip — between flips a tandem session is exactly one
+  harness process. Flips *into* opencode run serially: its TUI caches the
+  session on boot, so it must open only after the last turn has landed
+  in its database. `[frame] warm = false` makes every flip serial.
+- **The tab bar.** The bottom terminal row is tandem's one drawn pixel:
+  the child is told the terminal is a row shorter, a scroll region keeps
+  output above the bar, and a targeted watcher reasserts it after child
+  screen resets. It names every participant (● active, ○ shadow), the
+  flip key, and — on the active slot — live token accounting read from
+  the transcript as it grows: the model's current context (`144k ctx`, or
+  `43% ctx` for codex, which reports its window) and the session's
+  input↑ / output↓ totals, where input is the whole prompt side as billed
+  (fresh input plus cache reads and writes) and output includes
+  reasoning. Stats are cosmetic — any failure there disables them for the
+  session and never touches sync — and they're the first thing elided
+  when the row is too narrow. If a terminal can't sustain the bar it drops
+  for the session (the flip keeps working) and `tandem doctor` says so
+  until you delete the marker file it names; shrinking the window below
+  the bar's row floor drops it just as permanently, but silently — that
+  one isn't a conflict to fix.
 - **PTY passthrough.** tandem launches the real CLI on a pty (raw mode,
   resize forwarding, signals through the line discipline) and never
   scrapes terminal output — the transcript files are the source of truth.
   Turn-complete hooks (`claude --settings` Stop hook, `codex -c
   notify=[…]`) are wired per-invocation as wake-up signals, with
-  fs-watching as the data path and fallback. If your codex config already
-  sets `notify`, tandem leaves it alone.
+  fs-watching as the data path and fallback (opencode has no per-invocation
+  hook; tandem watches its database's WAL file). If your codex config
+  already sets `notify`, tandem leaves it alone.
 - **Append-only, crash-safe sync.** Each transcript entry is translated as
-  it lands — no bulk re-export at switch time. Appends are whole-line +
-  fsync, and a write-ahead intent in the sync cursor makes translation
-  exactly-once across crashes; on restart, sync resumes from the last
-  confirmed entry.
+  it lands — no bulk re-export at switch time. JSONL appends are
+  whole-line + fsync, opencode rows land in one transaction per synced
+  unit with pre-minted ids, and a write-ahead intent in the sync cursor
+  makes translation exactly-once across crashes; on restart, sync resumes
+  from the last confirmed entry.
 - **Tool calls translate natively.** The harnesses speak different tool
-  vocabularies, so each completed call+result pair is re-expressed in the
-  shadow's own terms — `Bash` ↔ `exec_command`, `Edit`/`Write` ↔
-  `apply_patch`, `TodoWrite` ↔ `update_plan` — and lands as a real
-  tool-call record, so shadow history reads as the shadow's own work.
-  Anything that wouldn't map truthfully passes through verbatim; a call
-  whose result never arrived is closed with a `(tool result not recorded)`
-  placeholder at handoff, since both replay APIs reject dangling calls.
+  vocabularies, so between claude and codex each completed call+result
+  pair is re-expressed in the shadow's own terms — `Bash` ↔
+  `exec_command`, `Edit`/`Write` ↔ `apply_patch`, `TodoWrite` ↔
+  `update_plan` — and lands as a real tool-call record, so shadow history
+  reads as the shadow's own work. Anything that wouldn't map truthfully
+  passes through verbatim (name, arguments, and result intact), which is
+  also how every call reaches opencode today; a call whose result never
+  arrived is closed with a `(tool result not recorded)` placeholder at
+  handoff, since the replay APIs reject dangling calls.
 - **Attribution stays legible.** Every synced *text* message is tagged
-  `[via claude-code]` / `[via codex]` (tandem's own notes use `[tandem]`),
-  so interleaved histories make sense to you and to the models. Tool
-  activity is untagged — it's mirrored as native records, not prose.
+  `[via claude-code]` / `[via codex]` / `[via opencode]` (tandem's own
+  notes use `[tandem]`), so interleaved histories make sense to you and to
+  the models. Tool activity is untagged — it's mirrored as native records,
+  not prose. Rows tandem writes into opencode carry `providerID: "tandem"`,
+  so opencode renders them as synced history rather than as its own model's
+  output.
 - **Errors are contained.** An entry that fails translation becomes a
   single per-turn placeholder in the shadow, with the raw entry
   quarantined under `~/.tandem/quarantine/…` — and sync continues. The
   shadow is never corrupted or truncated.
-- **Memory files stay in step.** Fresh launches and every switch sync
-  CLAUDE.md ↔ AGENTS.md: shared content lives in a
-  `<!-- tandem:shared:begin/end -->` block (newer file wins),
-  tool-specific text outside the block is preserved, and a file without
-  markers is read from but never rewritten. Git state is never touched.
+- **Memory files stay in step.** Fresh launches and every flip sync
+  CLAUDE.md ↔ AGENTS.md (codex and opencode both read AGENTS.md): shared
+  content lives in a `<!-- tandem:shared:begin/end -->` block (newer file
+  wins), tool-specific text outside the block is preserved, and a file
+  without markers is read from but never rewritten. Git state is never
+  touched.
 
 ## Compatibility
 
@@ -87,20 +130,32 @@ tandem pins what it was built against (observed formats documented in
 | --- | --- | --- |
 | Claude Code | 2.1.220 | ≥ 2.0, < 3 |
 | Codex CLI | 0.145.0 | ≥ 0.140, < 0.150 |
+| opencode | 1.18.15 | ≥ 1.18 (no ceiling) |
 
-Outside the range, tandem warns and asks you to run `tandem doctor`.
-Format knowledge is isolated per tool in
-`src/tandem/harness/claude_code.py` and `src/tandem/harness/codex.py`.
+Above a range's ceiling, tandem warns and asks you to run `tandem doctor`
+before trusting sync; below the floor the harness is excluded from the
+session (the format genuinely predates what tandem was built on).
+opencode has a floor only, because pre-1.18 opencode predates its SQLite
+session storage. Format knowledge is isolated per tool in
+`src/tandem/harness/claude_code.py`, `src/tandem/harness/codex.py`, and
+`src/tandem/harness/opencode.py`.
 
 ## Where your data lives
 
-- `~/.tandem/state.db` — SQLite: session pairing + per-source sync cursors
-  (override the directory with `TANDEM_HOME`)
+- `~/.tandem/state.db` — SQLite: session pairing (participants, native
+  session ids, active side) + per-direction sync cursors (override the
+  directory with `TANDEM_HOME`)
 - `~/.tandem/quarantine/<session>/` — raw entries that failed translation
+- `~/.tandem/subagents/<session>/` — GPT subagent worker logs and any
+  retained forks
 - `~/.claude/projects/<munged-cwd>/<session-id>.jsonl` — claude transcript
+  (`CLAUDE_CONFIG_DIR` honored)
 - `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<session-id>.jsonl` — codex
-  rollout (`CLAUDE_CONFIG_DIR` / `CODEX_HOME` honored)
+  rollout (`CODEX_HOME` honored)
+- opencode's own SQLite database — the path `opencode db path` prints
+  (`OPENCODE_DB` honored); tandem's session rows live alongside opencode's
 
 Claude session ids are minted by tandem (`claude --session-id`); codex
 mints its own on first run and tandem captures it from the new rollout
-file.
+file; opencode sessions are born through `opencode import`, so they exist
+before `opencode -s <id>` is ever asked to open them.

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -127,6 +127,13 @@ remove tandem` to also unregister the marketplace.
 Hacking on the plugin itself? Skip the marketplace and point Claude at your
 clone: `claude --plugin-dir /path/to/tandem/plugin`.
 
-Startup flags for the harnesses themselves (`[claude]` / `[codex]` args)
-are not a subagent setting; they live in the
+The worker is always codex, so the `codex` CLI must be installed and
+signed in, but codex needn't be one of the session's participants: the
+default task-only worker starts cold from a fresh seed, so a
+claude+opencode pair dispatches just fine. Only `context = "full"` forks
+the session's codex shadow, and that history exists when codex is a
+participant.
+
+Startup flags for the harnesses themselves (`[claude]` / `[codex]` /
+`[opencode]` args) are not a subagent setting; they live in the
 [configuration reference](configuration.md).

--- a/docs/why.md
+++ b/docs/why.md
@@ -4,6 +4,26 @@ The full pitch — every reason the [README](../README.md) doesn't have
 room for. Quick start and commands live there; the mechanics live in
 [How tandem works](how-it-works.md).
 
+## 🖥️ One CLI, three harnesses, zero ceremony.
+
+`tandem` is the terminal you live in. It fronts the native Claude Code,
+Codex CLI, or opencode interface, adding one status row and the **Ctrl-]**
+switch shortcut. Move the session to the next one and keep the same
+conversation, files, and history.
+
+## ⏳ Hit a usage limit? Just keep going.
+
+Claude runs out of its usage window mid-refactor? Press **Ctrl-]** and
+continue the **same conversation** in Codex when it is ready — same files,
+same history, same plan. Your subscriptions become one long runway
+instead of separate walls.
+
+## 🌩️ Keep working through a provider outage.
+
+If the active model's provider goes down and another configured CLI is
+available, press **Ctrl-]** and continue the same session there. Switch
+back after the outage clears.
+
 ## 🐣 Other model families, inside Claude Code
 
 Claude Code dispatches subagents on Claude models only. tandem's plugin
@@ -15,55 +35,55 @@ orchestrates; codex does the legwork; your Claude quota stays on the
 main thread. Setup and routing modes:
 [GPT subagents guide](subagents.md).
 
-## ⏳ Hit a usage limit? Just keep going.
+## 💳 Use your existing authentication and billing.
 
-Claude runs out of its usage window mid-refactor? Press **Ctrl-]** and
-Codex continues the **same conversation** a second later — same files,
-same history, same plan. Your two subscriptions become one long runway
-instead of two separate walls.
+tandem uses the authentication and billing already configured in each CLI.
+It adds no API keys, model charges, or billing layer of its own. Every model
+call happens inside the real CLI; tandem itself makes **zero network
+calls**.
 
-## 🌩️ Immune to outages.
+## 🧠 Every model on one problem.
 
-An Anthropic or OpenAI outage doesn't stop your work. If the active
-model's API goes down, press **Ctrl-]** — the same session continues
-seamlessly in the other harness, and you can flip back whenever the
-outage clears.
-
-## 💳 Subscriptions, not API bills.
-
-tandem wraps the official CLIs under the auth you already have — your
-Claude and ChatGPT subscription logins work as-is. No API keys to
-provision, no per-token surprises. tandem itself makes **zero network
-calls**; every model call happens inside the real CLI, on your existing
-plan.
-
-## 🧠 Two model families on one problem.
-
-Claude and GPT have different strengths and different blind spots. Get a
-second opinion **with full session context** — no copy-pasting walls of
-text between terminals:
+Claude, GPT, and whatever opencode is pointed at have different
+strengths and different blind spots. Get a second opinion **with full
+session context** — no copy-pasting walls of text between terminals:
 
 ```bash
 tandem run --on codex "second opinion: why is this test flaky?"
+tandem run --on opencode "review the diff and list anything risky"
 ```
 
 ## 🏠 Every model in its native harness.
 
 This is not a lowest-common-denominator wrapper UI. Claude runs in real
-Claude Code; GPT runs in real Codex CLI. Your keybindings, slash commands,
-MCP servers, and muscle memory all work exactly as they do today — tandem
-sits underneath, not in between.
+Claude Code; GPT runs in real Codex CLI; opencode runs in real opencode.
+Your keybindings, slash commands, MCP servers, and muscle memory all
+work exactly as they do today — tandem sits underneath, not in between.
 
-## ⚡ Switching is instant.
+## ⚡ Switch without a manual handoff.
 
-While one agent is active, tandem quietly keeps the other one's native
+While one agent is active, tandem quietly keeps every other one's native
 session file up to date by translating the transcript as it grows — pure
-local file I/O, no model calls, no "exporting…" step. The other side is
-*always* resume-ready.
+local file I/O, no model calls, no "exporting…" step. The other sessions
+stay ready to resume, and a flip pipelines the handover: the
+incoming harness boots while the outgoing one is still shutting down
+(flips *into* opencode run serially, since its TUI must open after the
+last turn has landed in its database).
+
+## 🧮 Know what you're spending.
+
+The tab bar's active slot shows the model's live context (`144k ctx`, or
+`43% ctx` where the harness reports its window) and the session's
+input↑ / output↓ token totals — read straight from the transcript,
+updated as you work, no extra calls:
+
+```
+ claude ● 144k ctx · 7.6M↑ 312k↓ │ codex ○ │ opencode ○   ^] flips
+```
 
 ## 🔒 Local, private, no lock-in.
 
 Everything lives in the CLIs' own session files plus a small SQLite
 database in `~/.tandem`. No cloud sync, no telemetry. Uninstall tandem
-tomorrow and both sessions still resume natively with `claude --resume`
-and `codex resume`.
+tomorrow and every session still resumes natively with `claude --resume`,
+`codex resume`, and `opencode -s`.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,19 +1,31 @@
 # tandem's Claude Code plugin
 
-Lets Claude Code dispatch subagents to GPT models: in a tandem-paired
-session, "ask gpt to review this migration" runs the task on a local
-codex worker and the result comes back like any subagent's.
+Lets Claude Code dispatch subagents to GPT models. In a tandem-paired
+session, "ask gpt to review this migration" runs the task on a local codex
+worker — with the brief forwarded verbatim — and the result comes back
+like any subagent's. Name a model ("ask sol to review it") to pin the
+worker to it; set `route = "all"` to reroute every dispatch without
+asking. Claude orchestrates, codex does the legwork, and your Claude
+quota stays on the main thread. The worker is always codex, so the `codex`
+CLI must be installed and signed in — whether the paired session is
+claude+codex, all three with opencode, or even claude+opencode (a
+task-only worker starts cold; only `context = "full"` forks the session's
+codex history, which exists when codex is a participant).
 
 ```bash
 tandem plugin install   # = claude plugin marketplace add Bhavya6187/tandem
                         #   + claude plugin install tandem@tandem
 ```
 
-Setup and usage: the [GPT subagents guide](../docs/subagents.md). The
-plugin is static registration only — all the work happens in the
-`tandem` binary the hook shells out to (`uv tool install tandem-cli`).
-Without that binary on PATH the plugin is inert: the hook command exits
-nonzero, `|| true` swallows it, and every dispatch runs natively.
+The first `tandem` launch offers this install too. Setup and usage: the
+[GPT subagents guide](../docs/subagents.md); config keys (`model`, `route`,
+`context`, `keep_forks`) in the
+[configuration reference](../docs/configuration.md). The plugin is static
+registration only — all the work happens in the `tandem` binary the hook
+shells out to (`uv tool install tandem-cli`). Without that binary on PATH
+the plugin is inert: the hook command exits nonzero, `|| true` swallows it,
+and every dispatch runs natively. Flipping between harnesses with Ctrl-]
+does not need the plugin at all; it exists only for GPT subagents.
 
 ## Internals
 


### PR DESCRIPTION
## Summary
- streamline the main README around quick start and user value
- add a compact switching flowchart and move advanced detail into linked guides
- document opencode, token stats, recent sessions, configuration, and adapter development
- calibrate timing, outage, context, and billing claims

## Verification
- 680 tests passed
- local Markdown links checked
- git diff --check passed