### PR TITLE
fix: tag model-less synced claude entries "<synthetic>" so --resume stops rejecting them

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -60,6 +60,16 @@ validation rather than being silently declared compatible.
     tandem drops it like any other non-text assistant block.
 - Resume: `claude --resume <sessionId>` (from the same cwd). A new session
   can be pinned to a chosen id with `claude --session-id <uuid>`.
+  - 2.1.261 restores the session model on resume from the last assistant
+    entry whose `message.model` is a string other than `"<synthetic>"`
+    (claude's own tag on model-less stubs such as API-error messages) and
+    warns `Session model X could not be restored (not a model this version
+    of Claude Code recognizes) — using <default> instead` when that value is
+    not a model it knows. Tandem-rendered assistant entries therefore copy
+    the model claude last used in that transcript, and carry `"<synthetic>"`
+    until claude has run at all (a zero-turn claude flipped back into). The
+    `"<synced>"` placeholder tandem ≤0.5.1 wrote there drew the warning;
+    entries carrying it are still skipped when tandem derives the model.
 - Turn boundary: a `user` entry with string content starts a turn; an
   `assistant` line with `stop_reason: "end_turn"` ends it. The `Stop` hook
   (injectable per-invocation via `--settings '<json>'`) fires at turn end.

--- a/src/tandem/harness/claude_code.py
+++ b/src/tandem/harness/claude_code.py
@@ -127,6 +127,18 @@ _CLAUDE_ENTRY_TYPES = {
 }
 
 
+# claude's own tag for an assistant entry no model produced (its API-error
+# stubs carry it). `claude --resume` (2.1.261) restores the session model from
+# the last assistant entry and warns "Session model X could not be restored"
+# for anything it does not recognise; "<synthetic>" is the one value that scan
+# skips, so rendered entries carry it until claude itself has run and a real
+# model can be copied instead (live-verified 2026-09-05: no warning, synced
+# turns still render and reach the model).
+SYNTHETIC_MODEL = "<synthetic>"
+# what tandem <= 0.5.1 wrote in that slot; still skipped when deriving
+LEGACY_SYNCED_MODEL = "<synced>"
+
+
 class ClaudeCodeAdapter(HarnessAdapter):
     id = "claude"
     display_name = "Claude Code"
@@ -434,7 +446,7 @@ class ClaudeCodeAdapter(HarnessAdapter):
             st["run_msg_id"] = f"msg_tandem_{entry['uuid'][:8]}"
         return {
             "role": "assistant",
-            "model": st.get("model") or "<synced>",
+            "model": st.get("model") or SYNTHETIC_MODEL,
             "id": st["run_msg_id"],
             "type": "message",
             "content": content,
@@ -487,14 +499,15 @@ class ClaudeCodeAdapter(HarnessAdapter):
 
     def derive_last_model(self, transcript: Path) -> str | None:
         """Model of the last main-thread assistant entry with a real model
-        name. Skips the "<synced>" placeholder (pre-fix tandem appends) and
-        sidechain entries (subagents may run on a different model)."""
+        name. Skips tandem's own tags (SYNTHETIC_MODEL now, the older
+        "<synced>"), claude's synthetic stubs, and sidechain entries
+        (subagents may run on a different model)."""
         model = None
         for obj in self._tail_objects(transcript):
             if obj.get("type") != "assistant" or obj.get("isSidechain"):
                 continue
             m = (obj.get("message") or {}).get("model")
-            if m and m != "<synced>":
+            if m and m not in (SYNTHETIC_MODEL, LEGACY_SYNCED_MODEL):
                 model = m
         return model
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -140,7 +140,10 @@ class TestDeriveLastModel:
         ])
         assert get_adapter("claude").derive_last_model(p) == "claude-fable-5"
 
-    def test_synced_and_sidechain_models_skipped(self, tmp_path):
+    def test_placeholder_and_sidechain_models_skipped(self, tmp_path):
+        # "<synced>" is the placeholder older tandem wrote; "<synthetic>" is
+        # claude's own tag for model-less assistant entries (its API-error
+        # stubs) and what tandem writes now — neither is a model claude ran
         p = self.write(tmp_path, [
             {"type": "assistant", "uuid": "a1",
              "message": {"role": "assistant", "model": "claude-fable-5",
@@ -150,6 +153,9 @@ class TestDeriveLastModel:
                          "content": []}},
             {"type": "assistant", "uuid": "a2",
              "message": {"role": "assistant", "model": "<synced>",
+                         "content": []}},
+            {"type": "assistant", "uuid": "a3",
+             "message": {"role": "assistant", "model": "<synthetic>",
                          "content": []}},
         ])
         assert get_adapter("claude").derive_last_model(p) == "claude-fable-5"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -159,8 +159,12 @@ class TestSyncCodexToClaude:
         assert synced
         assert all(e["message"]["model"] == "claude-fable-5" for e in synced)
 
-    def test_synced_model_placeholder_when_claude_never_ran(self, env_factory):
-        # regression guard for the fresh-shadow case: no real model to copy
+    def test_synthetic_model_tag_when_claude_never_ran(self, env_factory):
+        """Fresh-shadow case: no real model to copy. Entries carry claude's
+        own "<synthetic>" tag, which its --resume model-restore scan skips
+        (live-verified on 2.1.261); the old "<synced>" placeholder drew
+        "Session model <synced> could not be restored" on every zero-turn
+        claude session flipped back into."""
         env = env_factory(active="codex")
         for obj in self.codex_lines():
             write_line(env.source_file, obj)
@@ -168,7 +172,8 @@ class TestSyncCodexToClaude:
         loop.drain()
         synced = [e for e in read_jsonl(env.claude_shadow)
                   if e.get("type") == "assistant"]
-        assert all(e["message"]["model"] == "<synced>" for e in synced)
+        assert synced
+        assert all(e["message"]["model"] == "<synthetic>" for e in synced)
 
     def test_leaf_rederived_from_file(self, env_factory):
         """If claude itself appended entries (it was active earlier), new

--- a/tests/test_toolmap.py
+++ b/tests/test_toolmap.py
@@ -464,6 +464,19 @@ class TestClaudeToolRendering:
         ], ctx)
         assert all(e["message"]["model"] == "claude-fable-5" for e in entries)
 
