### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ network calls — set `rate_limits = false` under `[frame]` in
 [Configuration](https://github.com/Bhavya6187/tandem/blob/main/docs/configuration.md)
 for the status bar's other settings.
 
+**0.5.1 keeps up with the current CLIs.** claude 2.1.26x and codex 0.153
+changed their session records, and codex now holds a writer lock on every
+open thread. On those versions 0.5.0 failed `tandem doctor` and every flip
+into claude on the new metadata records, warned that codex was out of range
+at each start, and could lose a claude → codex flip to `already has an
+active writer`. All three are fixed, and codex's list-shaped tool outputs
+now reach the other side as text with their exit codes intact.
+
 ## Why tandem?
 
 - **Keep going when a model hits its limit.** The tab bar shows each

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "Run Claude Code, Codex CLI, and opencode in one shared coding session with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

Two fixes have landed on main since v0.5.0, and 0.5.0 users on the current CLIs (claude 2.1.26x, codex 0.153) hit both: `tandem doctor` and every flip into claude failed on new metadata records (#57), and a claude → codex flip could die on codex's new per-thread writer lock (#58). Neither adds a feature or a config key, so this is a patch bump.

## What changed

- `version` 0.5.0 → 0.5.1 in `pyproject.toml` and `plugin/.claude-plugin/plugin.json`, with `uv.lock` regenerated in the same commit (`uv sync --locked` passes).
- README: a **0.5.1** paragraph under *What's new in 0.5*, saying what broke on the current CLIs and that it is fixed.

## Verification

- `uv run --frozen pytest -q` on main `2b6e3ce`: 754 passed.
- `uv sync --locked` after the bump: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUudACZAAsuWC4RXBBqgCs
