### PR TITLE
fix: reap a stale same-side standby before the relaunch (codex writer lock)

### DIFF
--- a/src/tandem/flip.py
+++ b/src/tandem/flip.py
@@ -31,8 +31,8 @@ def run_session(tandem_id: str, sink_factory, run_harness=None) -> int:
     # The standby travels across flips here: popped for adoption by the
     # next run, refilled from the runner that just ended. Injected test
     # runners never touch it. `reapers` collects the threads tearing down
-    # standbys the gate rejected — the flip does not wait for them, this
-    # function's finally does.
+    # standbys the gate rejected for the wrong side — the flip does not
+    # wait for those, this function's finally does.
     carry: dict = {"standby": None, "reapers": []}
     if run_harness is None:
 
@@ -104,9 +104,10 @@ def _reap(standby, carry: dict) -> None:
     session's exit can join it.
 
     The kill ladder is slow by construction — quit keystrokes, then the
-    unconditional soft/term waits — so killing a stale standby inline would
-    put seconds between the user's Ctrl-] and the next harness starting,
-    on precisely the flips warmup exists to speed up. The child is
+    unconditional soft/term waits — so killing a stale standby inline puts
+    seconds between the user's Ctrl-] and the next harness starting, on
+    precisely the flips warmup exists to speed up. Only affordable when the
+    standby and the relaunch share no session (see `_switch`); the child is
     already out of the carry, so nothing can adopt it while it dies."""
     thread = threading.Thread(
         target=_kill, args=(standby,), name="tandem-warm-reap", daemon=True
@@ -226,8 +227,11 @@ def _switch(
     and the state it snapshotted are finally comparable against what the
     next run will actually launch. A stale one is killed here and nowhere
     else — the runner silently ignores an adoptee it cannot use, so a wrong
-    side that survived this gate would leak — but killed on a reaper thread,
-    since the ladder's own timeouts would otherwise be charged to the flip."""
+    side that survived this gate would leak. One warmed for the side about
+    to launch dies inline, before the relaunch: it holds that side's session
+    open, and codex refuses a second writer on a thread. One warmed for any
+    other side dies on a reaper thread, since the ladder's own timeouts
+    would otherwise be charged to the flip for nothing."""
     with StateStore() as store:
         session = store.get_session(tandem_id)
         if session is None:
@@ -264,7 +268,18 @@ def _switch(
             _flip_debug(f"standby-gate side={new_active} fresh={fresh}")
             if not fresh:
                 carry["standby"] = None
-                _reap(standby, carry)   # off-thread: the flip must not wait
+                if standby.recipe.side == new_active:
+                    # It resumed the very session the cold spawn is about
+                    # to resume, and codex (0.153+) holds a per-thread
+                    # writer lock for as long as the process lives: a
+                    # relaunch that overlaps its ladder fails with
+                    # `thread ... already has an active writer` and ends
+                    # the session. Killed inline — the ladder's seconds
+                    # are the price of a flip that lands at all.
+                    _kill(standby)
+                    _flip_debug(f"standby-reaped side={new_active} inline")
+                else:
+                    _reap(standby, carry)   # off-thread: nothing in common
     code, flip, launched = _try_enter(tandem_id, run_harness)
     if launched:
         return code, flip

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import threading
+import time
 
 import pytest
 
@@ -380,68 +381,67 @@ def test_gate_rejects_dead_wrong_side_grown_or_memory(monkeypatch):
                  actions=["wrote AGENTS.md"]) is False
 
 
-class BlockingStandby(FakeStandby):
-    """A standby whose kill ladder hangs, standing in for the real one: quit
-    keystrokes plus TERM/KILL timeouts put 0.5-5s between `kill()` and a dead
-    process."""
+class SlowStandby(FakeStandby):
+    """A standby whose kill takes real time, standing in for the real one:
+    quit keystrokes plus the soft/term waits put 0.5-5s between `kill()`
+    and a dead process."""
 
-    def __init__(self, release, **kw):
+    def __init__(self, delay=0.2, **kw):
         super().__init__(**kw)
-        self.release = release
-        self.kill_entered = threading.Event()
+        self.delay = delay
 
     def kill(self):
-        self.kill_entered.set()
-        self.release.wait(10)
+        time.sleep(self.delay)
         super().kill()
 
 
-def test_stale_standby_is_killed_at_the_gate(sess, monkeypatch, capsys):
-    from tandem import flip
-    import tandem.warm as warm
-    _flipping_switch(monkeypatch)
-    monkeypatch.setattr(warm, "_shadow_size", lambda session, side: 999)
-    stale = FakeStandby(side="codex", size=10)   # snapshot != 999 -> stale
-    runs = []
-
-    def run_harness(session):
-        runs.append(session.active)
-        return 0, False
-
-    carry = {"standby": stale}
-    flip._switch(sess.tandem_id, run_harness, 0, carry=carry)
-    for t in carry["reapers"]:   # the reap is off-thread; the exit joins it
-        t.join(timeout=10)
-    assert stale.killed
-    assert carry["standby"] is None
-    assert runs   # the flip still landed, on a cold spawn
-
-
-def test_the_gates_kill_does_not_delay_the_flip(sess, monkeypatch, capsys):
-    """The teardown of a stale standby costs seconds of quit-key ladder, and
-    it lands on exactly the flips warmup exists to make instant. So the gate
-    hands the kill to a reaper thread and re-enters immediately; the session's
-    exit is what joins it."""
+def test_a_stale_standby_for_the_launched_side_is_dead_before_the_relaunch(
+    sess, monkeypatch, capsys
+):
+    """The stale standby resumed the very session the cold spawn is about to
+    resume, and codex (0.153+) holds a per-thread writer lock for as long as
+    the process lives: a relaunch that overlaps the kill ladder fails with
+    `thread ... already has an active writer` and ends the session. So the
+    gate reaps a same-side standby inline, however many ladder seconds that
+    costs, and only then re-enters."""
     import tandem.warm as warm
     monkeypatch.setattr(warm, "_shadow_size", lambda session, side: 999)
-    release = threading.Event()
-    stale = BlockingStandby(release, side="codex", size=10)
+    stale = SlowStandby(side="codex", size=10)   # snapshot != 999 -> stale
     adopted = []
+    dead_at_launch = []
 
     class Runner(_adopting_runner(adopted, stale)):
         def run(self):
             if self.session.active == "codex":
-                # the post-flip run: the harness is already launching while
-                # the stale standby is still going down the ladder
-                assert stale.kill_entered.wait(10)
-                assert not stale.killed
-                release.set()
+                dead_at_launch.append(stale.killed)
             return super().run()
 
     _fake_runner_session(monkeypatch, sess, [([], True), ([], False)],
                          runner=Runner)
-    assert adopted == [None, None]   # stale: never handed to the next run
-    assert stale.killed              # run_session's exit joined the reaper
+    assert adopted == [None, None]    # stale: never handed to the next run
+    assert dead_at_launch == [True]   # and gone before the relaunch began
+
+
+def test_a_stale_standby_for_another_side_still_goes_down_off_thread(
+    sess, monkeypatch, capsys
+):
+    """Warmed for a side the flip is not landing on, it holds nothing the
+    relaunch needs, so the ladder must not delay the flip: the kill stays on
+    a reaper thread that the session's exit joins."""
+    _flipping_switch(monkeypatch)
+    stale = SlowStandby(side="claude", size=10)   # the flip lands on codex
+    alive_at_launch = []
+
+    def run_harness(session):
+        alive_at_launch.append(stale.alive())
+        return 0, False
+
+    carry = {"standby": stale}
+    flip._switch(sess.tandem_id, run_harness, 0, carry=carry)
+    assert alive_at_launch == [True]   # the flip did not wait
+    for t in carry["reapers"]:
+        t.join(timeout=10)
+    assert stale.killed
 
 
 def test_plain_exit_kills_the_leftover_standby(sess, monkeypatch, capsys):