+    def test_render_uses_claudes_synthetic_tag_when_no_model_is_known(self):
+        # claude --resume (2.1.261) restores the session model from the last
+        # assistant entry and warns "Session model X could not be restored"
+        # for anything it does not recognise; "<synthetic>" is claude's own
+        # tag for model-less assistant entries and the one value its scan
+        # skips, so it is what a shadow with no claude turn yet must carry
+        ctx = _ctx("codex->claude")
+        entries = get_adapter("claude").render_events([
+            AssistantMessage(source="codex", text="hi"),
+            call("Bash", {"command": "ls"}, source="codex", call_id="c9"),
+        ], ctx)
+        assert all(e["message"]["model"] == "<synthetic>" for e in entries)
+
     def test_is_error_flag_rides(self):
         ctx = _ctx("codex->claude")
         entries = get_adapter("claude").render_events([


### PR DESCRIPTION
## Bug

Flipping into a claude session that had never run a turn (claude → codex → opencode → claude) printed on arrival:

```
Session model <synced> could not be restored (not a model this version of Claude Code recognizes) — using fable instead.
```

## Root cause

claude 2.1.261 restores the session model on `--resume` from the last assistant entry whose `message.model` is a string other than `"<synthetic>"` (its own tag for API-error stubs), and warns when that value is not a model it recognises. The scan, read from the binary:

```js
if (l?.type !== "assistant" || l.isMeta || typeof l.message?.model !== "string" || l.message.model === "<synthetic>") continue;
```

Tandem copies the model claude last used into rendered entries, but with no claude turn in the transcript there is nothing to copy, and it wrote the `"<synced>"` placeholder instead. The existing test `test_synced_model_placeholder_when_claude_never_ran` locked that in.

## Fix

- Rendered assistant entries carry `"<synthetic>"` until a real model can be copied (`SYNTHETIC_MODEL` in `claude_code.py`). claude's scan skips it, so no restore attempt and no warning.
- `derive_last_model` skips both `"<synthetic>"` and the legacy `"<synced>"`, so neither a pre-fix transcript nor a claude API-error stub becomes the copied model.
- `docs/formats.md` records the resume-restore behaviour.

Omitting `model` entirely also passes (claude's `typeof` check skips it), but `"<synthetic>"` is the shape claude itself writes for model-less assistant entries, so every other code path that cares about the distinction already handles it.

## Verification

- Probe transcripts resumed on claude 2.1.261, interactive (pty) and `-p`: `"<synced>"` → warning; `"<synthetic>"` → no warning, synced turn renders, a follow-up question proves the synced assistant text reaches the model.
- TDD: three tests RED → GREEN (renderer, sync-level fresh shadow, `derive_last_model`); suite 755 green.
- Live gate (tmux driver, `/private/tmp/tandem-live-gate/gate_synced.py`): zero-turn claude → codex turn → opencode (no turn) → claude. Installed 0.5.1: warning reproduced. This build: codex turn rendered in claude, no warning, clean exit.

## Not fixed here (found while gating)

If codex also runs zero turns before the flip into opencode, opencode's last message is the mirrored `[via claude-code] [tandem] This session is one half…` seed note (a user-role row), so the flip probe reports opencode busy and Ctrl-] sits at "flipping at turn end…" until a turn runs there. Same seed-mirroring wart noted on #58; separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Gn5oFAMomzNj7px9domRJ
