### PR TITLE
Show each account's rate-limit windows on the tab bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ For more use cases, see
 Only the active model runs. tandem translates its growing conversation into
 the other CLIs' native session formats using local file access, so they are
 ready when you switch. Your session stays in the CLIs' own storage plus a
-small local database in `~/.tandem`; tandem adds no cloud sync or telemetry.
+small local database in `~/.tandem`; tandem adds no cloud sync or telemetry
+(its only network calls are the optional rate-limit polls for the tab bar).
 
 See [How tandem works](https://github.com/Bhavya6187/tandem/blob/main/docs/how-it-works.md)
 for transcript translation, switching, crash safety, compatibility, and data

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,20 +71,23 @@ silently ignored rather than failing the launch.
 
 The frame is tandem's own surface inside a running session: one reserved
 keybind that flips to the next harness in the cycle, the one-line tab
-bar on the bottom terminal row (participants, flip key, and the active
-model's live token stats), and the pipelined boot behind the flip.
+bar on the bottom terminal row (participants, flip key, the active
+model's live token stats, and each account's rate-limit windows), and
+the pipelined boot behind the flip.
 
 ```toml
 [frame]
 flip_key = "ctrl-]"
 bar = true
-warm = true   # boot the incoming harness while the outgoing one shuts down
+warm = true          # boot the incoming harness while the outgoing one shuts down
+rate_limits = true   # poll each account's usage windows for the bar
 ```
 
 | key | default | meaning |
 | --- | --- | --- |
 | `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). The bar relabels itself to match (`ctrl-t` shows `^T flips`). |
 | `bar` | `true` | The one-line tab bar on the bottom terminal row, including the active slot's token stats. `false` hides it; the flip still works. |
+| `rate_limits` | `true` | Show each participant's account rate limits on its slot (`5h 4% 7d 41%` — percent *used* per window). Polled every 60 s and after each response from the same account endpoints `claude`'s `/usage` and `codex`'s `/status` call, with the credentials those CLIs already keep; these are tandem's only outbound network calls. `false` makes none of them; the figures also stay blank for API-key logins or when a fetch fails. |
 | `warm` | `true` | Overlap the two halves of a flip: the incoming harness starts booting the moment the flip fires (a mid-turn press waits for the turn boundary first), while the outgoing one is still shutting down. `false` gives fully serial flips — the boot only begins once the old harness is gone. Flips *into* opencode are always serial (its TUI must open after the last turn has landed in its database). |
 
 An unparseable value falls back to the default rather than failing the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,8 +87,8 @@ rate_limits = true   # poll each account's usage windows for the bar
 | --- | --- | --- |
 | `flip_key` | `"ctrl-]"` | The flip keybind, consumed by tandem (never forwarded). Accepts `ctrl-<char>` or a hex byte like `"0x1d"`; printable keys are rejected (they would swallow typing). The bar relabels itself to match (`ctrl-t` shows `^T flips`). |
 | `bar` | `true` | The one-line tab bar on the bottom terminal row, including the active slot's token stats. `false` hides it; the flip still works. |
-| `rate_limits` | `true` | Show each participant's account rate limits on its slot (`5h 4% 7d 41%` — percent *used* per window). Polled every 60 s and after each response from the same account endpoints `claude`'s `/usage` and `codex`'s `/status` call, with the credentials those CLIs already keep; these are tandem's only outbound network calls. `false` makes none of them; the figures also stay blank for API-key logins or when a fetch fails. |
 | `warm` | `true` | Overlap the two halves of a flip: the incoming harness starts booting the moment the flip fires (a mid-turn press waits for the turn boundary first), while the outgoing one is still shutting down. `false` gives fully serial flips — the boot only begins once the old harness is gone. Flips *into* opencode are always serial (its TUI must open after the last turn has landed in its database). |
+| `rate_limits` | `true` | Show each participant's account rate limits on its slot (`5h 4% 7d 41%` — percent *used* per window). Polled every 60 s and after each response from the same account endpoints `claude`'s `/usage` and `codex`'s `/status` call, with the credentials those CLIs already keep; these are tandem's only outbound network calls. `false` makes none of them; the figures also stay blank for API-key logins or when a fetch fails. |
 
 An unparseable value falls back to the default rather than failing the
 launch. If a terminal can't sustain the bar, tandem drops it for the rest

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -71,9 +71,14 @@ flip, compatibility ranges, and where your data lives. (Back to the
   `43% ctx` for codex, which reports its window) and the session's
   input↑ / output↓ totals, where input is the whole prompt side as billed
   (fresh input plus cache reads and writes) and output includes
-  reasoning. Stats are cosmetic — any failure there disables them for the
-  session and never touches sync — and they're the first thing elided
-  when the row is too narrow. If a terminal can't sustain the bar it drops
+  reasoning. Every slot also carries its account's rate-limit windows
+  (`5h 4% 7d 41%`, percent used), polled on a side thread from the same
+  endpoints `claude`'s `/usage` and `codex`'s `/status` call, using the
+  credentials those CLIs keep on disk — tandem's only network calls, off
+  with `[frame] rate_limits = false`. Stats are cosmetic — any failure
+  there blanks them and never touches sync — and they're elided in
+  tiers when the row is too narrow: the ↑↓ totals first, then the rate
+  limits, then the ctx figure. If a terminal can't sustain the bar it drops
   for the session (the flip keeps working) and `tandem doctor` says so
   until you delete the marker file it names; shrinking the window below
   the bar's row floor drops it just as permanently, but silently — that

--- a/docs/why.md
+++ b/docs/why.md
@@ -75,15 +75,20 @@ last turn has landed in its database).
 The tab bar's active slot shows the model's live context (`144k ctx`, or
 `43% ctx` where the harness reports its window) and the session's
 input↑ / output↓ token totals — read straight from the transcript,
-updated as you work, no extra calls:
+updated as you work. Every slot also shows its account's rate-limit
+windows (percent used), so you can see which subscription has room
+before you flip:
 
 ```
- claude ● 144k ctx · 7.6M↑ 312k↓ │ codex ○ │ opencode ○   ^] flips
+ claude ● 144k ctx · 7.6M↑ 312k↓ · 5h 4% 7d 41% │ codex ○ 7d 12% │ opencode ○   ^] flips
 ```
 
 ## 🔒 Local, private, no lock-in.
 
 Everything lives in the CLIs' own session files plus a small SQLite
-database in `~/.tandem`. No cloud sync, no telemetry. Uninstall tandem
+database in `~/.tandem`. No cloud sync, no telemetry — the only network
+calls tandem makes are the rate-limit polls above, to the same account
+endpoints the CLIs' own `/usage` and `/status` use, and `[frame]
+rate_limits = false` turns those off. Uninstall tandem
 tomorrow and every session still resumes natively with `claude --resume`,
 `codex resume`, and `opencode -s`.

--- a/src/tandem/config.py
+++ b/src/tandem/config.py
@@ -2,8 +2,8 @@
 
 [subagents] controls codex subagent routing; [claude] / [codex] hold an
 `args` list appended to every interactive launch of that harness; [frame]
-holds the meta-harness flip keybind, its status bar toggle, and the
-pipelined-flip toggle.
+holds the meta-harness flip keybind, its status bar toggle, the
+pipelined-flip toggle, and the bar's rate-limit poll toggle.
 
 Unknown keys are ignored and every error yields defaults — configuration
 must never be the reason a launch breaks or subagent routing stops (the
@@ -88,6 +88,7 @@ class FrameConfig:
     flip_byte: int = 0x1D   # Ctrl-]
     bar: bool = True
     warm: bool = True       # boot the other harness during the flip's teardown
+    rate_limits: bool = True  # poll each account's usage windows for the bar
 
 
 def _parse_flip_key(value: str) -> int | None:
@@ -110,8 +111,8 @@ def _parse_flip_key(value: str) -> int | None:
 
 
 def load_frame_config() -> FrameConfig:
-    """[frame] table: the flip keybind, the status bar toggle, and the
-    pipelined-flip toggle."""
+    """[frame] table: the flip keybind, the status bar toggle, the
+    pipelined-flip toggle, and the bar's rate-limit poll toggle."""
     raw = _read_config().get("frame")
     if not isinstance(raw, dict):
         return FrameConfig()
@@ -120,10 +121,12 @@ def load_frame_config() -> FrameConfig:
     byte = _parse_flip_key(key) if isinstance(key, str) else None
     bar = raw.get("bar")
     warm = raw.get("warm")
+    limits = raw.get("rate_limits")
     return FrameConfig(
         flip_byte=byte if byte is not None else d.flip_byte,
         bar=bar if isinstance(bar, bool) else d.bar,
         warm=warm if isinstance(warm, bool) else d.warm,
+        rate_limits=limits if isinstance(limits, bool) else d.rate_limits,
     )
 
 

--- a/src/tandem/frame.py
+++ b/src/tandem/frame.py
@@ -241,7 +241,8 @@ class StatusBar:
         self.rows = rows
         self.cols = cols
 
-    def line(self, armed: bool, usage: str = "") -> str:
+    def line(self, armed: bool, usage: str = "",
+             limits: dict[str, str] | None = None) -> str:
         # padded and truncated by character count, so every glyph here must be
         # one terminal cell wide: a two-cell glyph (any with East_Asian_Width
         # W/F, e.g. ⏳ U+23F3) makes the painted row cols+1 cells and wraps off
@@ -251,24 +252,47 @@ class StatusBar:
             return (f" {self.active} ◐ flipping at turn end…  "
                     f"{self.key_label} cancels")[: self.cols].ljust(self.cols)
 
-        def compose(stats: str) -> str:
-            head = f"{self.active} ●" + (f" {stats}" if stats else "")
-            slots = " │ ".join([head] + [f"{o} ○" for o in self.others])
-            return f" {slots}   {self.key_label} flips"
+        # `usage` is the active slot's stats, most-important-first and
+        # ` · `-separated (UsageSnapshot.bar_text: ctx, then ↑↓ totals);
+        # `limits` is per-slot account rate-limit text for any harness.
+        parts = [pt for pt in usage.split(" · ") if pt] if usage else []
+        limits = limits or {}
 
-        text = compose(usage)
-        if usage and len(text) > self.cols:
-            # stats are the first thing to go: the key hint is the keybind's
-            # only advertisement, and the slot names are what it cycles
-            text = compose("")
+        def compose(stats: list[str], with_limits: bool) -> str:
+            def slot(name: str, glyph: str, extra: list[str]) -> str:
+                lim = limits.get(name, "") if with_limits else ""
+                bits = [*extra] + ([lim] if lim else [])
+                return f"{name} {glyph}" + (f" {' · '.join(bits)}" if bits else "")
+            slots = [slot(self.active, "●", stats)]
+            slots += [slot(o, "○", []) for o in self.others]
+            return f" {' │ '.join(slots)}   {self.key_label} flips"
+
+        # Elision order when the row is too narrow: the ↑↓ totals first, the
+        # rate limits second, the ctx figure third — the numbers that decide a
+        # flip outlive the ones that only describe the session — and the key
+        # hint last of all: it is the keybind's only advertisement, and the
+        # slot names are what it cycles.
+        tiers = [
+            (parts, True),
+            (parts[:1], True),
+            (parts[:1], False),
+            ([], False),
+        ]
+        text = compose(*tiers[-1])
+        for stats, with_limits in tiers:
+            candidate = compose(stats, with_limits)
+            if len(candidate) <= self.cols:
+                text = candidate
+                break
         return text[: self.cols].ljust(self.cols)
 
-    def paint(self, armed: bool, usage: str = "") -> bytes:
+    def paint(self, armed: bool, usage: str = "",
+              limits: dict[str, str] | None = None) -> bytes:
         return (
             b"\x1b7"
             + f"\x1b[{self.rows};1H".encode()
             + b"\x1b[7m"
-            + self.line(armed, usage).encode()
+            + self.line(armed, usage, limits).encode()
             + b"\x1b[0m\x1b8"
         )
 

--- a/src/tandem/harness/base.py
+++ b/src/tandem/harness/base.py
@@ -40,6 +40,8 @@ class UsageSnapshot:
     def bar_text(self) -> str:
         # `·` `↑` `↓` are East_Asian_Width A like the bar's ● │ ○ — one cell
         # outside CJK-wide terminal configs (frame.StatusBar.line's width rule).
+        # Parts are most-important-first, ` · `-joined: the bar elides from
+        # the end (↑↓ totals before ctx) when the row is too narrow.
         parts = []
         if self.ctx_percent is not None:
             parts.append(f"{self.ctx_percent}% ctx")

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -154,6 +154,9 @@ class FrameIO:
     # and polled on the pump tick, so the tail thread publishes by plain
     # assignment into whatever this closure reads
     usage: Callable[[], str] | None = None
+    # per-slot account rate-limit text (harness id → "5h 4% 7d 4%"), any
+    # slot; published the same way by the rate-limit poller thread
+    limits: Callable[[], dict[str, str]] | None = None
     bar_dropped: bool = False
 
 
@@ -241,7 +244,8 @@ def run_in_pty(
             return
         region = b"" if (g is not None and g.child_owns_region) else b.region()
         usage = frame.usage() if frame.usage is not None else ""
-        _write_all(out_fd, region + b.paint(frame.armed(), usage))
+        limits = frame.limits() if frame.limits is not None else None
+        _write_all(out_fd, region + b.paint(frame.armed(), usage, limits))
 
     def drop_bar(reason: str) -> None:
         """Terminal state: the guard's drop verdict is not latched, so the
@@ -355,6 +359,9 @@ def run_in_pty(
         last_usage = (
             frame.usage() if bar is not None and frame.usage is not None else ""
         )
+        last_limits = (
+            frame.limits() if bar is not None and frame.limits is not None else None
+        )
         last_stdin = time.monotonic()
         stdin_open = True
         # _is_alive, not isalive(): a PtyControl on another thread polls
@@ -424,6 +431,13 @@ def run_in_pty(
                 usage_now = frame.usage()
                 if usage_now != last_usage:
                     last_usage = usage_now
+                    paint()
+            if bar is not None and frame.limits is not None:
+                # the poller replaces the whole dict, so identity is the
+                # cheap change check and equality the correct one
+                limits_now = frame.limits()
+                if limits_now is not last_limits and limits_now != last_limits:
+                    last_limits = limits_now
                     paint()
     finally:
         # SIGWINCH goes back first: its handler is the one that paints, and

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -157,7 +157,20 @@ class FrameIO:
     # per-slot account rate-limit text (harness id → "5h 4% 7d 4%"), any
     # slot; published the same way by the rate-limit poller thread
     limits: Callable[[], dict[str, str]] | None = None
+    # the pump's word on whether a bar is actually drawn: True once at
+    # setup when it is, False when it never is (no tty, too few rows) or
+    # when it drops. Anything that only exists to feed the bar (the
+    # rate-limit poll) starts and stops on this.
+    on_bar: Callable[[bool], None] | None = None
     bar_dropped: bool = False
+
+
+def _report_bar(frame: FrameIO | None, on: bool) -> None:
+    if frame is not None and frame.on_bar is not None:
+        try:
+            frame.on_bar(on)
+        except Exception:
+            pass   # a listener must never take the pump down
 
 
 def _child_dims(rows: int, cols: int, bar_on: bool) -> tuple[int, int]:
@@ -202,6 +215,7 @@ def run_in_pty(
         # A pre-spawned `child` never legitimately reaches here: the flip
         # loop's own `_stdin_tty` gate kills a standby rather than hand it to
         # a path that spawns cold and would leave it unreaped.
+        _report_bar(frame, False)
         return subprocess.run(argv, cwd=cwd, env=env).returncode
 
     rows, cols = _winsize(stdin_fd)
@@ -217,6 +231,7 @@ def run_in_pty(
         if bar_on
         else None
     )
+    _report_bar(frame, bar_on)
 
     adopted = child is not None and _is_alive(child)
     if not adopted:
@@ -284,6 +299,7 @@ def run_in_pty(
         bar_on, guard = False, None
         if reason == "conflict":
             frame.bar_dropped = True
+        _report_bar(frame, False)
         if detector is not None:
             detector.bar_row = None
         _write_all(out_fd, dying.clear())

--- a/src/tandem/ptyrun.py
+++ b/src/tandem/ptyrun.py
@@ -231,7 +231,8 @@ def run_in_pty(
         if bar_on
         else None
     )
-    _report_bar(frame, bar_on)
+    if not bar_on:
+        _report_bar(frame, False)   # "on" is reported after the first paint
 
     adopted = child is not None and _is_alive(child)
     if not adopted:
@@ -369,6 +370,8 @@ def run_in_pty(
             except Exception:
                 pass   # child died in the gap: the liveness loop ends the pump
         paint()
+        if bar is not None:
+            _report_bar(frame, True)   # drawn for real: bytes are on the terminal
         # seeded from the state just painted, so an already-armed frame does
         # not draw a redundant repaint on the first iteration
         last_armed = frame.armed() if bar is not None else False

--- a/src/tandem/ratelimit.py
+++ b/src/tandem/ratelimit.py
@@ -1,0 +1,299 @@
+"""Account rate limits for the bar: the `5h 4% 7d 4%` figures on each slot.
+
+Both harnesses expose the numbers their own `/usage` (claude) and `/status`
+(codex) commands show, through the same account endpoints those commands
+call, authenticated with the credentials the CLIs already keep on disk.
+Neither endpoint is documented, so this module is cosmetic by contract:
+any failure — missing credentials, 401, timeout, unrecognized payload —
+blanks the figure and never surfaces anywhere else. The one exception is
+the endpoint throttling *us* (claude's answers 429 with a Retry-After of
+a few minutes when asked too often): that keeps the last figure and backs
+that harness off for as long as it said.
+
+Windows are labeled by their length (18000 s → `5h`, 604800 s → `7d`),
+never by position: codex plans differ in which of primary/secondary is
+populated. Percentages are *used*, matching claude's `/usage`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from . import paths
+
+
+@dataclass(frozen=True)
+class Window:
+    label: str
+    used_percent: int
+
+
+def window_label(seconds: int) -> str:
+    if seconds >= 86400:
+        return f"{seconds // 86400}d"
+    if seconds >= 3600:
+        return f"{seconds // 3600}h"
+    return f"{max(1, seconds // 60)}m"
+
+
+def _percent(value) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return max(0, min(100, int(value)))
+
+
+def parse_claude(payload) -> list[Window]:
+    """`/api/oauth/usage`: `five_hour` / `seven_day` each carry `utilization`
+    (a used percentage), independently absent."""
+    if not isinstance(payload, dict):
+        return []
+    out: list[Window] = []
+    for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
+        win = payload.get(key)
+        pct = _percent(win.get("utilization")) if isinstance(win, dict) else None
+        if pct is not None:
+            out.append(Window(label, pct))
+    return out
+
+
+def parse_codex(payload) -> list[Window]:
+    """`wham/usage`: `rate_limit.primary_window` / `secondary_window` each
+    carry `used_percent` and `limit_window_seconds`."""
+    if not isinstance(payload, dict):
+        return []
+    rl = payload.get("rate_limit")
+    if not isinstance(rl, dict):
+        return []
+    out: list[Window] = []
+    for key in ("primary_window", "secondary_window"):
+        win = rl.get(key)
+        if not isinstance(win, dict):
+            continue
+        pct = _percent(win.get("used_percent"))
+        secs = win.get("limit_window_seconds")
+        if pct is None or isinstance(secs, bool) or not isinstance(secs, int) or secs <= 0:
+            continue
+        out.append(Window(window_label(secs), pct))
+    return out
+
+
+def format_windows(windows: list[Window]) -> str:
+    # every glyph one cell wide (frame.StatusBar.line's width rule)
+    return " ".join(f"{w.label} {w.used_percent}%" for w in windows)
+
+
+# -- credentials -------------------------------------------------------------
+
+CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+CODEX_DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/"
+
+
+def _keychain_secret() -> str | None:
+    """Claude Code keeps its OAuth blob in the login keychain on macOS
+    (service `Claude Code-credentials`); elsewhere it is a file."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        proc = subprocess.run(
+            ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.stdout.strip() if proc.returncode == 0 else None
+
+
+def claude_token() -> str | None:
+    raw = _keychain_secret()
+    if raw is None:
+        try:
+            raw = (paths.claude_home() / ".credentials.json").read_text()
+        except OSError:
+            return None
+    try:
+        blob = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(blob, dict):
+        return None
+    oauth = blob.get("claudeAiOauth")
+    tok = oauth.get("accessToken") if isinstance(oauth, dict) else None
+    return tok if isinstance(tok, str) and tok else None
+
+
+def codex_credentials() -> tuple[str, str, str] | None:
+    """(access token, account id, usage URL) from `$CODEX_HOME/auth.json`
+    and the optional `chatgpt_base_url` in config.toml — mirroring
+    codex-rs/backend-client: `/wham/usage` under a `/backend-api` base,
+    `/api/codex/usage` otherwise. None for API-key logins."""
+    home = paths.codex_home()
+    try:
+        blob = json.loads((home / "auth.json").read_text())
+    except (OSError, ValueError):
+        return None
+    tokens = blob.get("tokens") if isinstance(blob, dict) else None
+    if not isinstance(tokens, dict):
+        return None
+    tok, acct = tokens.get("access_token"), tokens.get("account_id")
+    if not (isinstance(tok, str) and tok and isinstance(acct, str) and acct):
+        return None
+    base = CODEX_DEFAULT_BASE_URL
+    try:
+        with open(home / "config.toml", "rb") as f:
+            cfg_base = tomllib.load(f).get("chatgpt_base_url")
+        if isinstance(cfg_base, str) and cfg_base:
+            base = cfg_base
+    except (OSError, ValueError):
+        pass
+    base = base.rstrip("/")
+    path = "/wham/usage" if "/backend-api" in base else "/api/codex/usage"
+    return tok, acct, base + path
+
+
+# -- fetching ----------------------------------------------------------------
+
+# a 429 with no Retry-After (live claude 429s carry one, ~200 s): long enough
+# that a poller never becomes the thing keeping the endpoint throttled
+DEFAULT_RETRY_AFTER = 300.0
+
+
+class Throttled(Exception):
+    """The usage endpoint itself said 429: the figure is not unknown, we
+    were just told not to ask. Carries the seconds to wait."""
+
+    def __init__(self, retry_after: float):
+        super().__init__(f"retry after {retry_after:.0f}s")
+        self.retry_after = retry_after
+
+
+def _get_json(url: str, headers: dict[str, str], timeout: float):
+    req = urllib.request.Request(url, headers={"Accept": "application/json", **headers})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status != 200:
+                return None
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 429:
+            raise Throttled(_retry_after(exc.headers.get("Retry-After"))) from None
+        return None   # 401 (token rolled), 5xx: figure unknown for now
+    except Exception:
+        # URLError (refused, DNS), timeout, bad JSON
+        return None
+
+
+def _retry_after(value) -> float:
+    # delta-seconds only; the HTTP-date form is legal but not worth parsing
+    # for a cosmetic figure — the default backoff covers it
+    try:
+        secs = float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_AFTER
+    return secs if secs > 0 else DEFAULT_RETRY_AFTER
+
+
+def fetch_claude(token: str, *, url: str = CLAUDE_USAGE_URL,
+                 timeout: float = 5.0) -> list[Window] | None:
+    payload = _get_json(url, {
+        "Authorization": f"Bearer {token}",
+        "anthropic-beta": "oauth-2025-04-20",
+    }, timeout)
+    return None if payload is None else parse_claude(payload)
+
+
+def fetch_codex(token: str, account_id: str, *, url: str,
+                timeout: float = 5.0) -> list[Window] | None:
+    payload = _get_json(url, {
+        "Authorization": f"Bearer {token}",
+        "ChatGPT-Account-Id": account_id,
+        "User-Agent": "codex-cli",
+    }, timeout)
+    return None if payload is None else parse_codex(payload)
+
+
+# -- poller ------------------------------------------------------------------
+
+
+def _claude_fetcher() -> list[Window] | None:
+    tok = claude_token()
+    return None if tok is None else fetch_claude(tok)
+
+
+def _codex_fetcher() -> list[Window] | None:
+    creds = codex_credentials()
+    return None if creds is None else fetch_codex(creds[0], creds[1], url=creds[2])
+
+
+DEFAULT_FETCHERS: dict[str, Callable[[], list[Window] | None]] = {
+    "claude": _claude_fetcher,
+    "codex": _codex_fetcher,
+}
+
+
+class RateLimitPoller(threading.Thread):
+    """Owns the bar's rate-limit figures for every participant of a session:
+    fetches each harness's account limits on start, every `interval`
+    seconds after, and on `poke()` (a turn just landed) no more than once
+    per `min_gap`. Publishes into `state["limits"]` — harness id → bar text
+    ("" when unknown) — with a whole-dict replace, so the pump's read is
+    a single GIL-atomic slot fetch, same as the usage text. Credentials
+    are re-read on every fetch: both CLIs rotate their tokens in place."""
+
+    def __init__(self, harnesses: list[str], state: dict, *,
+                 fetchers: dict[str, Callable[[], list[Window] | None]] | None = None,
+                 interval: float = 60.0, min_gap: float = 30.0):
+        super().__init__(name="tandem-ratelimit", daemon=True)
+        pool = DEFAULT_FETCHERS if fetchers is None else fetchers
+        self.fetchers = {h: pool[h] for h in harnesses if h in pool}
+        self.state = state
+        self.interval = interval
+        self.min_gap = min_gap
+        self._halt = threading.Event()
+        self._wake = threading.Event()
+        self._last = float("-inf")
+        self._not_before: dict[str, float] = {}   # per-harness 429 backoff
+
+    def refresh(self) -> None:
+        now = time.monotonic()
+        self._last = now
+        prev = self.state.get("limits") or {}
+        out: dict[str, str] = {}
+        for h, fetch in self.fetchers.items():
+            if now < self._not_before.get(h, 0.0):
+                out[h] = prev.get(h, "")   # still told not to ask: keep what we had
+                continue
+            try:
+                windows = fetch()
+            except Throttled as exc:
+                self._not_before[h] = now + exc.retry_after
+                out[h] = prev.get(h, "")
+                continue
+            except Exception:
+                windows = None
+            out[h] = format_windows(windows) if windows else ""
+        self.state["limits"] = out
+
+    def poke(self) -> None:
+        if time.monotonic() - self._last >= self.min_gap:
+            self._wake.set()
+
+    def run(self) -> None:
+        while not self._halt.is_set():
+            self.refresh()
+            self._wake.wait(self.interval)
+            self._wake.clear()
+
+    def stop(self) -> None:
+        self._halt.set()
+        self._wake.set()
+        if self.is_alive() and threading.current_thread() is not self:
+            self.join(timeout=1.0)

--- a/src/tandem/ratelimit.py
+++ b/src/tandem/ratelimit.py
@@ -48,7 +48,7 @@ def window_label(seconds: int) -> str:
 def _percent(value) -> int | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
-    return max(0, min(100, int(value)))
+    return max(0, min(100, round(value)))
 
 
 def parse_claude(payload) -> list[Window]:
@@ -80,9 +80,10 @@ def parse_codex(payload) -> list[Window]:
             continue
         pct = _percent(win.get("used_percent"))
         secs = win.get("limit_window_seconds")
-        if pct is None or isinstance(secs, bool) or not isinstance(secs, int) or secs <= 0:
+        if (pct is None or isinstance(secs, bool)
+                or not isinstance(secs, (int, float)) or secs <= 0):
             continue
-        out.append(Window(window_label(secs), pct))
+        out.append(Window(window_label(int(secs)), pct))
     return out
 
 
@@ -97,19 +98,48 @@ CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 CODEX_DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/"
 
 
-def _keychain_secret() -> str | None:
+class _SharedState:
+    """Poller state that outlives one poller. A tandem session runs one
+    `InteractiveRunner` per flip leg, each with its own poller; the account
+    is the same throughout, so the endpoint's backoff, the min-gap clock and
+    the last figures must carry across — or every flip is an immediate
+    fetch pair that ignores an in-flight 429, and the new leg's bar goes
+    blank until its first fetch returns."""
+
+    def __init__(self) -> None:
+        self.not_before: dict[str, float] = {}   # per-harness 429 backoff
+        self.last_refresh: float = float("-inf")
+        self.text: dict[str, str] = {}           # last published, per harness
+        self.keychain_dead: bool = False         # one failure and we stop asking
+
+
+_shared = _SharedState()
+
+
+def _keychain_secret_uncached() -> str | None:
     """Claude Code keeps its OAuth blob in the login keychain on macOS
-    (service `Claude Code-credentials`); elsewhere it is a file."""
-    if sys.platform != "darwin":
+    (service `Claude Code-credentials`); elsewhere it is a file. One
+    failure — the binary missing, a denied or timed-out (i.e. prompting)
+    ACL — latches the read off for the process: a keychain dialog every
+    60 s of an interactive session is not fail-quiet."""
+    if sys.platform != "darwin" or _shared.keychain_dead:
         return None
     try:
         proc = subprocess.run(
             ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
             capture_output=True, text=True, timeout=5, check=False,
+            stdin=subprocess.DEVNULL,   # never touch the raw-mode tty
         )
     except (OSError, subprocess.SubprocessError):
+        _shared.keychain_dead = True
         return None
-    return proc.stdout.strip() if proc.returncode == 0 else None
+    if proc.returncode != 0:
+        _shared.keychain_dead = True
+        return None
+    return proc.stdout.strip()
+
+
+_keychain_secret = _keychain_secret_uncached
 
 
 def claude_token() -> str | None:
@@ -175,10 +205,20 @@ class Throttled(Exception):
         self.retry_after = retry_after
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    # urllib re-sends Authorization across redirects, cross-host included;
+    # these are fixed-URL calls, so any 3xx is simply a failed fetch
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_opener = urllib.request.build_opener(_NoRedirect)
+
+
 def _get_json(url: str, headers: dict[str, str], timeout: float):
     req = urllib.request.Request(url, headers={"Accept": "application/json", **headers})
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _opener.open(req, timeout=timeout) as resp:
             if resp.status != 200:
                 return None
             return json.load(resp)
@@ -240,13 +280,17 @@ DEFAULT_FETCHERS: dict[str, Callable[[], list[Window] | None]] = {
 
 
 class RateLimitPoller(threading.Thread):
-    """Owns the bar's rate-limit figures for every participant of a session:
-    fetches each harness's account limits on start, every `interval`
-    seconds after, and on `poke()` (a turn just landed) no more than once
-    per `min_gap`. Publishes into `state["limits"]` — harness id → bar text
-    ("" when unknown) — with a whole-dict replace, so the pump's read is
-    a single GIL-atomic slot fetch, same as the usage text. Credentials
-    are re-read on every fetch: both CLIs rotate their tokens in place."""
+    """Owns the bar's rate-limit figures for every participant of a session
+    leg: fetches each harness's account limits when the pump reports a bar
+    (`ensure_started`), every `interval` seconds after, and on `poke()` (a
+    turn just landed) — never more than once per `min_gap`, counted across
+    legs. Publishes into `state["limits"]` — harness id → bar text ("" when
+    unknown) — with a whole-dict replace, so the pump's read is a single
+    GIL-atomic slot fetch, same as the usage text; the last figures of the
+    previous leg are published at construction, so a fresh leg's bar never
+    blanks. Credentials are re-read on every fetch: both CLIs rotate their
+    tokens in place. `halt()` signals from any thread (the pump's drop path
+    included) without joining; `stop()` also joins."""
 
     def __init__(self, harnesses: list[str], state: dict, *,
                  fetchers: dict[str, Callable[[], list[Window] | None]] | None = None,
@@ -259,41 +303,53 @@ class RateLimitPoller(threading.Thread):
         self.min_gap = min_gap
         self._halt = threading.Event()
         self._wake = threading.Event()
-        self._last = float("-inf")
-        self._not_before: dict[str, float] = {}   # per-harness 429 backoff
+        self._start_lock = threading.Lock()
+        self._launched = False
+        self.state["limits"] = {h: _shared.text.get(h, "") for h in self.fetchers}
 
     def refresh(self) -> None:
         now = time.monotonic()
-        self._last = now
-        prev = self.state.get("limits") or {}
+        _shared.last_refresh = now
         out: dict[str, str] = {}
         for h, fetch in self.fetchers.items():
-            if now < self._not_before.get(h, 0.0):
-                out[h] = prev.get(h, "")   # still told not to ask: keep what we had
+            if now < _shared.not_before.get(h, 0.0):
+                out[h] = _shared.text.get(h, "")   # still told not to ask: keep what we had
                 continue
             try:
                 windows = fetch()
             except Throttled as exc:
-                self._not_before[h] = now + exc.retry_after
-                out[h] = prev.get(h, "")
+                _shared.not_before[h] = now + exc.retry_after
+                out[h] = _shared.text.get(h, "")
                 continue
             except Exception:
                 windows = None
             out[h] = format_windows(windows) if windows else ""
+        _shared.text.update(out)
         self.state["limits"] = out
 
     def poke(self) -> None:
-        if time.monotonic() - self._last >= self.min_gap:
+        if time.monotonic() - _shared.last_refresh >= self.min_gap:
             self._wake.set()
+
+    def ensure_started(self) -> None:
+        with self._start_lock:
+            if self._launched or self._halt.is_set():
+                return
+            self._launched = True
+        self.start()
 
     def run(self) -> None:
         while not self._halt.is_set():
-            self.refresh()
+            if time.monotonic() - _shared.last_refresh >= self.min_gap:
+                self.refresh()
             self._wake.wait(self.interval)
             self._wake.clear()
 
-    def stop(self) -> None:
+    def halt(self) -> None:
         self._halt.set()
         self._wake.set()
+
+    def stop(self) -> None:
+        self.halt()
         if self.is_alive() and threading.current_thread() is not self:
             self.join(timeout=1.0)

--- a/src/tandem/ratelimit.py
+++ b/src/tandem/ratelimit.py
@@ -17,6 +17,8 @@ populated. Percentages are *used*, matching claude's `/usage`.
 
 from __future__ import annotations
 
+import datetime
+import email.utils
 import json
 import subprocess
 import sys
@@ -232,12 +234,20 @@ def _get_json(url: str, headers: dict[str, str], timeout: float):
 
 
 def _retry_after(value) -> float:
-    # delta-seconds only; the HTTP-date form is legal but not worth parsing
-    # for a cosmetic figure — the default backoff covers it
+    """Retry-After is delta-seconds or an HTTP-date; anything else, or a
+    date already past, takes the default backoff."""
+    if value is None:
+        return DEFAULT_RETRY_AFTER
     try:
         secs = float(value)
     except (TypeError, ValueError):
-        return DEFAULT_RETRY_AFTER
+        try:
+            when = email.utils.parsedate_to_datetime(str(value))
+        except (TypeError, ValueError):
+            return DEFAULT_RETRY_AFTER
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=datetime.timezone.utc)
+        secs = (when - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
     return secs if secs > 0 else DEFAULT_RETRY_AFTER
 
 
@@ -312,6 +322,11 @@ class RateLimitPoller(threading.Thread):
         _shared.last_refresh = now
         out: dict[str, str] = {}
         for h, fetch in self.fetchers.items():
+            if self._halt.is_set():
+                # halted mid-refresh (bar dropped, leg ending): no further
+                # credentialed calls; what was already fetched still lands
+                out[h] = _shared.text.get(h, "")
+                continue
             if now < _shared.not_before.get(h, 0.0):
                 out[h] = _shared.text.get(h, "")   # still told not to ask: keep what we had
                 continue

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -23,6 +23,7 @@ from .config import load_frame_config
 from .events import SessionContext
 from .harness import get_adapter
 from .ptyrun import FrameIO, PtyControl, _winsize, run_in_pty
+from .ratelimit import RateLimitPoller
 from .state import PairedSession, StateStore, SyncCursor
 from .tailer import TailedLine, TranscriptTruncated, TranscriptWatcher
 from .util import json_line
@@ -687,7 +688,15 @@ class InteractiveRunner:
         # written by the tail thread, read by the pump on every paint/tick;
         # a plain dict-slot assignment is the entire synchronization (GIL),
         # same as monitor.transcript
-        usage_state = {"text": ""}
+        usage_state = {"text": "", "limits": {}}
+        # Account rate limits for every slot, polled on their own thread
+        # (network calls must never sit on the tail thread's sync path).
+        # Only with a bar to paint them on: no bar, no calls.
+        poller = (
+            RateLimitPoller([active, *session.targets_for(active)], usage_state)
+            if frame_cfg.bar and frame_cfg.rate_limits
+            else None
+        )
         frame = FrameIO(
             flip_byte=frame_cfg.flip_byte,
             on_flip=monitor.flip_pressed,
@@ -697,6 +706,7 @@ class InteractiveRunner:
             others=session.targets_for(active),
             key_label=_key_label(frame_cfg.flip_byte),
             usage=lambda: usage_state["text"],
+            limits=(lambda: usage_state["limits"]) if poller is not None else None,
         )
         self.flip_requested = False
         self.warm_child = None
@@ -770,7 +780,12 @@ class InteractiveRunner:
                         with ops._sub_lock():
                             for loop in loops:
                                 loop.drain()
+                        before = usage_state["text"]
                         ufeed.poll()
+                        if poller is not None and usage_state["text"] != before:
+                            # a response just landed: the account figures
+                            # moved, refresh them ahead of the interval
+                            poller.poke()
                         watcher.wait()
                     # final drain after the CLI exits
                     with ops._sub_lock():
@@ -786,6 +801,8 @@ class InteractiveRunner:
         thread = threading.Thread(target=tail_thread, name="tandem-tail", daemon=True)
         thread.start()
         monitor.start()   # before the try: stop() on an unstarted thread raises
+        if poller is not None:
+            poller.start()
         try:
             # A release that returns None means the discard reader still owns
             # the fd, so there is nothing safe to hand over: run_in_pty spawns
@@ -804,6 +821,8 @@ class InteractiveRunner:
                               control=control, child=pre_spawned)
         finally:
             stop.set()
+            if poller is not None:
+                poller.stop()
             # stop() first, and only then read the monitor: `flip_requested`
             # and `how` are assigned as the ladder finishes, so a read before
             # the join races the flip thread.

--- a/src/tandem/runner.py
+++ b/src/tandem/runner.py
@@ -691,12 +691,23 @@ class InteractiveRunner:
         usage_state = {"text": "", "limits": {}}
         # Account rate limits for every slot, polled on their own thread
         # (network calls must never sit on the tail thread's sync path).
-        # Only with a bar to paint them on: no bar, no calls.
+        # Only with a bar to paint them on — no bar, no calls — and the pump
+        # is the one that knows: it starts the poll when it draws the bar
+        # and halts it when the bar is never drawn or drops.
         poller = (
             RateLimitPoller([active, *session.targets_for(active)], usage_state)
             if frame_cfg.bar and frame_cfg.rate_limits
             else None
         )
+
+        def on_bar(drawn: bool) -> None:
+            if poller is None:
+                return
+            if drawn:
+                poller.ensure_started()
+            else:
+                poller.halt()
+
         frame = FrameIO(
             flip_byte=frame_cfg.flip_byte,
             on_flip=monitor.flip_pressed,
@@ -707,6 +718,7 @@ class InteractiveRunner:
             key_label=_key_label(frame_cfg.flip_byte),
             usage=lambda: usage_state["text"],
             limits=(lambda: usage_state["limits"]) if poller is not None else None,
+            on_bar=on_bar if poller is not None else None,
         )
         self.flip_requested = False
         self.warm_child = None
@@ -801,8 +813,6 @@ class InteractiveRunner:
         thread = threading.Thread(target=tail_thread, name="tandem-tail", daemon=True)
         thread.start()
         monitor.start()   # before the try: stop() on an unstarted thread raises
-        if poller is not None:
-            poller.start()
         try:
             # A release that returns None means the discard reader still owns
             # the fd, so there is nothing safe to hand over: run_in_pty spawns

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,6 +262,28 @@ class Env3(Env):
 
 
 @pytest.fixture(autouse=True)
+def _rate_limits_hermetic(monkeypatch):
+    """No test may carry the developer's real credentials to a real endpoint.
+    The Env sandbox moves CLAUDE_CONFIG_DIR/CODEX_HOME, but the macOS
+    keychain read sits outside any env dir — stub it — and refuse every
+    non-loopback URL outright so a gap anywhere else fails loudly instead of
+    phoning home. Cross-run poller state (backoff, last figures) starts
+    fresh per test."""
+    from tandem import ratelimit
+
+    monkeypatch.setattr(ratelimit, "_keychain_secret", lambda: None)
+    monkeypatch.setattr(ratelimit, "_shared", ratelimit._SharedState())
+    real_get_json = ratelimit._get_json
+
+    def guarded(url, headers, timeout):
+        if not url.startswith("http://127.0.0.1:"):
+            raise RuntimeError(f"test tried to reach the network: {url}")
+        return real_get_json(url, headers, timeout)
+
+    monkeypatch.setattr(ratelimit, "_get_json", guarded)
+
+
+@pytest.fixture(autouse=True)
 def _warm_gate_closed(monkeypatch):
     """No test may boot a hidden harness for real. Under plain `pytest` stdin
     is not a terminal and the warm gate is shut anyway, but `pytest -s` on a

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -177,3 +177,20 @@ def test_frame_flip_key_multichar_casefold_does_not_raise(tmp_path, monkeypatch)
 def test_frame_malformed_values_fall_back(tmp_path, monkeypatch):
     _write_config(tmp_path, monkeypatch, '[frame]\nflip_key = 29\nbar = "yes"\n')
     assert load_frame_config() == FrameConfig()
+
+
+def test_frame_rate_limits_defaults_true(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, "[frame]\n")
+    assert load_frame_config().rate_limits is True
+
+
+def test_frame_rate_limits_off(tmp_path, monkeypatch):
+    _write_config(tmp_path, monkeypatch, "[frame]\nrate_limits = false\n")
+    assert load_frame_config().rate_limits is False
+
+
+def test_frame_rate_limits_garbage_falls_back_to_default(tmp_path, monkeypatch):
+    # rate_limits gates tandem's only outbound network calls; a stray
+    # string must read as the default, not as "on"
+    _write_config(tmp_path, monkeypatch, '[frame]\nrate_limits = "off"\n')
+    assert load_frame_config().rate_limits is True

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -586,3 +586,68 @@ def test_bar_three_slots_truncates_to_cols():
     bar = StatusBar(rows=40, cols=24, active="claude",
                     others=["codex", "opencode"])
     assert len(bar.line(armed=False)) == 24
+
+
+# -- rate limits on the bar ---------------------------------------------------
+
+
+def test_bar_line_shows_limits_on_every_slot():
+    bar = StatusBar(rows=40, cols=90, active="claude", others=["codex", "opencode"])
+    line = bar.line(
+        armed=False,
+        usage="12% ctx · 7.6M↑ 312k↓",
+        limits={"claude": "5h 4% 7d 4%", "codex": "7d 12%"},
+    )
+    assert "claude ● 12% ctx · 7.6M↑ 312k↓ · 5h 4% 7d 4% │ codex ○ 7d 12% │ opencode ○" in line
+    assert "^] flips" in line
+    assert len(line) == 90
+
+
+def test_bar_line_limits_without_usage_sit_alone_on_the_active_slot():
+    # before the first turn there are no token stats yet, but the account
+    # limits are already known: no dangling separator
+    bar = StatusBar(rows=40, cols=60, active="codex", others=["claude"])
+    line = bar.line(armed=False, usage="", limits={"codex": "7d 12%"})
+    assert "codex ● 7d 12% │ claude ○" in line
+
+
+def test_bar_line_elides_token_totals_before_limits():
+    # tiered elision: the ↑↓ totals go first, the limits second, the ctx
+    # figure third, so a narrower row keeps the numbers that decide a flip
+    usage = "12% ctx · 7.6M↑ 312k↓"
+    limits = {"claude": "5h 4% 7d 4%", "codex": "7d 12%"}
+    full = " claude ● 12% ctx · 7.6M↑ 312k↓ · 5h 4% 7d 4% │ codex ○ 7d 12%   ^] flips"
+    bar = StatusBar(rows=40, cols=len(full) - 1, active="claude", others=["codex"])
+    line = bar.line(armed=False, usage=usage, limits=limits)
+    assert "↑" not in line
+    assert "12% ctx · 5h 4% 7d 4%" in line and "codex ○ 7d 12%" in line
+
+
+def test_bar_line_elides_limits_before_ctx():
+    usage = "12% ctx · 7.6M↑ 312k↓"
+    limits = {"claude": "5h 4% 7d 4%", "codex": "7d 12%"}
+    no_tokens = " claude ● 12% ctx · 5h 4% 7d 4% │ codex ○ 7d 12%   ^] flips"
+    bar = StatusBar(rows=40, cols=len(no_tokens) - 1, active="claude", others=["codex"])
+    line = bar.line(armed=False, usage=usage, limits=limits)
+    assert "5h" not in line and "7d" not in line
+    assert "claude ● 12% ctx │ codex ○" in line
+
+
+def test_bar_line_elides_ctx_last_and_keeps_the_flip_hint():
+    usage = "12% ctx · 7.6M↑ 312k↓"
+    limits = {"claude": "5h 4% 7d 4%", "codex": "7d 12%"}
+    ctx_only = " claude ● 12% ctx │ codex ○   ^] flips"
+    bar = StatusBar(rows=40, cols=len(ctx_only) - 1, active="claude", others=["codex"])
+    line = bar.line(armed=False, usage=usage, limits=limits)
+    assert "ctx" not in line
+    assert "claude ● │ codex ○" in line and "^] flips" in line
+
+
+def test_bar_line_armed_state_ignores_limits():
+    bar = StatusBar(rows=40, cols=60, active="claude", others=["codex"])
+    assert bar.line(armed=True, limits={"codex": "7d 12%"}) == bar.line(armed=True)
+
+
+def test_bar_paint_carries_limits():
+    bar = StatusBar(rows=40, cols=60, active="claude", others=["codex"])
+    assert "7d 12%".encode() in bar.paint(armed=False, limits={"codex": "7d 12%"})

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -1,4 +1,5 @@
 import fcntl
+import io
 import os
 import pty
 import signal
@@ -492,6 +493,42 @@ def test_limits_change_repaints_the_bar(monkeypatch):
         assert any("codex ○ 7d 12%".encode() in w for w in pump.writes)
 
     assert pump.run(drive) == 0
+
+
+def test_pump_reports_the_bar_on_and_then_off_around_a_drop(monkeypatch):
+    """The runner gates its rate-limit polls on the bar actually being drawn,
+    which only the pump knows: it reports on at setup and off at a drop."""
+    events = []
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False,
+                    on_bar=events.append)
+    pump = _Pump(monkeypatch, frame=frame)
+
+    def drive():
+        assert events == [True]
+        pump.feed(b"\x1b[1;24r")            # conflict: DECSTBM covers the bar row
+        assert pump.await_clear()
+
+    assert pump.run(drive) == 0
+    assert events == [True, False]
+
+
+def test_pump_reports_the_bar_off_when_the_window_is_too_short(monkeypatch):
+    events = []
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False,
+                    on_bar=events.append)
+    pump = _Pump(monkeypatch, frame=frame, rows=3)
+    pump.painted.set()          # no bar means no paint: don't wait for one
+    assert pump.run(lambda: None) == 0
+    assert events == [False]
+
+
+def test_pump_reports_the_bar_off_on_the_non_tty_path(monkeypatch):
+    events = []
+    frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False,
+                    on_bar=events.append)
+    monkeypatch.setattr(ptyrun.sys, "stdin", io.StringIO())   # no fileno: not a tty
+    assert run_in_pty(["true"], frame=frame) == 0
+    assert events == [False]
 
 
 def test_drop_bar_survives_a_sigwinch_landing_inside_its_own_teardown(monkeypatch):

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -472,6 +472,28 @@ def test_usage_change_repaints_the_bar(monkeypatch):
     assert pump.run(drive) == 0
 
 
+def test_limits_change_repaints_the_bar(monkeypatch):
+    """The rate-limit poller publishes per-slot text on its own thread; the
+    pump's tick must notice a change there just like a usage change."""
+    limits = {"by": {}}
+    frame = FrameIO(
+        flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False,
+        active="claude", others=["codex"], limits=lambda: limits["by"],
+    )
+    pump = _Pump(monkeypatch, frame=frame)
+
+    def drive():
+        limits["by"] = {"codex": "7d 12%"}
+        deadline = time.time() + 3
+        while time.time() < deadline:
+            if any("codex ○ 7d 12%".encode() in w for w in pump.writes):
+                break
+            time.sleep(0.02)
+        assert any("codex ○ 7d 12%".encode() in w for w in pump.writes)
+
+    assert pump.run(drive) == 0
+
+
 def test_drop_bar_survives_a_sigwinch_landing_inside_its_own_teardown(monkeypatch):
     """Drops and resizes are causally correlated, so the SIGWINCH handler
     lands inside drop_bar's writes all the time. The bar must already be gone

--- a/tests/test_ptyrun.py
+++ b/tests/test_ptyrun.py
@@ -499,12 +499,24 @@ def test_pump_reports_the_bar_on_and_then_off_around_a_drop(monkeypatch):
     """The runner gates its rate-limit polls on the bar actually being drawn,
     which only the pump knows: it reports on at setup and off at a drop."""
     events = []
+    painted_before_report = []
+    pump = None
+
+    def on_bar(on):
+        events.append(on)
+        if on:
+            # something was already written to the terminal when we hear "on"
+            painted_before_report.append(any(b"\x1b[7m" in w for w in pump.writes))
+
     frame = FrameIO(flip_byte=0x1D, on_flip=lambda: None, armed=lambda: False,
-                    on_bar=events.append)
+                    on_bar=on_bar)
     pump = _Pump(monkeypatch, frame=frame)
 
     def drive():
+        # `drive` runs after the first paint: on(True) was reported by then,
+        # and only then — a bar is "drawn" once bytes hit the terminal
         assert events == [True]
+        assert painted_before_report == [True]
         pump.feed(b"\x1b[1;24r")            # conflict: DECSTBM covers the bar row
         assert pump.await_clear()
 

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,365 @@
+"""Account rate limits behind the bar's `5h 4% 7d 4%` figures.
+
+Fixture shapes are the live payloads (probed 2026-08-16): claude's
+`/api/oauth/usage` (what `/usage` calls) and codex's `wham/usage` (what
+its `/status` calls, `codex-rs/backend-client`). Both are undocumented,
+so every parser must go quiet on any shape it doesn't recognize.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from tandem import ratelimit
+from tandem.ratelimit import (
+    RateLimitPoller,
+    Window,
+    format_windows,
+    parse_claude,
+    parse_codex,
+)
+
+CLAUDE_PAYLOAD = {
+    "five_hour": {"utilization": 4.0, "resets_at": "2026-08-16T17:49:59+00:00"},
+    "seven_day": {"utilization": 41.6, "resets_at": "2026-08-22T17:59:59+00:00"},
+    "seven_day_opus": None,
+    "extra_usage": {"is_enabled": False},
+}
+
+CODEX_PAYLOAD = {
+    "plan_type": "plus",
+    "rate_limit": {
+        "allowed": True,
+        "limit_reached": False,
+        "primary_window": {
+            "used_percent": 12,
+            "limit_window_seconds": 604800,
+            "reset_after_seconds": 302642,
+            "reset_at": 1787209799,
+        },
+        "secondary_window": None,
+    },
+    "additional_rate_limits": None,
+}
+
+
+# -- parsing -----------------------------------------------------------------
+
+
+def test_parse_claude_reads_both_windows_in_order():
+    assert parse_claude(CLAUDE_PAYLOAD) == [Window("5h", 4), Window("7d", 41)]
+
+
+def test_parse_claude_skips_absent_windows():
+    assert parse_claude({"five_hour": {"utilization": 9.0}, "seven_day": None}) == [
+        Window("5h", 9)
+    ]
+
+
+def test_parse_claude_rejects_junk():
+    assert parse_claude({"five_hour": {"utilization": "lots"}}) == []
+    assert parse_claude("nope") == []
+    assert parse_claude({}) == []
+
+
+def test_parse_codex_labels_windows_by_their_length():
+    assert parse_codex(CODEX_PAYLOAD) == [Window("7d", 12)]
+
+
+def test_parse_codex_reads_secondary_window_when_present():
+    payload = json.loads(json.dumps(CODEX_PAYLOAD))
+    payload["rate_limit"]["primary_window"] = {
+        "used_percent": 63.4, "limit_window_seconds": 18000}
+    payload["rate_limit"]["secondary_window"] = {
+        "used_percent": 12, "limit_window_seconds": 604800}
+    assert parse_codex(payload) == [Window("5h", 63), Window("7d", 12)]
+
+
+def test_parse_codex_rejects_junk():
+    assert parse_codex({"rate_limit": None}) == []
+    assert parse_codex({"rate_limit": {"primary_window": {"used_percent": 3}}}) == []
+    assert parse_codex([]) == []
+
+
+@pytest.mark.parametrize("seconds,label", [
+    (18000, "5h"), (604800, "7d"), (3600, "1h"), (86400, "1d"), (300, "5m"),
+])
+def test_window_label_from_seconds(seconds, label):
+    assert ratelimit.window_label(seconds) == label
+
+
+# -- formatting --------------------------------------------------------------
+
+
+def test_format_windows_is_one_cell_per_glyph():
+    text = format_windows([Window("5h", 4), Window("7d", 41)])
+    assert text == "5h 4% 7d 41%"
+
+
+def test_format_windows_empty_is_blank():
+    assert format_windows([]) == ""
+
+
+# -- credentials -------------------------------------------------------------
+
+
+def test_claude_token_prefers_keychain(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(ratelimit, "_keychain_secret",
+                        lambda: json.dumps({"claudeAiOauth": {"accessToken": "kc-tok"}}))
+    assert ratelimit.claude_token() == "kc-tok"
+
+
+def test_claude_token_falls_back_to_credentials_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(ratelimit, "_keychain_secret", lambda: None)
+    (tmp_path / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "file-tok"}}))
+    assert ratelimit.claude_token() == "file-tok"
+
+
+def test_claude_token_absent_is_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(ratelimit, "_keychain_secret", lambda: None)
+    assert ratelimit.claude_token() is None
+    (tmp_path / ".credentials.json").write_text("{not json")
+    assert ratelimit.claude_token() is None
+
+
+def _codex_home(tmp_path, tokens=None, config=None):
+    home = tmp_path / "codex"
+    home.mkdir()
+    if tokens is not None:
+        (home / "auth.json").write_text(json.dumps({"auth_mode": "chatgpt", "tokens": tokens}))
+    if config is not None:
+        (home / "config.toml").write_text(config)
+    return home
+
+
+def test_codex_credentials_default_url(monkeypatch, tmp_path):
+    home = _codex_home(tmp_path, {"access_token": "t", "account_id": "acct"})
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    assert ratelimit.codex_credentials() == (
+        "t", "acct", "https://chatgpt.com/backend-api/wham/usage")
+
+
+def test_codex_credentials_honor_chatgpt_base_url(monkeypatch, tmp_path):
+    home = _codex_home(tmp_path, {"access_token": "t", "account_id": "acct"},
+                       'chatgpt_base_url = "https://example.test/backend-api/"\n')
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    assert ratelimit.codex_credentials()[2] == "https://example.test/backend-api/wham/usage"
+    # a base without /backend-api takes codex's other path style
+    (home / "config.toml").write_text('chatgpt_base_url = "https://example.test"\n')
+    assert ratelimit.codex_credentials()[2] == "https://example.test/api/codex/usage"
+
+
+def test_codex_credentials_absent_for_api_key_logins(monkeypatch, tmp_path):
+    home = _codex_home(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    assert ratelimit.codex_credentials() is None
+    (home / "auth.json").write_text(json.dumps({"auth_mode": "apikey", "OPENAI_API_KEY": "sk"}))
+    assert ratelimit.codex_credentials() is None
+
+
+# -- fetching ----------------------------------------------------------------
+
+
+class _Handler(BaseHTTPRequestHandler):
+    status = 200
+    body: bytes = b"{}"
+    seen: list  # reset per `server` fixture
+    extra_headers: dict = {}
+
+    def do_GET(self):
+        # header names are case-insensitive on the wire (urllib title-cases them)
+        type(self).seen.append((self.path, {k.lower(): v for k, v in self.headers.items()}))
+        self.send_response(type(self).status)
+        self.send_header("Content-Type", "application/json")
+        for k, v in type(self).extra_headers.items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(type(self).body)
+
+    def log_message(self, *a):  # keep pytest output pristine
+        pass
+
+
+@pytest.fixture
+def server():
+    _Handler.seen = []
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{srv.server_port}"
+    srv.shutdown()
+
+
+def test_fetch_claude_sends_bearer_and_beta_header(server):
+    _Handler.status, _Handler.body = 200, json.dumps(CLAUDE_PAYLOAD).encode()
+    assert ratelimit.fetch_claude("tok", url=server + "/usage") == [
+        Window("5h", 4), Window("7d", 41)]
+    path, headers = _Handler.seen[-1]
+    assert path == "/usage"
+    assert headers["authorization"] == "Bearer tok"
+    assert headers["anthropic-beta"] == "oauth-2025-04-20"
+
+
+def test_fetch_codex_sends_bearer_and_account_id(server):
+    _Handler.status, _Handler.body = 200, json.dumps(CODEX_PAYLOAD).encode()
+    assert ratelimit.fetch_codex("tok", "acct", url=server + "/wham/usage") == [
+        Window("7d", 12)]
+    _, headers = _Handler.seen[-1]
+    assert headers["authorization"] == "Bearer tok"
+    assert headers["chatgpt-account-id"] == "acct"
+
+
+def test_fetch_non_200_is_none(server):
+    _Handler.status, _Handler.body = 401, b'{"error":"expired"}'
+    assert ratelimit.fetch_claude("tok", url=server + "/usage") is None
+    assert ratelimit.fetch_codex("tok", "acct", url=server + "/wham/usage") is None
+
+
+def test_fetch_unreachable_is_none():
+    # nothing listens on this port; the connection is refused rather than hung
+    assert ratelimit.fetch_claude("tok", url="http://127.0.0.1:9/usage", timeout=1) is None
+
+
+# -- poller ------------------------------------------------------------------
+
+
+def test_poller_refresh_publishes_text_per_harness():
+    state = {}
+    fetchers = {
+        "claude": lambda: [Window("5h", 4), Window("7d", 41)],
+        "codex": lambda: [Window("7d", 12)],
+    }
+    p = RateLimitPoller(["claude", "codex", "opencode"], state, fetchers=fetchers)
+    p.refresh()
+    assert state["limits"] == {"claude": "5h 4% 7d 41%", "codex": "7d 12%"}
+
+
+def test_poller_blanks_a_harness_whose_fetch_fails():
+    state = {}
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [Window("7d", 12)]
+        raise RuntimeError("boom")
+
+    p = RateLimitPoller(["codex"], state, fetchers={"codex": flaky})
+    p.refresh()
+    assert state["limits"] == {"codex": "7d 12%"}
+    p.refresh()
+    assert state["limits"] == {"codex": ""}
+    # None (no credentials / non-200) blanks the same way
+    p = RateLimitPoller(["codex"], state, fetchers={"codex": lambda: None})
+    p.refresh()
+    assert state["limits"] == {"codex": ""}
+
+
+def test_poller_thread_fetches_on_start_and_on_poke():
+    state = {}
+    fetched = threading.Semaphore(0)
+    value = {"pct": 4}
+
+    def fetch():
+        fetched.release()
+        return [Window("5h", value["pct"])]
+
+    p = RateLimitPoller(["claude"], state, fetchers={"claude": fetch},
+                        interval=3600, min_gap=0)
+    p.start()
+    try:
+        assert fetched.acquire(timeout=5)
+        assert state["limits"]["claude"] == "5h 4%"
+        value["pct"] = 9
+        p.poke()
+        assert fetched.acquire(timeout=5)
+        assert state["limits"]["claude"] == "5h 9%"
+    finally:
+        p.stop()
+    assert not p.is_alive()
+
+
+def test_poller_poke_inside_min_gap_is_ignored():
+    state = {}
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        return [Window("5h", 1)]
+
+    p = RateLimitPoller(["claude"], state, fetchers={"claude": fetch},
+                        interval=3600, min_gap=3600)
+    p.start()
+    try:
+        deadline = 5
+        while calls["n"] < 1 and deadline > 0:
+            threading.Event().wait(0.05)
+            deadline -= 0.05
+        assert calls["n"] == 1
+        p.poke()
+        threading.Event().wait(0.3)
+        assert calls["n"] == 1
+    finally:
+        p.stop()
+
+
+def test_poller_default_fetchers_cover_claude_and_codex_only():
+    p = RateLimitPoller(["claude", "codex", "opencode"], {})
+    assert set(p.fetchers) == {"claude", "codex"}
+
+
+# -- throttling by the endpoint itself ---------------------------------------
+
+
+def test_fetch_429_raises_throttled_with_retry_after(server):
+    _Handler.status, _Handler.body = 429, b'{"error":{"type":"rate_limit_error"}}'
+    _Handler.extra_headers = {"Retry-After": "213"}
+    try:
+        with pytest.raises(ratelimit.Throttled) as exc:
+            ratelimit.fetch_claude("tok", url=server + "/usage")
+        assert exc.value.retry_after == 213
+        with pytest.raises(ratelimit.Throttled):
+            ratelimit.fetch_codex("tok", "acct", url=server + "/wham/usage")
+    finally:
+        _Handler.extra_headers = {}
+
+
+def test_fetch_429_without_retry_after_backs_off_by_default(server):
+    _Handler.status, _Handler.body = 429, b"{}"
+    with pytest.raises(ratelimit.Throttled) as exc:
+        ratelimit.fetch_claude("tok", url=server + "/usage")
+    assert exc.value.retry_after == ratelimit.DEFAULT_RETRY_AFTER
+
+
+def test_poller_keeps_the_last_figure_and_backs_off_when_throttled():
+    state = {}
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [Window("5h", 4)]
+        raise ratelimit.Throttled(3600)
+
+    p = RateLimitPoller(["claude"], state, fetchers={"claude": fetch})
+    p.refresh()
+    p.refresh()
+    assert state["limits"] == {"claude": "5h 4%"}   # kept, not blanked
+    p.refresh()
+    assert calls["n"] == 2                          # backing off: no third call
+
+
+def test_poller_throttled_with_nothing_known_stays_blank():
+    def fetch():
+        raise ratelimit.Throttled(3600)
+
+    state = {}
+    p = RateLimitPoller(["claude"], state, fetchers={"claude": fetch})
+    p.refresh()
+    assert state["limits"] == {"claude": ""}

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -8,6 +8,7 @@ so every parser must go quiet on any shape it doesn't recognize.
 
 import json
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
@@ -49,7 +50,7 @@ CODEX_PAYLOAD = {
 
 
 def test_parse_claude_reads_both_windows_in_order():
-    assert parse_claude(CLAUDE_PAYLOAD) == [Window("5h", 4), Window("7d", 41)]
+    assert parse_claude(CLAUDE_PAYLOAD) == [Window("5h", 4), Window("7d", 42)]
 
 
 def test_parse_claude_skips_absent_windows():
@@ -199,7 +200,7 @@ def server():
 def test_fetch_claude_sends_bearer_and_beta_header(server):
     _Handler.status, _Handler.body = 200, json.dumps(CLAUDE_PAYLOAD).encode()
     assert ratelimit.fetch_claude("tok", url=server + "/usage") == [
-        Window("5h", 4), Window("7d", 41)]
+        Window("5h", 4), Window("7d", 42)]
     path, headers = _Handler.seen[-1]
     assert path == "/usage"
     assert headers["authorization"] == "Bearer tok"
@@ -227,6 +228,15 @@ def test_fetch_unreachable_is_none():
 
 
 # -- poller ------------------------------------------------------------------
+
+
+def _eventually(pred, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pred():
+            return True
+        time.sleep(0.02)
+    return pred()
 
 
 def test_poller_refresh_publishes_text_per_harness():
@@ -275,11 +285,11 @@ def test_poller_thread_fetches_on_start_and_on_poke():
     p.start()
     try:
         assert fetched.acquire(timeout=5)
-        assert state["limits"]["claude"] == "5h 4%"
+        assert _eventually(lambda: state.get("limits", {}).get("claude") == "5h 4%")
         value["pct"] = 9
         p.poke()
         assert fetched.acquire(timeout=5)
-        assert state["limits"]["claude"] == "5h 9%"
+        assert _eventually(lambda: state["limits"]["claude"] == "5h 9%")
     finally:
         p.stop()
     assert not p.is_alive()
@@ -363,3 +373,127 @@ def test_poller_throttled_with_nothing_known_stays_blank():
     p = RateLimitPoller(["claude"], state, fetchers={"claude": fetch})
     p.refresh()
     assert state["limits"] == {"claude": ""}
+
+
+def test_parse_rejects_bool_typed_numbers():
+    assert parse_claude({"five_hour": {"utilization": True}}) == []
+    assert parse_codex({"rate_limit": {"primary_window": {
+        "used_percent": True, "limit_window_seconds": 18000}}}) == []
+    assert parse_codex({"rate_limit": {"primary_window": {
+        "used_percent": 5, "limit_window_seconds": True}}}) == []
+
+
+def test_parse_codex_accepts_float_window_seconds():
+    assert parse_codex({"rate_limit": {"primary_window": {
+        "used_percent": 5, "limit_window_seconds": 604800.0}}}) == [Window("7d", 5)]
+
+
+def test_percent_rounds_rather_than_truncates():
+    assert parse_claude({"five_hour": {"utilization": 41.6}}) == [Window("5h", 42)]
+    assert parse_claude({"five_hour": {"utilization": 41.4}}) == [Window("5h", 41)]
+
+
+def test_fetch_refuses_to_follow_redirects(server):
+    # urllib would re-send the bearer to wherever a 302 points; a redirect is
+    # treated as a failed fetch instead
+    _Handler.status, _Handler.body = 302, b""
+    _Handler.extra_headers = {"Location": server + "/elsewhere"}
+    try:
+        assert ratelimit.fetch_claude("tok", url=server + "/usage") is None
+        assert [p for p, _ in _Handler.seen] == ["/usage"]   # never followed
+    finally:
+        _Handler.extra_headers = {}
+
+
+# -- keychain ----------------------------------------------------------------
+
+
+def test_keychain_read_latches_off_after_a_failure(monkeypatch):
+    # a keychain that prompts or errors must not be re-asked every minute of
+    # an interactive session: one failure and the file path is all we use
+    calls = []
+
+    def boom(*a, **kw):
+        calls.append(kw)
+        raise OSError("no security binary")
+
+    monkeypatch.setattr(ratelimit.sys, "platform", "darwin")
+    monkeypatch.setattr(ratelimit.subprocess, "run", boom)
+    monkeypatch.setattr(ratelimit, "_keychain_secret", ratelimit._keychain_secret_uncached)
+    assert ratelimit._keychain_secret() is None
+    assert ratelimit._keychain_secret() is None
+    assert len(calls) == 1
+    assert calls[0]["stdin"] is ratelimit.subprocess.DEVNULL
+
+
+def test_keychain_read_off_platform_never_spawns(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ratelimit.sys, "platform", "linux")
+    monkeypatch.setattr(ratelimit.subprocess, "run", lambda *a, **kw: calls.append(1))
+    monkeypatch.setattr(ratelimit, "_keychain_secret", ratelimit._keychain_secret_uncached)
+    assert ratelimit._keychain_secret() is None
+    assert calls == []
+
+
+# -- state that outlives one poller (one flip leg) ---------------------------
+
+
+def test_new_poller_paints_the_last_known_figures_before_its_first_fetch():
+    a_state = {}
+    a = RateLimitPoller(["claude", "codex"], a_state,
+                        fetchers={"claude": lambda: [Window("5h", 4)],
+                                  "codex": lambda: [Window("7d", 12)]})
+    a.refresh()
+    b_state = {}
+    RateLimitPoller(["claude", "codex"], b_state, fetchers={"claude": lambda: None,
+                                                            "codex": lambda: None})
+    assert b_state["limits"] == {"claude": "5h 4%", "codex": "7d 12%"}
+
+
+def test_backoff_survives_a_new_poller():
+    def throttled():
+        raise ratelimit.Throttled(3600)
+
+    calls = {"n": 0}
+
+    def counting():
+        calls["n"] += 1
+        return [Window("5h", 1)]
+
+    a = RateLimitPoller(["claude"], {}, fetchers={"claude": throttled})
+    a.refresh()
+    b_state = {}
+    b = RateLimitPoller(["claude"], b_state, fetchers={"claude": counting})
+    b.refresh()
+    assert calls["n"] == 0
+    assert b_state["limits"] == {"claude": ""}
+
+
+def test_min_gap_survives_a_new_poller():
+    calls = {"n": 0}
+
+    def counting():
+        calls["n"] += 1
+        return [Window("5h", 1)]
+
+    a = RateLimitPoller(["claude"], {}, fetchers={"claude": counting}, min_gap=3600)
+    a.refresh()
+    b = RateLimitPoller(["claude"], {}, fetchers={"claude": counting},
+                        interval=3600, min_gap=3600)
+    b.start()
+    try:
+        time.sleep(0.3)
+        assert calls["n"] == 1     # the new leg did not fetch again on start
+    finally:
+        b.stop()
+
+
+def test_poller_stop_before_start_and_halt_are_safe():
+    p = RateLimitPoller(["claude"], {}, fetchers={"claude": lambda: None})
+    p.stop()
+    p.halt()
+    p.ensure_started()
+    p.ensure_started()   # idempotent: a bar reports on at most once, but be safe
+    p.halt()             # signal without joining: safe from any thread
+    p.stop()
+    assert not p.is_alive()

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -497,3 +497,30 @@ def test_poller_stop_before_start_and_halt_are_safe():
     p.halt()             # signal without joining: safe from any thread
     p.stop()
     assert not p.is_alive()
+
+
+# -- review follow-ups -------------------------------------------------------
+
+
+def test_refresh_stops_between_fetches_once_halted():
+    # a halt landing while one harness's fetch is in flight must not be
+    # followed by a fresh credentialed call for the next harness
+    state = {}
+    calls = []
+    p = RateLimitPoller(["claude", "codex"], state, fetchers={
+        "claude": lambda: (calls.append("claude"), p.halt(), [Window("5h", 1)])[2],
+        "codex": lambda: (calls.append("codex"), [Window("7d", 2)])[1],
+    })
+    p.refresh()
+    assert calls == ["claude"]
+
+
+def test_retry_after_accepts_an_http_date():
+    from email.utils import format_datetime
+    from datetime import datetime, timedelta, timezone
+    when = datetime.now(timezone.utc) + timedelta(seconds=120)
+    secs = ratelimit._retry_after(format_datetime(when, usegmt=True))
+    assert 100 <= secs <= 121
+    # a date in the past means "now": fall back to the default rather than 0
+    past = datetime.now(timezone.utc) - timedelta(seconds=30)
+    assert ratelimit._retry_after(format_datetime(past, usegmt=True)) == ratelimit.DEFAULT_RETRY_AFTER

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1569,7 +1569,10 @@ def test_runner_polls_rate_limits_for_every_participant(env_factory, monkeypatch
     seen = {}
 
     def fake_run_in_pty(argv, cwd=None, frame=None, control=None, child=None):
-        # the poller starts before the pty runs and publishes on its own thread
+        # the pump reports the bar drawn; only then does the poller start,
+        # publishing on its own thread
+        assert not any(frame.limits().values())   # seeded blank, nothing fetched yet
+        frame.on_bar(True)
         assert _wait_for(lambda: frame.limits() and "codex" in frame.limits())
         seen["limits"] = dict(frame.limits())
         return 0
@@ -1612,3 +1615,85 @@ def test_runner_skips_the_rate_limit_poll_without_a_bar(env_factory, monkeypatch
                         lambda argv, cwd=None, frame=None, control=None, child=None: 0)
     runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()
     assert called == []
+
+
+def test_runner_makes_no_rate_limit_calls_when_the_pump_never_draws_a_bar(
+        env_factory, monkeypatch):
+    # config says bar, but the pump found no tty / too few rows: no bar, no calls
+    from tandem import ratelimit
+    env = env_factory(active="claude")
+    called = []
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "claude", lambda: called.append(1))
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "codex", lambda: called.append(1))
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None, child=None):
+        frame.on_bar(False)
+        time.sleep(0.2)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()
+    assert called == []
+
+
+def test_runner_halts_the_poll_when_the_bar_drops(env_factory, monkeypatch):
+    from tandem import ratelimit
+    env = env_factory(active="claude")
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        return [ratelimit.Window("7d", 12)]
+
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "claude", fetch)
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "codex", fetch)
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None, child=None):
+        frame.on_bar(True)
+        assert _wait_for(lambda: calls["n"] >= 2)
+        frame.on_bar(False)
+        assert _wait_for(lambda: not any(
+            t.name == "tandem-ratelimit" and t.is_alive() for t in threading.enumerate()))
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()
+
+
+def test_runner_pokes_the_poller_when_a_response_lands(env_factory, monkeypatch):
+    """The tail thread sees the active transcript grow; a change in the usage
+    text means a response just landed, so the account figures get refreshed
+    ahead of the interval."""
+    import functools
+
+    from tandem import ratelimit
+    env = env_factory(active="claude")
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        return [ratelimit.Window("5h", 4)]
+
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "claude", fetch)
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "codex", lambda: None)
+    monkeypatch.setattr(runner, "RateLimitPoller",
+                        functools.partial(ratelimit.RateLimitPoller,
+                                          interval=3600, min_gap=0))
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None, child=None):
+        frame.on_bar(True)
+        assert _wait_for(lambda: calls["n"] == 1)
+        time.sleep(0.2)
+        assert calls["n"] == 1
+        with open(env.claude_shadow, "a") as f:
+            f.write(json.dumps({
+                "type": "assistant", "uuid": "a-1", "sessionId": "x",
+                "message": {"id": "m1", "role": "assistant",
+                            "content": [{"type": "text", "text": "hi"}],
+                            "usage": {"input_tokens": 10, "output_tokens": 5}},
+            }) + "\n")
+        assert _wait_for(lambda: calls["n"] >= 2, timeout=5)
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1545,3 +1545,70 @@ def test_warm_skips_opencode_target(tmp_path, monkeypatch):
     assert env.session.next_active("codex") == "opencode"
     r, spawns = _drive_flip(monkeypatch, env, expect_spawn=False)
     assert spawns == [] and r.warm_child is None
+
+
+# -- rate limits on the bar ---------------------------------------------------
+
+
+def _wait_for(pred, timeout=3.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pred():
+            return True
+        time.sleep(0.02)
+    return pred()
+
+
+def test_runner_polls_rate_limits_for_every_participant(env_factory, monkeypatch):
+    from tandem import ratelimit
+    env = env_factory(active="claude")
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "claude",
+                        lambda: [ratelimit.Window("5h", 4), ratelimit.Window("7d", 41)])
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "codex",
+                        lambda: [ratelimit.Window("7d", 12)])
+    seen = {}
+
+    def fake_run_in_pty(argv, cwd=None, frame=None, control=None, child=None):
+        # the poller starts before the pty runs and publishes on its own thread
+        assert _wait_for(lambda: frame.limits() and "codex" in frame.limits())
+        seen["limits"] = dict(frame.limits())
+        return 0
+
+    monkeypatch.setattr(runner, "run_in_pty", fake_run_in_pty)
+    runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()
+    assert seen["limits"] == {"claude": "5h 4% 7d 41%", "codex": "7d 12%"}
+    # and it is torn down with the run
+    assert not any(t.name == "tandem-ratelimit" and t.is_alive()
+                   for t in threading.enumerate())
+
+
+def test_runner_skips_the_rate_limit_poll_when_disabled(env_factory, monkeypatch):
+    from tandem import ratelimit
+    env = env_factory(active="claude")
+    (paths.tandem_home() / "config.toml").write_text("[frame]\nrate_limits = false\n")
+    called = []
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "claude", lambda: called.append(1))
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "codex", lambda: called.append(1))
+    seen = {}
+    monkeypatch.setattr(
+        runner, "run_in_pty",
+        lambda argv, cwd=None, frame=None, control=None, child=None:
+            seen.update(frame=frame) or 0,
+    )
+    runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()
+    assert seen["frame"].limits is None
+    assert called == []
+
+
+def test_runner_skips_the_rate_limit_poll_without_a_bar(env_factory, monkeypatch):
+    # nothing to paint the figures on: no network calls either
+    from tandem import ratelimit
+    env = env_factory(active="claude")
+    (paths.tandem_home() / "config.toml").write_text("[frame]\nbar = false\n")
+    called = []
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "claude", lambda: called.append(1))
+    monkeypatch.setitem(ratelimit.DEFAULT_FETCHERS, "codex", lambda: called.append(1))
+    monkeypatch.setattr(runner, "run_in_pty",
+                        lambda argv, cwd=None, frame=None, control=None, child=None: 0)
+    runner.InteractiveRunner(env.session, lambda st, se, so, tg: _Sink()).run()
+    assert called == []


### PR DESCRIPTION
## Summary

Every bar slot now shows its harness's account rate limits — `5h 4% 7d 41%` for claude, `7d 12%` for codex (percent **used**, windows labeled by length) — so the bar answers "which subscription has room" before a flip, for the inactive harness as much as the active one:

```
 claude ● 12% ctx · 7.6M↑ 312k↓ · 5h 4% 7d 41% │ codex ○ 7d 12% │ opencode ○   ^] flips