### PR DESCRIPTION
## What broke

A claude → codex flip died with:

```
Error: Failed to resume session from …/rollout-….jsonl: thread/resume failed during TUI bootstrap: thread/resume failed: thread <id> already has an active writer (code -32600)
```

codex 0.153+ holds a per-thread writer lock (an flock on `~/.codex/thread-writer-locks/<thread_id>.lock`) for as long as a process has the thread open. A second `codex resume <id>` on a held thread fails at TUI bootstrap. The lock is released on process death (SIGKILL included); the empty file lingers and is reused.

In tandem, the flip's freshness gate rejected the warm standby (the codex rollout grew during claude's teardown), handed its kill ladder to a reaper **thread**, and cold-spawned `codex resume` on the same thread 2 ms later. The relaunch collided with the dying standby's lock. Timing-dependent: it reproduced in a project with plugins/hooks loaded (slower claude teardown) but not in a bare scratch repo.

## The fix

`flip._switch`: a stale standby whose `recipe.side == new_active` is now killed **inline** before `_try_enter` (about 1.1 s live, on a path that was already a cold spawn). A stale standby warmed for another side still goes to the off-thread reaper, since it shares no session with the relaunch. New flip-debug line: `standby-reaped side=<s> inline`.

## Tests

- `test_a_stale_standby_for_the_launched_side_is_dead_before_the_relaunch` replaces `test_the_gates_kill_does_not_delay_the_flip` (which pinned the off-thread reap that now fails the flip). Red before the fix (`[False] == [True]`), green after.
- `test_a_stale_standby_for_another_side_still_goes_down_off_thread` guards the retained branch.
- Full suite: 744 passed.

## Live gate

Zero-turn claude → Ctrl-] → codex in `~/git/tandem` via tmux:

- installed 0.5.0: `standby-gate fresh=False` → `run-start side=codex` 2 ms later → `run-exit side=codex code=1` with the error above.
- this branch: `standby-gate fresh=False` → `standby-reaped side=codex inline` (+1.13 s) → `run-start side=codex` → codex TUI up, clean exit.

## Not in this PR

- The seed note tandem writes into a zero-turn claude transcript gets mirrored into the codex rollout as a `[via claude-code]` user message; that growth is what made the standby stale here.
- The runner's late-landing warm-fire path kills its child on the worker thread with the same overlap hazard (much narrower window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b8TTghPiPHTq8qEYGtKSw
