### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ at each start, and could lose a claude → codex flip to `already has an
 active writer`. All three are fixed, and codex's list-shaped tool outputs
 now reach the other side as text with their exit codes intact.
 
+**0.5.2 stops claude complaining about synced turns.** claude 2.1.261
+restores a session's model on resume from its last assistant entry, and a
+claude session that had never run a turn of its own (claude → codex →
+opencode → claude) opened with `Session model <synced> could not be
+restored … using fable instead`. Synced entries now carry claude's own
+`<synthetic>` tag until claude has run, which its resume skips; the synced
+turns still render and still reach the model.
+
 ## Why tandem?
 
 - **Keep going when a model hits its limit.** The tab bar shows each

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem",
   "description": "Route Claude Code subagent dispatches to cheap codex models via tandem.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {"name": "tandem"}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tandem-cli"
-version = "0.5.1"
+version = "0.5.2"
 description = "Run Claude Code, Codex CLI, and opencode in one shared coding session with live trace sync."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "tandem-cli"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

One fix has landed on main since v0.5.1: synced claude entries in a zero-turn claude session carried the `"<synced>"` placeholder, which claude 2.1.261 rejects on resume with `Session model <synced> could not be restored … using fable instead` (#60). No feature or config key, so a patch bump.

## What changed

- `version` 0.5.1 → 0.5.2 in `pyproject.toml` and `plugin/.claude-plugin/plugin.json`, with `uv.lock` regenerated in the same commit (`uv sync --locked` passes).
- README: a **0.5.2** paragraph under *What's new in 0.5*.

## Verification

- CI on #60 (`f909cb5`) and the suite on main `310230e`: 755 passed.
- `uv sync --locked` after the bump: clean.
- Live gate of the installed tool built from `310230e`: zero-turn claude → codex turn → opencode → claude lands with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Gn5oFAMomzNj7px9domRJ