```

- **Sources**: the same account endpoints the CLIs' own commands call — claude's `/usage` → `GET /api/oauth/usage` (bearer from the keychain blob / `~/.claude/.credentials.json`), codex's `/status` → `wham/usage` (bearer + `ChatGPT-Account-Id` from `~/.codex/auth.json`, honoring `chatgpt_base_url`; source of truth: `codex-rs/backend-client`). Both undocumented → cosmetic by contract: any failure blanks the figure; a 429 keeps the last one and backs that harness off for its `Retry-After` (live claude 429s carry ~200 s; 8 probes at 30 s spacing all 200). API-key logins and opencode show nothing.
- **Poller**: own daemon thread (never on the tail thread's sync path), 60 s interval + a poke when a response lands (≥30 s apart), started only when the pump actually draws a bar and halted when it never does or drops. Backoff / min-gap / last figures survive flips, so a new leg paints the previous figures immediately.
- **Bar**: elision is now tiered — ↑↓ totals go first, then rate limits, then ctx, then bare slots + key hint.
- **Config**: `[frame] rate_limits = true`. These are tandem's only outbound network calls; README/docs say so explicitly and the toggle is documented.
- **Tests**: 742 green; an autouse fixture stubs the keychain, resets cross-leg state and refuses non-loopback URLs (verified with a socket-level guard: 0 outbound connections across the suite).

## Live gate

tmux-driven session in a fresh dir: figures on both slots before the first turn (` claude ● 5h 6% 7d 6% │ codex ○ 7d 12% │ opencode ○`), carried across a claude→codex flip (` codex ● 7d 12% │ claude ○ 5h 6% 7d 6%`), clean exit.

## Notes for release

Worth a line in the release notes: a tool that advertises no telemetry now makes (opt-out) calls to the user's own account endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)