### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "Meta-harness that runs Claude Code and Codex CLI with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump 0.3.0 → 0.4.0 across `pyproject.toml`, `plugin/.claude-plugin/plugin.json`, and `uv.lock` in one commit.

Release notes go on the GitHub release (`v0.4.0`) once this merges: opencode as a full peer harness (#44), `tandem sessions` (#49), status-bar token stats (#47, #48), onboarding defaults + install hints (#46), always-warm standby removed (#45), zero-turn-claude shadow fix (#51), docs refresh (#50, #52).

## Test plan
- [x] `uv sync --locked && uv run pytest -q` → 680 passed (includes the plugin/pyproject version-drift test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)